### PR TITLE
Updates to the SDK approach for working with Endpoints

### DIFF
--- a/get-started/midi-developers/app-developers/samples/cpp-winrt/sdk-client-basics/main.cpp
+++ b/get-started/midi-developers/app-developers/samples/cpp-winrt/sdk-client-basics/main.cpp
@@ -69,9 +69,11 @@ int main()
             // then you connect to the UMP endpoint
             auto endpoint = session.ConnectToEndpoint(selectedMidiEndpointInformation.Id(), true, MidiEndpointConnectOptions::Default());
 
-            // after connecting, you can send and receive messages and more
+            // after connecting, you can send and receive messages
 
-            // ...
+            auto writer = endpoint.GetMessageWriter();
+
+            // writer.WriteUmpWithTimestamp(...);
 
 
         }

--- a/get-started/midi-developers/app-developers/samples/cpp-winrt/sdk-client-basics/main.cpp
+++ b/get-started/midi-developers/app-developers/samples/cpp-winrt/sdk-client-basics/main.cpp
@@ -80,7 +80,8 @@ int main()
             // no MIDI endpoints found. We'll just bail here
         }
 
-        // close the session, detaching all Windows MIDI Services resources
+        // close the session, detaching all Windows MIDI Services resources and closing all connections
+        // You can also disconnect individual Endpoint Connections when you are done with them
         session.Close();
     }
     else

--- a/src/app-dev-sdk/sdk-core/IMidiEndpointSettingsData.idl
+++ b/src/app-dev-sdk/sdk-core/IMidiEndpointSettingsData.idl
@@ -10,6 +10,7 @@
 // provide the settings to the service. The service only understands Json for this, and
 // delegates all the parsing to the plugins, so we want to provide more app-friendly 
 // approach which will ensure the json is well-formed and correct.
