### PR TITLE
Fix high CPU usage in service (issue #170)

### DIFF
--- a/build/staging/version/BundleInfo.wxi
+++ b/build/staging/version/BundleInfo.wxi
@@ -1,4 +1,4 @@
 <Include>
   <?define SetupVersionName="Developer Preview" ?>
-  <?define SetupVersionNumber="1.0.23351.2023" ?>
+  <?define SetupVersionNumber="1.0.23352.2034" ?>
 </Include>

--- a/src/api/Service/Exe/MidiClientManager.cpp
+++ b/src/api/Service/Exe/MidiClientManager.cpp
@@ -30,6 +30,8 @@ CMidiClientManager::Initialize(
 HRESULT
 CMidiClientManager::Cleanup()
 {
+    OutputDebugString(L"" __FUNCTION__ " enter");
+    
     auto lock = m_ClientManagerLock.lock();
 
     m_PerformanceManager.reset();
@@ -433,7 +435,7 @@ CMidiClientManager::CreateMidiClient(
                 devicePipe->DataFormatIn(), 
                 clientPipe->DataFormatIn(), 
                 devicePipe, 
-                clientConnectionPipe));
+                clientConnectionPipe)); // clientConnectionPipe is the plugin
 
             clientConnectionPipe->AddClient((MidiClientHandle)clientPipe.get());
         }
@@ -512,7 +514,9 @@ CMidiClientManager::CreateMidiClient(
                 clientPipe->DataFormatOut(), 
                 newClientConnectionPipe->DataFormatOut(), 
                 devicePipe, 
-                clientConnectionPipe));
+                clientConnectionPipe)); // clientConnectionPipe is the plugin
+
+            clientConnectionPipe->AddClient((MidiClientHandle)clientPipe.get());
 
             newClientConnectionPipe = clientConnectionPipe;
         }
@@ -528,7 +532,9 @@ CMidiClientManager::CreateMidiClient(
                 MidiFlowOut, 
                 devicePipe, 
                 newClientConnectionPipe, 
-                clientConnectionPipe));
+                clientConnectionPipe)); // clientConnectionPipe is the plugin
+
+            clientConnectionPipe->AddClient((MidiClientHandle)clientPipe.get());
 
             newClientConnectionPipe = clientConnectionPipe;
         }
@@ -536,7 +542,7 @@ CMidiClientManager::CreateMidiClient(
         // no more transforms to add
         clientConnectionPipe = newClientConnectionPipe;
 
-        clientConnectionPipe->AddClient((MidiClientHandle)clientPipe.get());
+        //clientConnectionPipe->AddClient((MidiClientHandle)clientPipe.get());
 
         RETURN_IF_FAILED(clientPipe->SetDataFormatOut(clientConnectionPipe->DataFormatOut()));
         Client->DataFormat = clientPipe->DataFormatOut();

--- a/src/api/Service/Exe/MidiTransformPipe.cpp
+++ b/src/api/Service/Exe/MidiTransformPipe.cpp
@@ -45,6 +45,13 @@ GUID CMidiTransformPipe::TransformGuid()
 HRESULT
 CMidiTransformPipe::Cleanup()
 {
+    OutputDebugString(L"" __FUNCTION__);
+
+    if (m_MidiDataTransform)
+    {
+        RETURN_IF_FAILED(m_MidiDataTransform->Cleanup());
+    }
+
     RETURN_IF_FAILED(CMidiPipe::Cleanup());
     return S_OK;
 }

--- a/src/api/Service/Inc/MidiPipe.h
+++ b/src/api/Service/Inc/MidiPipe.h
@@ -42,6 +42,8 @@ public:
 
     virtual HRESULT Cleanup()
     {
+        OutputDebugString(L"" __FUNCTION__);
+
         auto lock = m_Lock.lock();
         m_ConnectedPipes.clear();
         m_Clients.clear();

--- a/src/api/Transform/SchedulerTransform/Midi2.SchedulerMidiTransform.h
+++ b/src/api/Transform/SchedulerTransform/Midi2.SchedulerMidiTransform.h
@@ -23,6 +23,8 @@ private:
 
     HRESULT GetTopMessageTimestamp(_Out_ internal::MidiTimestamp& timestamp);
 
+    HRESULT CalculateSafeSleepTime(_In_ internal::MidiTimestamp nextWakeupWindowTimestamp, _Out_ uint32_t& sleepMS);
+
 
     HRESULT SendMidiMessageNow(
         _In_ PVOID Data,


### PR DESCRIPTION
Needed to get the cleanup calls properly chained down to the message transform plugins. Once that happened, the scheduler would properly shut down.

Fixes #170 