### PR TITLE
Prep for release 2.1

### DIFF
--- a/build/staging/version/BundleInfo.wxi
+++ b/build/staging/version/BundleInfo.wxi
@@ -1,4 +1,4 @@
 <Include>
   <?define SetupVersionName="Developer Preview" ?>
-  <?define SetupVersionNumber="1.0.23352.2048" ?>
+  <?define SetupVersionNumber="1.0.23353.1652" ?>
 </Include>

--- a/src/user-tools/midi-console/Midi/Commands/Endpoint/SendMessageCommand.cs
+++ b/src/user-tools/midi-console/Midi/Commands/Endpoint/SendMessageCommand.cs
@@ -168,9 +168,11 @@ namespace Microsoft.Devices.Midi2.ConsoleApp
                 {
                     int sleepMs = (int)Math.Ceiling(MidiClock.ConvertTimestampToMilliseconds(maxTimestampScheduled - MidiClock.Now));
 
-                    AnsiConsole.MarkupLine($"Keeping connection alive until timestamp : {AnsiMarkupFormatter.FormatTimestamp(maxTimestampScheduled)} ({sleepMs / 1000} seconds from now)");
+                    sleepMs += 1000;    // we wait an extra second to avoid any timing issues
 
-                    Thread.Sleep(sleepMs + 500);
+                    AnsiConsole.MarkupLine($"Keeping connection alive until timestamp : {AnsiMarkupFormatter.FormatTimestamp(maxTimestampScheduled)} (apx {Math.Round(sleepMs / 1000.0, 1)} seconds from now)");
+
+                    Thread.Sleep(sleepMs);
                 }
 
 


### PR DESCRIPTION
Need to put out a release 2.1 due to the CPU usage issue. In some cases, it can lead to 100% CPU and an unusable system.