+
 namespace Microsoft.Devices.Midi2
 {
     [

--- a/src/app-dev-sdk/sdk-core/IMidiSdkMessagePreProcessor.idl
+++ b/src/app-dev-sdk/sdk-core/IMidiSdkMessagePreProcessor.idl
@@ -20,7 +20,7 @@ namespace Microsoft.Devices.Midi2
         //  MIDI CI processing
 
 
-        void foo;
+        void foo();
 
         // The trick here will be to be able to pull out messages from the stream without
         // having a big impact on performance (because now we're having to copy and move, 

--- a/src/app-dev-sdk/sdk-core/IMidiSdkMessagePreProcessor.idl
+++ b/src/app-dev-sdk/sdk-core/IMidiSdkMessagePreProcessor.idl
@@ -1,0 +1,41 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License
+// ============================================================================
+// This is part of the Windows MIDI Services App SDK and should be used
+// in your Windows application via an official binary distribution.
+// Further information: https://github.com/microsoft/MIDI/
+// ============================================================================
+
+namespace Microsoft.Devices.Midi2
+{
+    [
+        uuid(1526409d-8842-4714-abc8-371cfb5c32a2),
+        version(1.0),
+    ]
+    interface IMidiSdkMessagePreProcessor
+    {
+        // TODO: This is the interface which will allow implementation of message processors.
+        // Examples:
+        //  Stream message (Endpoint, function block, other future messages) parsing
+        //  MIDI CI processing
+
+
+        void foo;
+
+        // The trick here will be to be able to pull out messages from the stream without
+        // having a big impact on performance (because now we're having to copy and move, 
+        // or flag/nullify messages, which would require room in the message header to do 
+        // it, or a separate array of indexes). Can't just turn them into NOOP messages 
+        // because the messages removed can be any of the UMP sizes, and we'd need the
+        // timestamp entries to still line up. Also Don't want to use magic numbers in the
+        // UMP themselves because that will come back to haunt us in the future. 
+        // 
+        // Or, it may be, that because of how the circular buffer works, we're better off
+        // keeping our own copy of the data anyway, which would make this moot. But this 
+        // Really needs to be tested for memory usage and performance in some of the 
+        // more extreme MIDI 2.0 use cases.
+        // 
+        // This is all under consideration and no matter what solution, would be optional.
+
+    }
+}

--- a/src/app-dev-sdk/sdk-core/Microsoft.Devices.Midi2.Core.vcxproj
+++ b/src/app-dev-sdk/sdk-core/Microsoft.Devices.Midi2.Core.vcxproj
@@ -241,12 +241,14 @@
   </ItemGroup>
   <ItemGroup>
     <Midl Include="IMidiEndpointSettingsData.idl" />
+    <Midl Include="IMidiSdkMessagePreProcessor.idl" />
     <Midl Include="IMidiTransportSettingsData.idl" />
     <Midl Include="MidiChannel.idl" />
     <Midl Include="MidiEndpointInformation.idl" />
     <Midl Include="MidiEndpointDataFormatEnum.idl" />
     <Midl Include="MidiFunctionBlockDirectionEnum.idl" />
     <Midl Include="MidiHighResolutionValueDisplayFormatter.idl" />
+    <Midl Include="MidiMessageReader.idl" />
     <Midl Include="MidiMessagesReceivedEvent.idl" />
     <Midl Include="MidiMessageTranslator.idl" />
     <Midl Include="MidiDeviceInformation.idl" />
@@ -259,6 +261,7 @@
     <Midl Include="MidiGroupTerminalBlock.idl" />
     <Midl Include="MidiLocalizedStrings.idl" />
     <Midl Include="MidiMessageTypeEnum.idl" />
+    <Midl Include="MidiMessageWriter.idl" />
     <Midl Include="MidiServices.idl" />
     <Midl Include="MidiSession.idl" />
     <Midl Include="MidiSessionSettings.idl" />

--- a/src/app-dev-sdk/sdk-core/Microsoft.Devices.Midi2.Core.vcxproj
+++ b/src/app-dev-sdk/sdk-core/Microsoft.Devices.Midi2.Core.vcxproj
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="packages\Microsoft.Windows.CppWinRT.2.0.230225.1\build\native\Microsoft.Windows.CppWinRT.props" Condition="Exists('packages\Microsoft.Windows.CppWinRT.2.0.230225.1\build\native\Microsoft.Windows.CppWinRT.props')" />
+  <Import Project="..\packages\Microsoft.Windows.CppWinRT.2.0.220531.1\build\native\Microsoft.Windows.CppWinRT.props" Condition="Exists('..\packages\Microsoft.Windows.CppWinRT.2.0.220531.1\build\native\Microsoft.Windows.CppWinRT.props')" />
   <PropertyGroup Label="Globals">
     <ProjectName>Microsoft.Devices.Midi2.Core</ProjectName>
     <RootNamespace>Microsoft.Devices.Midi2</RootNamespace>
@@ -102,7 +102,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)'=='Debug'">
     <ClCompile>
       <PreprocessorDefinitions>_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <LanguageStandard Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">stdcpp20</LanguageStandard>
+      <LanguageStandard Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">stdcpp17</LanguageStandard>
       <GenerateXMLDocumentationFiles Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">false</GenerateXMLDocumentationFiles>
     </ClCompile>
   </ItemDefinitionGroup>
@@ -143,10 +143,18 @@
     <ClInclude Include="MidiDeviceInformation.h">
       <DependentUpon>MidiDeviceInformation.idl</DependentUpon>
     </ClInclude>
-    <ClInclude Include="MidiMessagesReceivedEventArgs.h" />
+	  <ClInclude Include="MidiMessageReader.h">
+		  <DependentUpon>MidiMessageReader.idl</DependentUpon>
+	  </ClInclude>
+	  <ClInclude Include="MidiMessagesReceivedEventArgs.h">
+		  <DependentUpon>MidiMessagesReceivedEventArgs.idl</DependentUpon>
+	  </ClInclude>
     <ClInclude Include="MidiMessageTranslator.h">
       <DependentUpon>MidiMessageTranslator.idl</DependentUpon>
     </ClInclude>
+	  <ClInclude Include="MidiMessageWriter.h">
+		  <DependentUpon>MidiMessageWriter.idl</DependentUpon>
+	  </ClInclude>
     <ClInclude Include="MidiServices.h">
       <DependentUpon>MidiServices.idl</DependentUpon>
     </ClInclude>
@@ -175,7 +183,9 @@
       <DependentUpon>MidiSession.idl</DependentUpon>
     </ClInclude>
     <ClInclude Include="pch.h" />
-    <ClInclude Include="UmpWithTimestamp.h" />
+    <ClInclude Include="UmpWithTimestamp.h">
+      <DependentUpon>UmpWithTimestamp.idl</DependentUpon>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="Generated Files\module.g.cpp" />
@@ -206,10 +216,18 @@
     <ClCompile Include="MidiDeviceInformation.cpp">
       <DependentUpon>MidiDeviceInformation.idl</DependentUpon>
     </ClCompile>
-    <ClCompile Include="MidiMessagesReceivedEventArgs.cpp" />
+	  <ClCompile Include="MidiMessageReader.cpp">
+		  <DependentUpon>MidiMessageReader.idl</DependentUpon>
+	  </ClCompile>
+	  <ClCompile Include="MidiMessagesReceivedEventArgs.cpp">
+		  <DependentUpon>MidiMessagesReceivedEventArgs.idl</DependentUpon>
+	  </ClCompile>
     <ClCompile Include="MidiMessageTranslator.cpp">
       <DependentUpon>MidiMessageTranslator.idl</DependentUpon>
     </ClCompile>
+	  <ClCompile Include="MidiMessageWriter.cpp">
+		  <DependentUpon>MidiMessageWriter.idl</DependentUpon>
+	  </ClCompile>
     <ClCompile Include="MidiServices.cpp">
       <DependentUpon>MidiServices.idl</DependentUpon>
     </ClCompile>
@@ -237,7 +255,9 @@
     <ClCompile Include="pch.cpp">
       <PrecompiledHeader>Create</PrecompiledHeader>
     </ClCompile>
-    <ClCompile Include="UmpWithTimestamp.cpp" />
+    <ClCompile Include="UmpWithTimestamp.cpp">
+      <DependentUpon>UmpWithTimestamp.idl</DependentUpon>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <Midl Include="IMidiEndpointSettingsData.idl" />
@@ -249,7 +269,7 @@
     <Midl Include="MidiFunctionBlockDirectionEnum.idl" />
     <Midl Include="MidiHighResolutionValueDisplayFormatter.idl" />
     <Midl Include="MidiMessageReader.idl" />
-    <Midl Include="MidiMessagesReceivedEvent.idl" />
+    <Midl Include="MidiMessagesReceivedEventArgs.idl" />
     <Midl Include="MidiMessageTranslator.idl" />
     <Midl Include="MidiDeviceInformation.idl" />
     <Midl Include="MidiEndpointConnection.idl" />
@@ -279,13 +299,13 @@
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
-    <Import Project="packages\Microsoft.Windows.CppWinRT.2.0.230225.1\build\native\Microsoft.Windows.CppWinRT.targets" Condition="Exists('packages\Microsoft.Windows.CppWinRT.2.0.230225.1\build\native\Microsoft.Windows.CppWinRT.targets')" />
+    <Import Project="..\packages\Microsoft.Windows.CppWinRT.2.0.220531.1\build\native\Microsoft.Windows.CppWinRT.targets" Condition="Exists('..\packages\Microsoft.Windows.CppWinRT.2.0.220531.1\build\native\Microsoft.Windows.CppWinRT.targets')" />
   </ImportGroup>
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('packages\Microsoft.Windows.CppWinRT.2.0.230225.1\build\native\Microsoft.Windows.CppWinRT.props')" Text="$([System.String]::Format('$(ErrorText)', 'packages\Microsoft.Windows.CppWinRT.2.0.230225.1\build\native\Microsoft.Windows.CppWinRT.props'))" />
-    <Error Condition="!Exists('packages\Microsoft.Windows.CppWinRT.2.0.230225.1\build\native\Microsoft.Windows.CppWinRT.targets')" Text="$([System.String]::Format('$(ErrorText)', 'packages\Microsoft.Windows.CppWinRT.2.0.230225.1\build\native\Microsoft.Windows.CppWinRT.targets'))" />
+    <Error Condition="!Exists('..\packages\Microsoft.Windows.CppWinRT.2.0.220531.1\build\native\Microsoft.Windows.CppWinRT.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Windows.CppWinRT.2.0.220531.1\build\native\Microsoft.Windows.CppWinRT.props'))" />
+    <Error Condition="!Exists('..\packages\Microsoft.Windows.CppWinRT.2.0.220531.1\build\native\Microsoft.Windows.CppWinRT.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Windows.CppWinRT.2.0.220531.1\build\native\Microsoft.Windows.CppWinRT.targets'))" />
   </Target>
 </Project>

--- a/src/app-dev-sdk/sdk-core/Microsoft.Devices.Midi2.Core.vcxproj.filters
+++ b/src/app-dev-sdk/sdk-core/Microsoft.Devices.Midi2.Core.vcxproj.filters
@@ -163,6 +163,15 @@
     <Midl Include="UmpWithTimestamp.idl">
       <Filter>SDK\Messages</Filter>
     </Midl>
+    <Midl Include="IMidiSdkMessagePreProcessor.idl">
+      <Filter>SDK\Endpoints</Filter>
+    </Midl>
+    <Midl Include="MidiMessageReader.idl">
+      <Filter>SDK\Endpoints</Filter>
+    </Midl>
+    <Midl Include="MidiMessageWriter.idl">
+      <Filter>SDK\Endpoints</Filter>
+    </Midl>
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />

--- a/src/app-dev-sdk/sdk-core/MidiEndpointConnectOptions.idl
+++ b/src/app-dev-sdk/sdk-core/MidiEndpointConnectOptions.idl
@@ -19,12 +19,6 @@ namespace Microsoft.Devices.Midi2
         Boolean DisableProcessingFunctionBlockInformationMessages { get; set; };
         Boolean DisableProcessingEndpointInformationMessages { get; set; };
 
-        Boolean UseSessionLevelMessageReceiveHandler{ get; set; };
-
-        // TODO: Option to use polling instead of events
-        // But maybe the whole central event / endpoint event / polling thing needs to be global to the session instead.
-
-
 
         static MidiEndpointConnectOptions Default{ get; };
     }

