### PR TITLE
Update midi.exe to gracefully handle an endpoint disconnect when monitoring messages

### DIFF
--- a/build/staging/version/BundleInfo.wxi
+++ b/build/staging/version/BundleInfo.wxi
@@ -1,4 +1,4 @@
 <Include>
   <?define SetupVersionName="Developer Preview 3" ?>
-  <?define SetupVersionNumber="1.0.24013.1953" ?>
+  <?define SetupVersionNumber="1.0.24013.2139" ?>
 </Include>

--- a/src/README.md
+++ b/src/README.md
@@ -4,12 +4,8 @@ The main source tree.
 
 | Location | Description |
 | -------------------- | ----------------------------------------------------- |
-| app-dev-api | API underneath the SDK |
+| api | Root of tree that is mirrored with our internal system. This has the API, the Service, Plugins, and the USB Driver |
 | app-dev-sdk | SDK which applications should use to speak to the API and service |
 | dev-tools | Developer-focused tools, when appropriate |
-| plugins | plugin implementations which use the MIDI Services abstractions |
-| service | This is core Windows MIDI Services including the Windows Services and the abstractions |
 | shared | Certain files shared across the different projects |
-| unit-tests | test code |
-| usb-driver | USB MIDI 2.0 driver |
 | user-tools | End-user tools like settings and the CLI |

--- a/src/api/Client/Midi2Client/MidiEndpointConnection.cpp
+++ b/src/api/Client/Midi2Client/MidiEndpointConnection.cpp
@@ -272,7 +272,9 @@ namespace winrt::Windows::Devices::Midi2::implementation
     MidiEndpointConnection::~MidiEndpointConnection()
     {
         if (!m_closeHasBeenCalled)
+        {
             Close();
+        }
     }
 
 

--- a/src/api/Client/Midi2Client/MidiSession.cpp
+++ b/src/api/Client/Midi2Client/MidiSession.cpp
@@ -209,7 +209,7 @@ namespace winrt::Windows::Devices::Midi2::implementation
         {
             if (m_connections.HasKey(endpointConnectionId))
             {
-                // todo: disconnect the endpoint from the service, call Close() etc.
+                // disconnect the endpoint from the service, call Close() etc.
 
                 m_connections.Lookup(endpointConnectionId).as<foundation::IClosable>().Close();
 
@@ -217,7 +217,7 @@ namespace winrt::Windows::Devices::Midi2::implementation
             }
             else
             {
-                // endpoint already disconnected. No need to except or anything, just exit.
+                // endpoint already disconnected. No need to throw an exception or anything, just exit.
             }
         }
         catch (winrt::hresult_error const& ex)

--- a/src/user-tools/midi-console/Midi/Resources/Strings.Designer.cs
+++ b/src/user-tools/midi-console/Midi/Resources/Strings.Designer.cs
@@ -259,6 +259,15 @@ namespace Microsoft.Devices.Midi2.ConsoleApp.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Endpoint has been disconnected.
+        /// </summary>
+        internal static string EndpointDisconnected {
+            get {
+                return ResourceManager.GetString("EndpointDisconnected", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Please select an endpoint.
         /// </summary>
         internal static string EndpointPickerPleaseSelectEndpoint {

--- a/src/user-tools/midi-console/Midi/Resources/Strings.resx
+++ b/src/user-tools/midi-console/Midi/Resources/Strings.resx
@@ -183,6 +183,9 @@
   <data name="CommonTableHeaderIndex" xml:space="preserve">
     <value>Index</value>
   </data>
+  <data name="EndpointDisconnected" xml:space="preserve">
+    <value>Endpoint has been disconnected</value>
+  </data>
   <data name="EndpointPickerPleaseSelectEndpoint" xml:space="preserve">
     <value>Please select an endpoint</value>
   </data>


### PR DESCRIPTION
If a device is disconnected while midi.exe is monitoring, it will no longer just sit there waiting for more messages. Instead, it displays a message to the user and exits.

![image](https://github.com/microsoft/MIDI/assets/1421146/d546f6c9-c363-4c45-b3e6-e2c17d4dfbde)