--- a/src/app-dev-sdk/sdk-core/MidiEndpointConnectOptions.idl
+++ b/src/app-dev-sdk/sdk-core/MidiEndpointConnectOptions.idl
@@ -21,6 +21,11 @@ namespace Microsoft.Devices.Midi2
 
         Boolean UseSessionLevelMessageReceiveHandler{ get; set; };
 
+        // TODO: Option to use polling instead of events
+        // But maybe the whole central event / endpoint event / polling thing needs to be global to the session instead.
+
+
+
         static MidiEndpointConnectOptions Default{ get; };
     }
 }

--- a/src/app-dev-sdk/sdk-core/MidiEndpointConnection.cpp
+++ b/src/app-dev-sdk/sdk-core/MidiEndpointConnection.cpp
@@ -37,14 +37,6 @@ namespace winrt::Microsoft::Devices::Midi2::implementation
     {
         throw hresult_not_implemented();
     }
-    winrt::event_token MidiEndpointConnection::MessagesReceived(winrt::Windows::Foundation::EventHandler<winrt::Microsoft::Devices::Midi2::MidiMessagesReceivedEventArgs> const& handler)
-    {
-        throw hresult_not_implemented();
-    }
-    void MidiEndpointConnection::MessagesReceived(winrt::event_token const& token) noexcept
-    {
-        throw hresult_not_implemented();
-    }
     void MidiEndpointConnection::RequestEndpointInformationAndFunctions(bool forceRefresh)
     {
         throw hresult_not_implemented();
@@ -53,15 +45,19 @@ namespace winrt::Microsoft::Devices::Midi2::implementation
     {
         throw hresult_not_implemented();
     }
-    void MidiEndpointConnection::SendUmp(winrt::Microsoft::Devices::Midi2::UmpWithTimestamp const& ump)
+    winrt::Microsoft::Devices::Midi2::MidiMessageReader MidiEndpointConnection::GetMessageReader()
     {
         throw hresult_not_implemented();
     }
-    void MidiEndpointConnection::SendMultipleUmps(winrt::Windows::Foundation::Collections::IVector<winrt::Microsoft::Devices::Midi2::UmpWithTimestamp> const& umps)
+    winrt::Microsoft::Devices::Midi2::MidiMessageWriter MidiEndpointConnection::GetMessageWriter()
     {
         throw hresult_not_implemented();
     }
-    void MidiEndpointConnection::SendMultipleUmpsAsWords(uint64_t timestamp, winrt::Windows::Foundation::Collections::IVector<uint32_t> const& midiWords)
+    winrt::event_token MidiEndpointConnection::MessagesReceived(winrt::Windows::Foundation::EventHandler<winrt::Microsoft::Devices::Midi2::MidiMessagesReceivedEventArgs> const& handler)
+    {
+        throw hresult_not_implemented();
+    }
+    void MidiEndpointConnection::MessagesReceived(winrt::event_token const& token) noexcept
     {
         throw hresult_not_implemented();
     }

--- a/src/app-dev-sdk/sdk-core/MidiEndpointConnection.h
+++ b/src/app-dev-sdk/sdk-core/MidiEndpointConnection.h
@@ -22,10 +22,12 @@ namespace winrt::Microsoft::Devices::Midi2::implementation
         bool EndpointInformationValid();
         winrt::Microsoft::Devices::Midi2::MidiEndpointInformation EndpointInformation();
         winrt::Windows::Foundation::Collections::IObservableVector<winrt::Microsoft::Devices::Midi2::MidiFunctionBlock> FunctionBlocks();
-        winrt::event_token MessagesReceived(winrt::Windows::Foundation::EventHandler<winrt::Microsoft::Devices::Midi2::MidiMessagesReceivedEventArgs> const& handler);
-        void MessagesReceived(winrt::event_token const& token) noexcept;
         void RequestEndpointInformationAndFunctions(bool forceRefresh);
         winrt::Windows::Foundation::IAsyncAction RequestEndpointInformationAndFunctionsAsync(bool forceRefresh);
+        winrt::Microsoft::Devices::Midi2::MidiMessageReader GetMessageReader();
+        winrt::Microsoft::Devices::Midi2::MidiMessageWriter GetMessageWriter();
+        winrt::event_token MessagesReceived(winrt::Windows::Foundation::EventHandler<winrt::Microsoft::Devices::Midi2::MidiMessagesReceivedEventArgs> const& handler);
+        void MessagesReceived(winrt::event_token const& token) noexcept;
     };
 }
 namespace winrt::Microsoft::Devices::Midi2::factory_implementation

--- a/src/app-dev-sdk/sdk-core/MidiEndpointConnection.h
+++ b/src/app-dev-sdk/sdk-core/MidiEndpointConnection.h
@@ -26,9 +26,6 @@ namespace winrt::Microsoft::Devices::Midi2::implementation
         void MessagesReceived(winrt::event_token const& token) noexcept;
         void RequestEndpointInformationAndFunctions(bool forceRefresh);
         winrt::Windows::Foundation::IAsyncAction RequestEndpointInformationAndFunctionsAsync(bool forceRefresh);
-        void SendUmp(winrt::Microsoft::Devices::Midi2::UmpWithTimestamp const& ump);
-        void SendMultipleUmps(winrt::Windows::Foundation::Collections::IVector<winrt::Microsoft::Devices::Midi2::UmpWithTimestamp> const& umps);
-        void SendMultipleUmpsAsWords(uint64_t timestamp, winrt::Windows::Foundation::Collections::IVector<uint32_t> const& midiWords);
     };
 }
 namespace winrt::Microsoft::Devices::Midi2::factory_implementation

--- a/src/app-dev-sdk/sdk-core/MidiEndpointConnection.idl
+++ b/src/app-dev-sdk/sdk-core/MidiEndpointConnection.idl
@@ -23,7 +23,9 @@ namespace Microsoft.Devices.Midi2
     [default_interface]
     runtimeclass MidiEndpointConnection
     {
-        MidiEndpointConnection();
+        //MidiEndpointConnection();
+
+        // Enumeration Assistance ==============================================================================================
 
         // Get the device selector for all compatible devices
         static String GetDeviceSelector();
@@ -31,21 +33,19 @@ namespace Microsoft.Devices.Midi2
         // device selector for a device which implements a specific MIDI transport/protocol
         static String GetDeviceSelector(MidiEndpointDataFormat midiEndpointDataFormat);
 
-
-
-
         // Id from Windows. This can be used to retrieve the MidiDeviceInformation object with the PnP properties
         String DeviceId{ get; };
 
-       
+
+
+
+        // In-protocol Metadata ================================================================================================
+
         Boolean EndpointInformationValid{ get; };               // needed because WinRT doesn't allow null types
         MidiEndpointInformation EndpointInformation{ get; };    // information from Endpoint Info request. Not valid until EndpointInformation requested and received.
 
         // Blocks which tell us how to treat the groups
         IObservableVector<MidiFunctionBlock>FunctionBlocks { get; };  // these are discovered in-protocol. They can change within the rules in the spec
-
-        // Messages received event only if the centralized message receive is not used
-        event Windows.Foundation.EventHandler<MidiMessagesReceivedEventArgs> MessagesReceived;
 
 
         // call this if you have your own worker thread. It's a long-running operation
@@ -55,30 +55,21 @@ namespace Microsoft.Devices.Midi2
         Windows.Foundation.IAsyncAction RequestEndpointInformationAndFunctionsAsync(Boolean forceRefresh);
 
 
+
+
+        // Message I/O =========================================================================================================
+
+        // Use this to obtain the message reader (one per Endpoint Connection) for processing incoming messages
+        // repeat calls to this will return the same instance
         MidiMessageReader GetMessageReader();
+
+        // Use this to obtain the message writer (one per Endpoint Connection) for sending messages
+        // repeat calls to this will return the same instance
         MidiMessageWriter GetMessageWriter();
 
 
-        //// Send a single strongly-typed UMP with a timestamp
-        ////void SendUmp(UInt64 timestamp, Microsoft.Devices.Midi2.Ump ump);
-        //void SendUmp(Microsoft.Devices.Midi2.UmpWithTimestamp ump);
-
-        //// send multiple strongly-typed UMPs
-        ////void SendMultipleUmps(UInt64 timestamp, IVector<Ump> umps);
-        //void SendMultipleUmps(IVector<UmpWithTimestamp> umps);
-
-        //// Send a vector of MIDI words. The full set of words need to result in complete UMPs.
-        //// This will require the code to read the words and inser the the timestamp into the stream
-        //// in between each complete UMP
-        //void SendMultipleUmpsAsWords(UInt64 timestamp, IVector<UInt32> midiWords);
-
-
-        // May need to implement a separate COM interface for just pointer passing from C++ and similar, as an optimization
-        // That could be done inside a buffer type so the buffer can point to pre-allocated app memory
-        // More info: https://devblogs.microsoft.com/oldnewthing/20200424-00/?p=103702
-        // And our winmm impl https://learn.microsoft.com/en-us/windows/win32/api/mmeapi/nf-mmeapi-midioutlongmsg
-        // https://learn.microsoft.com/en-us/previous-versions/dd798449(v=vs.85)
-
+        // notification that there are new messages received. Optional.
+        event Windows.Foundation.EventHandler<MidiMessagesReceivedEventArgs> MessagesReceived;
 
     }
 }

--- a/src/app-dev-sdk/sdk-core/MidiEndpointConnection.idl
+++ b/src/app-dev-sdk/sdk-core/MidiEndpointConnection.idl
@@ -15,6 +15,8 @@ import "MidiFunctionBlock.idl";
 import "MidiEndpointDataFormatEnum.idl";
 import "UmpWithTimestamp.idl";
 import "MidiMessagesReceivedEvent.idl";
+import "MidiMessageReader.idl";
+import "MidiMessageWriter.idl";
 
 namespace Microsoft.Devices.Midi2
 {
@@ -29,11 +31,13 @@ namespace Microsoft.Devices.Midi2
         // device selector for a device which implements a specific MIDI transport/protocol
         static String GetDeviceSelector(MidiEndpointDataFormat midiEndpointDataFormat);
 
+
+
+
         // Id from Windows. This can be used to retrieve the MidiDeviceInformation object with the PnP properties
         String DeviceId{ get; };
 
-        // TODO: the other types of names (user-provided, device-provided, etc.)
-        
+       
         Boolean EndpointInformationValid{ get; };               // needed because WinRT doesn't allow null types
         MidiEndpointInformation EndpointInformation{ get; };    // information from Endpoint Info request. Not valid until EndpointInformation requested and received.
 
@@ -51,20 +55,22 @@ namespace Microsoft.Devices.Midi2
         Windows.Foundation.IAsyncAction RequestEndpointInformationAndFunctionsAsync(Boolean forceRefresh);
 
 
+        MidiMessageReader GetMessageReader();
+        MidiMessageWriter GetMessageWriter();
 
 
-        // Send a single strongly-typed UMP with a timestamp
-        //void SendUmp(UInt64 timestamp, Microsoft.Devices.Midi2.Ump ump);
-        void SendUmp(Microsoft.Devices.Midi2.UmpWithTimestamp ump);
+        //// Send a single strongly-typed UMP with a timestamp
+        ////void SendUmp(UInt64 timestamp, Microsoft.Devices.Midi2.Ump ump);
+        //void SendUmp(Microsoft.Devices.Midi2.UmpWithTimestamp ump);
 
-        // send multiple strongly-typed UMPs
-        //void SendMultipleUmps(UInt64 timestamp, IVector<Ump> umps);
-        void SendMultipleUmps(IVector<UmpWithTimestamp> umps);
+        //// send multiple strongly-typed UMPs
+        ////void SendMultipleUmps(UInt64 timestamp, IVector<Ump> umps);
+        //void SendMultipleUmps(IVector<UmpWithTimestamp> umps);
 
-        // Send a vector of MIDI words. The full set of words need to result in complete UMPs.
-        // This will require the code to read the words and inser the the timestamp into the stream
-        // in between each complete UMP
-        void SendMultipleUmpsAsWords(UInt64 timestamp, IVector<UInt32> midiWords);
+        //// Send a vector of MIDI words. The full set of words need to result in complete UMPs.
+        //// This will require the code to read the words and inser the the timestamp into the stream
+        //// in between each complete UMP
+        //void SendMultipleUmpsAsWords(UInt64 timestamp, IVector<UInt32> midiWords);
 
 
         // May need to implement a separate COM interface for just pointer passing from C++ and similar, as an optimization

--- a/src/app-dev-sdk/sdk-core/MidiEndpointConnection.idl
+++ b/src/app-dev-sdk/sdk-core/MidiEndpointConnection.idl
@@ -14,7 +14,7 @@ import "MidiEndpointInformation.idl";
 import "MidiFunctionBlock.idl";
 import "MidiEndpointDataFormatEnum.idl";
 import "UmpWithTimestamp.idl";
-import "MidiMessagesReceivedEvent.idl";
+import "MidiMessagesReceivedEventArgs.idl";
 import "MidiMessageReader.idl";
 import "MidiMessageWriter.idl";
 

--- a/src/app-dev-sdk/sdk-core/MidiMessageReader.cpp
+++ b/src/app-dev-sdk/sdk-core/MidiMessageReader.cpp
@@ -1,0 +1,47 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License
+// ============================================================================
+// This is part of the Windows MIDI Services App SDK and should be used
+// in your Windows application via an official binary distribution.
+// Further information: https://github.com/microsoft/MIDI/
+// ============================================================================
+
+#include "pch.h"
+#include "MidiMessageReader.h"
+#include "MidiMessageReader.g.cpp"
+
+namespace winrt::Microsoft::Devices::Midi2::implementation
+{
+    winrt::Microsoft::Devices::Midi2::MidiMessageReaderNoMoreDataBehavior MidiMessageReader::NoMoreDataBehavior()
+    {
+        throw hresult_not_implemented();
+    }
+    void MidiMessageReader::NoMoreDataBehavior(winrt::Microsoft::Devices::Midi2::MidiMessageReaderNoMoreDataBehavior const& value)
+    {
+        throw hresult_not_implemented();
+    }
+    bool MidiMessageReader::EndOfMessages()
+    {
+        throw hresult_not_implemented();
+    }
+    uint64_t MidiMessageReader::PeekNextTimestamp()
+    {
+        throw hresult_not_implemented();
+    }
+    winrt::Microsoft::Devices::Midi2::MidiMessageType MidiMessageReader::PeekNextMessageType()
+    {
+        throw hresult_not_implemented();
+    }
+    winrt::Microsoft::Devices::Midi2::UmpWithTimestamp MidiMessageReader::PeekNextMessage()
+    {
+        throw hresult_not_implemented();
+    }
+    winrt::Windows::Foundation::Collections::IVector<winrt::Microsoft::Devices::Midi2::UmpWithTimestamp> MidiMessageReader::ReadToEnd()
+    {
+        throw hresult_not_implemented();
+    }
+    winrt::Microsoft::Devices::Midi2::UmpWithTimestamp MidiMessageReader::ReadNextMessage()
+    {
+        throw hresult_not_implemented();
+    }
+}

--- a/src/app-dev-sdk/sdk-core/MidiMessageReader.h
+++ b/src/app-dev-sdk/sdk-core/MidiMessageReader.h
@@ -1,0 +1,28 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License
+// ============================================================================
+// This is part of the Windows MIDI Services App SDK and should be used
+// in your Windows application via an official binary distribution.
+// Further information: https://github.com/microsoft/MIDI/
+// ============================================================================
+
+#pragma once
+#include "MidiMessageReader.g.h"
+
+
+namespace winrt::Microsoft::Devices::Midi2::implementation
+{
+    struct MidiMessageReader : MidiMessageReaderT<MidiMessageReader>
+    {
+        MidiMessageReader() = default;
+
+        winrt::Microsoft::Devices::Midi2::MidiMessageReaderNoMoreDataBehavior NoMoreDataBehavior();
+        void NoMoreDataBehavior(winrt::Microsoft::Devices::Midi2::MidiMessageReaderNoMoreDataBehavior const& value);
+        bool EndOfMessages();
+        uint64_t PeekNextTimestamp();
+        winrt::Microsoft::Devices::Midi2::MidiMessageType PeekNextMessageType();
+        winrt::Microsoft::Devices::Midi2::UmpWithTimestamp PeekNextMessage();
+        winrt::Windows::Foundation::Collections::IVector<winrt::Microsoft::Devices::Midi2::UmpWithTimestamp> ReadToEnd();
+        winrt::Microsoft::Devices::Midi2::UmpWithTimestamp ReadNextMessage();
+    };
+}

--- a/src/app-dev-sdk/sdk-core/MidiMessageReader.idl
+++ b/src/app-dev-sdk/sdk-core/MidiMessageReader.idl
@@ -1,0 +1,50 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License
+// ============================================================================
+// This is part of the Windows MIDI Services App SDK and should be used
+// in your Windows application via an official binary distribution.
+// Further information: https://github.com/microsoft/MIDI/
+// ============================================================================
+
+import "MidiMessageTypeEnum.idl";
+
+
+// TODO: Consider thread synchronization for this class. Right now, assumes single-threaded access
+
+namespace Microsoft.Devices.Midi2
+{
+    // WinRT doesn't let you return null values so we need to consider the
+    // the circumstances where the caller didn't check for the end but
+    // kept reading, or the caller is multi-threaded and another thread
+    // drained the queue while they were looping
+    enum MidiMessageReaderNoMoreDataBehavior
+    {
+        ThrowException = 0,
+        WaitAndBlockCallingThread
+    };
+
+    [default_interface]
+    runtimeclass MidiMessageReader : Windows.Foundation.IClosable
+    {
+        //MidiMessageReader();
+
+        MidiMessageReaderNoMoreDataBehavior NoMoreDataBehavior{get; set; };
+
+        // EOF for MIDI messages.
+        Boolean EndOfMessages();
+
+        UInt64 PeekNextTimestamp();
+        MidiMessageType PeekNextMessageType();
+        
+        // copies all pending messages into an IVector (List in some languages)
+        IVector<UmpWithTimestamp> ReadAllPendingMessages();
+
+        // reads a single message
+        UmpWithTimestamp ReadNextMessage();
+
+        // TODO: Consider a method to read next messages into a pre-allocated app buffer
+        // This would require a COM interface because WinRT doesn't do pointers.
+
+
+    }
+}

--- a/src/app-dev-sdk/sdk-core/MidiMessageReader.idl
+++ b/src/app-dev-sdk/sdk-core/MidiMessageReader.idl
@@ -33,11 +33,17 @@ namespace Microsoft.Devices.Midi2
         // EOF for MIDI messages.
         Boolean EndOfMessages();
 
+        // look at the timestamp in the buffer. This is always the first 64 bits at the read pointer
         UInt64 PeekNextTimestamp();
+
+        // look at the next message's type without moving the read pointer (skips over the timestamp to do this)
         MidiMessageType PeekNextMessageType();
+
+        // look at the next message without moving the read pointer
+        UmpWithTimestamp PeekNextMessage();
         
         // copies all pending messages into an IVector (List in some languages)
-        IVector<UmpWithTimestamp> ReadAllPendingMessages();
+        IVector<UmpWithTimestamp> ReadToEnd();
 
         // reads a single message
         UmpWithTimestamp ReadNextMessage();

--- a/src/app-dev-sdk/sdk-core/MidiMessageReader.idl
+++ b/src/app-dev-sdk/sdk-core/MidiMessageReader.idl
@@ -7,6 +7,7 @@
 // ============================================================================
 
 import "MidiMessageTypeEnum.idl";
+import "UmpWithTimestamp.idl";
 
 
 // TODO: Consider thread synchronization for this class. Right now, assumes single-threaded access
@@ -24,14 +25,14 @@ namespace Microsoft.Devices.Midi2
     };
 
     [default_interface]
-    runtimeclass MidiMessageReader : Windows.Foundation.IClosable
+    runtimeclass MidiMessageReader // : Windows.Foundation.IClosable
     {
         //MidiMessageReader();
 
-        MidiMessageReaderNoMoreDataBehavior NoMoreDataBehavior{get; set; };
+        MidiMessageReaderNoMoreDataBehavior NoMoreDataBehavior{ get; set; };
 
         // EOF for MIDI messages.
-        Boolean EndOfMessages();
+        Boolean EndOfMessages{ get; };
 
         // look at the timestamp in the buffer. This is always the first 64 bits at the read pointer
         UInt64 PeekNextTimestamp();

--- a/src/app-dev-sdk/sdk-core/MidiMessageTypeEnum.idl
+++ b/src/app-dev-sdk/sdk-core/MidiMessageTypeEnum.idl
@@ -9,9 +9,25 @@
 
 namespace Microsoft.Devices.Midi2
 {
+    // We recommend not using the FutureReserved ones in client app code
+    // because those names will change when they are used by new messages by the MIDI Association
     enum MidiMessageType
     {
-        foo
-
+        UtilityMessage32 = 0x0,
+        SystemCommon32 = 0x1,
+        Midi1ChannelVoice32 = 0x2,
+        DataMessage64 = 0x3,
+        Midi2ChannelVoice64 = 0x4,
+        DataMessage128 = 0x5,
+        FutureReserved632 = 0x6,
+        FutureReserved732 = 0x7,
+        FutureReserved864 = 0x8,
+        FutureReserved964 = 0x9,
+        FutureReservedA64 = 0xA,
+        FutureReservedB96 = 0xB,
+        FutureReservedC96 = 0xC,
+        FlexData128 = 0xD,
+        FutureReservedE128 = 0xE,
+        UmpStream128 = 0xF
     };
 }

--- a/src/app-dev-sdk/sdk-core/MidiMessageWriter.cpp
+++ b/src/app-dev-sdk/sdk-core/MidiMessageWriter.cpp
@@ -1,0 +1,51 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License
+// ============================================================================
+// This is part of the Windows MIDI Services App SDK and should be used
+// in your Windows application via an official binary distribution.
+// Further information: https://github.com/microsoft/MIDI/
+// ============================================================================
+
+#include "pch.h"
+#include "MidiMessageWriter.h"
+#include "MidiMessageWriter.g.cpp"
+
+namespace winrt::Microsoft::Devices::Midi2::implementation
+{
+    bool MidiMessageWriter::IsFull()
+    {
+        throw hresult_not_implemented();
+    }
+    void MidiMessageWriter::WriteUmpWords32(uint64_t midiTimestamp, uint32_t umpWord1)
+    {
+        throw hresult_not_implemented();
+    }
+    void MidiMessageWriter::WriteUmpWords64(uint64_t midiTimestamp, uint32_t umpWord1, uint32_t umpWord2)
+    {
+        throw hresult_not_implemented();
+    }
+    void MidiMessageWriter::WriteUmpWords96(uint64_t midiTimestamp, uint32_t umpWord1, uint32_t umpWord2, uint32_t umpWord3)
+    {
+        throw hresult_not_implemented();
+    }
+    void MidiMessageWriter::WriteUmpWords128(uint64_t midiTimestamp, uint32_t umpWord1, uint32_t umpWord2, uint32_t umpWord3, uint32_t umpWord4)
+    {
+        throw hresult_not_implemented();
+    }
+    void MidiMessageWriter::WriteUmpWords(uint64_t midiTimeStamp, array_view<uint32_t const> words, uint8_t wordCount)
+    {
+        throw hresult_not_implemented();
+    }
+    void MidiMessageWriter::WriteUmpWithTimestamp(winrt::Microsoft::Devices::Midi2::UmpWithTimestamp const& ump)
+    {
+        throw hresult_not_implemented();
+    }
+    void MidiMessageWriter::WriteUmpWithTimestamp(uint64_t midiTimestamp, winrt::Microsoft::Devices::Midi2::Ump const& ump)
+    {
+        throw hresult_not_implemented();
+    }
+    void MidiMessageWriter::WriteMultipleUmpsWithTimestamps(winrt::Windows::Foundation::Collections::IVector<winrt::Microsoft::Devices::Midi2::UmpWithTimestamp> const& umpList)
+    {
+        throw hresult_not_implemented();
+    }
+}

--- a/src/app-dev-sdk/sdk-core/MidiMessageWriter.h
+++ b/src/app-dev-sdk/sdk-core/MidiMessageWriter.h
@@ -1,0 +1,28 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License
+// ============================================================================
+// This is part of the Windows MIDI Services App SDK and should be used
+// in your Windows application via an official binary distribution.
+// Further information: https://github.com/microsoft/MIDI/
+// ============================================================================
+
+#pragma once
+#include "MidiMessageWriter.g.h"
+
+namespace winrt::Microsoft::Devices::Midi2::implementation
+{
+    struct MidiMessageWriter : MidiMessageWriterT<MidiMessageWriter>
+    {
+        MidiMessageWriter() = default;
+
+        bool IsFull();
+        void WriteUmpWords32(uint64_t midiTimestamp, uint32_t umpWord1);
+        void WriteUmpWords64(uint64_t midiTimestamp, uint32_t umpWord1, uint32_t umpWord2);
+        void WriteUmpWords96(uint64_t midiTimestamp, uint32_t umpWord1, uint32_t umpWord2, uint32_t umpWord3);
+        void WriteUmpWords128(uint64_t midiTimestamp, uint32_t umpWord1, uint32_t umpWord2, uint32_t umpWord3, uint32_t umpWord4);
+        void WriteUmpWords(uint64_t midiTimeStamp, array_view<uint32_t const> words, uint8_t wordCount);
+        void WriteUmpWithTimestamp(winrt::Microsoft::Devices::Midi2::UmpWithTimestamp const& ump);
+        void WriteUmpWithTimestamp(uint64_t midiTimestamp, winrt::Microsoft::Devices::Midi2::Ump const& ump);
+        void WriteMultipleUmpsWithTimestamps(winrt::Windows::Foundation::Collections::IVector<winrt::Microsoft::Devices::Midi2::UmpWithTimestamp> const& umpList);
+    };
+}

--- a/src/app-dev-sdk/sdk-core/MidiMessageWriter.idl
+++ b/src/app-dev-sdk/sdk-core/MidiMessageWriter.idl
@@ -1,0 +1,61 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License
+// ============================================================================
+// This is part of the Windows MIDI Services App SDK and should be used
+// in your Windows application via an official binary distribution.
+// Further information: https://github.com/microsoft/MIDI/
+// ============================================================================
+
+
+// TODO: Consider thread synchronization for this class. Right now, assumes single-threaded access
+
+namespace Microsoft.Devices.Midi2
+{
+    enum MidiMessageWriterQueueFullBehavior
+    {
+        ThrowException = 0,
+        WaitAndBlockCallingThread
+
+        // May also have options to:
+        // - Allocate a side-by-side buffer and table the messages until they can be sent
+        // - Reallocate buffer size (this is very expensive, so not recommended)
+        // Both of those options require real investigation before we consider them here.
+    };
+
+    [default_interface]
+    runtimeclass MidiMessageWriter : Windows.Foundation.IClosable
+    {
+        //MidiMessageWriter();
+
+        Boolean IsFull {get; };
+
+        void WriteUmpWords32(UInt64 midiTimestamp, UInt32 umpWord1);
+        void WriteUmpWords64(UInt64 midiTimestamp, UInt32 umpWord1, UInt32 umpWord2,);
+        void WriteUmpWords96(UInt64 midiTimestamp, UInt32 umpWord1, UInt32 umpWord2, UInt32 umpWord3);
+        void WriteUmpWords128(UInt64 midiTimestamp, UInt32 umpWord1, UInt32 umpWord2, UInt32 umpWord3, UInt32 umpWord4);
+
+        void WriteUmpWords(UInt64 midiTimeStamp, UInt32[] words, UInt8 wordCount);
+
+        void WriteUmpWithTimestamp(UmpWithTimestamp ump);
+        void WriteUmpWithTimestamp(UInt64 midiTimestamp, Ump ump);
+
+        void WriteMultipleUmpsWithTimestamps(IVector<UmpWithTimestamp> umpList);
+
+
+        // TODO: Considering adding a separate COM interface to this class, only for C++ 
+        // (or other COM-aware and pointer-centric languages) to allow passing a pointer 
+        // to a UMP or perhaps to a buffer which has multiple UMPs and timestamps already
+        // prepared. The IBuffer approach just doesn't seem great for this and WinRT 
+        // doesn't do pointer passing across boundaries. 
+
+
+        // NOTE: This class doesn't use the usual buffered approach which requires a call to Flush().
+        // May rethink that, but currently, there's no perf benefit to transmitting multiple
+        // messages at once.
+        // However, there does need to be a notification to the service that the message(s)
+        // are ready to transmit. So this class will include a method like Complete() or 
+        // Notify() or Signal() or similar. That breaks the usual stream pattern, but is
+        // appropriate here.
+
+    }
+}

--- a/src/app-dev-sdk/sdk-core/MidiMessageWriter.idl
+++ b/src/app-dev-sdk/sdk-core/MidiMessageWriter.idl
@@ -9,6 +9,8 @@
 
 // TODO: Consider thread synchronization for this class. Right now, assumes single-threaded access
 
+import "UmpWithTimestamp.idl";
+
 namespace Microsoft.Devices.Midi2
 {
     enum MidiMessageWriterQueueFullBehavior
@@ -23,14 +25,14 @@ namespace Microsoft.Devices.Midi2
     };
 
     [default_interface]
-    runtimeclass MidiMessageWriter : Windows.Foundation.IClosable
+    runtimeclass MidiMessageWriter // : Windows.Foundation.IClosable
     {
         //MidiMessageWriter();
 
-        Boolean IsFull {get; };
+        Boolean IsFull { get; };
 
         void WriteUmpWords32(UInt64 midiTimestamp, UInt32 umpWord1);
-        void WriteUmpWords64(UInt64 midiTimestamp, UInt32 umpWord1, UInt32 umpWord2,);
+        void WriteUmpWords64(UInt64 midiTimestamp, UInt32 umpWord1, UInt32 umpWord2);
         void WriteUmpWords96(UInt64 midiTimestamp, UInt32 umpWord1, UInt32 umpWord2, UInt32 umpWord3);
         void WriteUmpWords128(UInt64 midiTimestamp, UInt32 umpWord1, UInt32 umpWord2, UInt32 umpWord3, UInt32 umpWord4);
 

--- a/src/app-dev-sdk/sdk-core/MidiMessagesReceivedEvent.idl
+++ b/src/app-dev-sdk/sdk-core/MidiMessagesReceivedEvent.idl
@@ -6,6 +6,10 @@
 // Further information: https://github.com/microsoft/MIDI/
 // ============================================================================
 
+// this event is just a signal to the client to read from the midimessagereader for the endpointconnection
+// This avoids copying data, and provides a lot more flexibility.
+
+
 import "UmpWithTimestamp.idl";
 
 namespace Microsoft.Devices.Midi2
@@ -18,15 +22,10 @@ namespace Microsoft.Devices.Midi2
         // TODO: Decide if we just want a reference to the MidiEndpoint here instead of a fat string
         String SourceMidiEndpointId{ get; set; };
 
-        // this creates copies of the data from the buffer, which is important
-        // in casees where the buffer is rapidly filling up and the app wants to
-        // do some longer processing
-//        IVector<Microsoft.Devices.Midi2.UmpWithTimestamp> GetMessagesList();
+        // convenience shortcut to the same reader from the Endpoint Connection. Useful for those who
+        // prefer a traditional .NET or WinRT approach to message handling
+        MidiMessageReader Reader{ get; };
 
-
-
-        // this event will just be a signal to the client to read from the midimessagereader for the endpointconnection
-        // This avoids copying data, and provides a lot more flexibility.
 
     }
 }

--- a/src/app-dev-sdk/sdk-core/MidiMessagesReceivedEvent.idl
+++ b/src/app-dev-sdk/sdk-core/MidiMessagesReceivedEvent.idl
@@ -21,14 +21,12 @@ namespace Microsoft.Devices.Midi2
         // this creates copies of the data from the buffer, which is important
         // in casees where the buffer is rapidly filling up and the app wants to
         // do some longer processing
-        IVector<Microsoft.Devices.Midi2.UmpWithTimestamp> GetMessagesList();
+//        IVector<Microsoft.Devices.Midi2.UmpWithTimestamp> GetMessagesList();
 
-        // todo: potentially a method to get the raw buffer. Some danger here
-        // with the contents changing though, as it's a circular buffer, not
-        // a copy of the data. Don't want to build in a known race condition.
-        // we may just need to memcopy the buffer into app memory space for 
-        // this to be safe. We can then provide an optional message reader which
-        // will spit out strongly typed messages in a stream reader type fashion
-        // This is simply to accommodate different app coding approaches.
+
+
+        // this event will just be a signal to the client to read from the midimessagereader for the endpointconnection
+        // This avoids copying data, and provides a lot more flexibility.
+
     }
 }

--- a/src/app-dev-sdk/sdk-core/MidiMessagesReceivedEventArgs.cpp
+++ b/src/app-dev-sdk/sdk-core/MidiMessagesReceivedEventArgs.cpp
@@ -16,11 +16,7 @@ namespace winrt::Microsoft::Devices::Midi2::implementation
     {
         throw hresult_not_implemented();
     }
-    void MidiMessagesReceivedEventArgs::SourceMidiEndpointId(hstring const& value)
-    {
-        throw hresult_not_implemented();
-    }
-    winrt::Windows::Foundation::Collections::IVector<winrt::Microsoft::Devices::Midi2::UmpWithTimestamp> MidiMessagesReceivedEventArgs::GetMessagesList()
+    winrt::Microsoft::Devices::Midi2::MidiMessageReader MidiMessagesReceivedEventArgs::GetMessageReader()
     {
         throw hresult_not_implemented();
     }

--- a/src/app-dev-sdk/sdk-core/MidiMessagesReceivedEventArgs.h
+++ b/src/app-dev-sdk/sdk-core/MidiMessagesReceivedEventArgs.h
@@ -16,8 +16,7 @@ namespace winrt::Microsoft::Devices::Midi2::implementation
         MidiMessagesReceivedEventArgs() = default;
 
         hstring SourceMidiEndpointId();
-        void SourceMidiEndpointId(hstring const& value);
-        winrt::Windows::Foundation::Collections::IVector<winrt::Microsoft::Devices::Midi2::UmpWithTimestamp> GetMessagesList();
+        winrt::Microsoft::Devices::Midi2::MidiMessageReader GetMessageReader();
     };
 }
 namespace winrt::Microsoft::Devices::Midi2::factory_implementation

--- a/src/app-dev-sdk/sdk-core/MidiMessagesReceivedEventArgs.idl
+++ b/src/app-dev-sdk/sdk-core/MidiMessagesReceivedEventArgs.idl
@@ -11,6 +11,7 @@
 
 
 import "UmpWithTimestamp.idl";
+import "MidiMessageReader.idl";
 
 namespace Microsoft.Devices.Midi2
 {
@@ -20,11 +21,11 @@ namespace Microsoft.Devices.Midi2
         MidiMessagesReceivedEventArgs();
 
         // TODO: Decide if we just want a reference to the MidiEndpoint here instead of a fat string
-        String SourceMidiEndpointId{ get; set; };
+        String SourceMidiEndpointId{ get; };
 
         // convenience shortcut to the same reader from the Endpoint Connection. Useful for those who
         // prefer a traditional .NET or WinRT approach to message handling
-        MidiMessageReader Reader{ get; };
+        MidiMessageReader GetMessageReader();
 
 
     }

--- a/src/app-dev-sdk/sdk-core/MidiSession.idl
+++ b/src/app-dev-sdk/sdk-core/MidiSession.idl
@@ -10,7 +10,7 @@
 import "MidiEndpointConnection.idl";
 import "MidiEndpointConnectOptions.idl";
 import "MidiSessionSettings.idl";
-import "MidiMessagesReceivedEvent.idl";
+import "MidiMessagesReceivedEventArgs.idl";
 
 namespace Microsoft.Devices.Midi2
 {
@@ -49,7 +49,8 @@ namespace Microsoft.Devices.Midi2
 
         // Messages received event fires here only for Endpoints where 
         // the centralized message receive option was set when they were connected 
-        event Windows.Foundation.EventHandler<MidiMessagesReceivedEventArgs> MessagesReceived;
+        // TBD if we support this. Commented out for now to go with the Endpoint-centric approach
+        //event Windows.Foundation.EventHandler<MidiMessagesReceivedEventArgs> MessagesReceived;
 
 
         // utility methods =======================================================================

--- a/src/app-dev-sdk/sdk-core/UmpWithTimestamp.cpp
+++ b/src/app-dev-sdk/sdk-core/UmpWithTimestamp.cpp
@@ -12,11 +12,11 @@
 
 namespace winrt::Microsoft::Devices::Midi2::implementation
 {
-    uint32_t UmpWithTimestamp::Timestamp()
+    uint64_t UmpWithTimestamp::Timestamp()
     {
         throw hresult_not_implemented();
     }
-    void UmpWithTimestamp::Timestamp(uint32_t value)
+    void UmpWithTimestamp::Timestamp(uint64_t value)
     {
         throw hresult_not_implemented();
     }

--- a/src/app-dev-sdk/sdk-core/UmpWithTimestamp.h
+++ b/src/app-dev-sdk/sdk-core/UmpWithTimestamp.h
@@ -15,8 +15,8 @@ namespace winrt::Microsoft::Devices::Midi2::implementation
     {
         UmpWithTimestamp() = default;
 
-        uint32_t Timestamp();
-        void Timestamp(uint32_t value);
+        uint64_t Timestamp();
+        void Timestamp(uint64_t value);
         winrt::Microsoft::Devices::Midi2::Ump Ump();
         void Ump(winrt::Microsoft::Devices::Midi2::Ump const& value);
     };

--- a/src/app-dev-sdk/sdk-core/UmpWithTimestamp.idl
+++ b/src/app-dev-sdk/sdk-core/UmpWithTimestamp.idl
@@ -25,7 +25,7 @@ namespace Microsoft.Devices.Midi2
     {
         UmpWithTimestamp();
 
-        UInt32 Timestamp{ get; set; };
+        UInt64 Timestamp{ get; set; };
 
         Microsoft.Devices.Midi2.Ump Ump{ get; set; };
 

--- a/src/app-dev-sdk/sdk-core/packages.config
+++ b/src/app-dev-sdk/sdk-core/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.Windows.CppWinRT" version="2.0.230225.1" targetFramework="native" />
+  <package id="Microsoft.Windows.CppWinRT" version="2.0.230524.4" targetFramework="native" />
 </packages>


### PR DESCRIPTION
After a discussion with Gary about how the cyclic buffers work in practice, I moved all the read/write (receive/send) functionality into the MidiMessageReader and MidiMessageWriter. The MessagesReceived event is now a convenience rather than a requirement. The SendUmpxxxx methods are gone. The pattern is very similar to the DataReader/StreamReader / Writer patterns commonly used in Windows in WinRT and .NET.

I'm considering adding a COM interface to this for C++ (and other pointer-friendly languages which understand COM) to allow more efficient copying of the data buffers from applications for cases when applications want to send large numbers of messages at once. (WinRT itself does not do pointers.) Factoring this logic into the new class makes that easier to do should that optimization be necessary.

As before, this is all "shape", not implementation just yet.