### PR TITLE
KS (USB) Endpoint name and description can now be specified in the config file

### DIFF
--- a/build/staging/configuration/Default.midiconfig.json
+++ b/build/staging/configuration/Default.midiconfig.json
@@ -10,7 +10,9 @@
     {
         "{26FA740D-469C-4D33-BEB1-3885DE7D6DF1}":
         {
-            "_comment": "KS MIDI (USB etc.)"
+            "_comment": "KS MIDI (USB etc.)",
+
+
         },
         "{C95DCD1F-CDE3-4C2D-913C-528CB8A4CBE6}":
         {

--- a/build/staging/version/BundleInfo.wxi
+++ b/build/staging/version/BundleInfo.wxi
@@ -1,4 +1,4 @@
 <Include>
   <?define SetupVersionName="Developer Preview 4" ?>
-  <?define SetupVersionNumber="1.0.24014.1827" ?>
+  <?define SetupVersionNumber="1.0.24014.2024" ?>
 </Include>

--- a/get-started/midi-users/docs/config-json.md
+++ b/get-started/midi-users/docs/config-json.md
@@ -1,7 +1,12 @@
 # JSON Config File
 
-
 It's best to use the Settings application and the transport / processing plugins for Settings to manipulate the file. However, if you edit it by hand, here are some notes.
+
+## The File location is Restricted
+
+The JSON configuration files are all stored in `%allusersprofile%\Microsoft\MIDI` which typically resolves to `C:\ProgramData\Microsoft\MIDI`. For security reasons, we don't allow the file to be stored in any other location. However, you can have as many files in that folder as you want, and switch between them as needed.
+
+The default config file is typically named `Default.midiconfig.json`. The actual name is stored in the registry under `HKLM\SOFTWARE\Microsoft\Windows MIDI Services` in the `CurrentConfig` value. This value must not contain any non-filename path characters (no backslashes, colons, etc.).
 
 ## JSON is Case-Sensitive
 
@@ -20,12 +25,6 @@ and
             "_comment": "KS MIDI (USB etc.)"
         },
 ```
-
-## The File location is Restricted
-
-The JSON configuration files are all stored in `%allusersprofile%\Microsoft\MIDI` which typically resolves to `C:\ProgramData\Microsoft\MIDI`. For security reasons, we don't allow the file to be stored in any other location. However, you can have as many files in that folder as you want, and switch between them as needed.
-
-The default config file is typically named `Default.midiconfig.json`. The actual name is stored in the registry under `HKLM\SOFTWARE\Microsoft\Windows MIDI Services` in the `CurrentConfig` value. This value must not contain any non-filename path characters (no backslashes, colons, etc.).
 
 ## Schema
 
@@ -64,6 +63,38 @@ Here's an example of a bare-bones file, with sections for three different transp
     }
 }
 ```
+
+### Endpoint Properties
+
+The basics of this are identical for each transport. We'll use KS (USB) as an example
+
+```json
+"{26FA740D-469C-4D33-BEB1-3885DE7D6DF1}":
+{
+    "_comment": "KS MIDI (USB etc.)"
+    "SWD: \\\\?\\SWD#MIDISRV#MIDIU_KS_BIDI_6799286025327820155_OUTPIN.0_INPIN.2#{e7cce071-3c03-423f-88d3-f1045d02552b}":
+    {
+        "userSuppliedName" : "Pete's Kontrol S61",
+        "userSuppliedDescription" : "This is my most favorite MIDI 2.0 controller in the whole world!"
+    }
+    ...
+},
+```
+
+Of those, the identification method `SWD` is the most important. This controls how we identify a matching device. In cases where the manufacturer doesn't supply a unique iSerialNumber in USB, unplugging your device from one USB port and plugging it into another can result in a new Id. Similarly, if you have two or more of the same device, and they do not have unique serial numbers, it can be impossible for Windows to distinguish between them.
+
+Valid values for the identification method prefix
+
+- `SWD: ` : (The colon and trailing space are required). Use the full Windows Endpoint Device Interface Id. For example `\\\\?\\SWD#MIDISRV#MIDIU_KS_BIDI_16024944077548273316_OUTPIN.0_INPIN.2#{e7cce071-3c03-423f-88d3-f1045d02552b}`. (Note how the backslashes have to be escaped with additional backslashes.) If the device has an `iSerialNumber` or you never move it between USB ports, this tends to work fine.
+- (other methods to be added here when we implement them)
+
+Valid properties you can set across all supported endpoints
+
+| Property | Type | Description |
+| -------- | ---- | ----------- |
+| `userSuppliedName` | Quoted Text | The name you want to use for the endpoint. This will override the name displayed in correctly-coded applications, but won't necessarily change what you see in Device Manager. These names should be relatively short so they display fully in all/most applications, but meaningful to you. |
+| `userSuppliedDescription` | Quoted Text | A text description and/or notes about the endpoint. Applications may or may not use this data |
+| `forceSingleClientOnly` | Boolean true/false (no quotes) | Most endpoints are multi-client (more than one applicatation can use them simultaneously) by default. This is for forcing an endpoint to be single-client only (true). It's unusual to need this, but a typical use may be to disable multi-client for a device which has a custom driver which doesn't gracefully handle multiple client applications at the same time. |
 
 ## Plugin-specific settings
 

--- a/src/api/Abstraction/KSAbstraction/Midi2.KSAbstraction.h
+++ b/src/api/Abstraction/KSAbstraction/Midi2.KSAbstraction.h
@@ -1,4 +1,11 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License
+// ============================================================================
+// This is part of the Windows MIDI Services App API and should be used
+// in your Windows application via an official binary distribution.
+// Further information: https://github.com/microsoft/MIDI/
+// ============================================================================
+
 #pragma once
 
 class MidiKSAbstractionTelemetryProvider : public wil::TraceLoggingProvider

--- a/src/api/Abstraction/KSAbstraction/Midi2.KSMidi.h
+++ b/src/api/Abstraction/KSAbstraction/Midi2.KSMidi.h
@@ -1,4 +1,11 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License
+// ============================================================================
+// This is part of the Windows MIDI Services App API and should be used
+// in your Windows application via an official binary distribution.
+// Further information: https://github.com/microsoft/MIDI/
+// ============================================================================
+
 #pragma once
 
 class CMidi2KSMidi

--- a/src/api/Abstraction/KSAbstraction/Midi2.KSMidiBidi.h
+++ b/src/api/Abstraction/KSAbstraction/Midi2.KSMidiBidi.h
@@ -1,4 +1,11 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License
+// ============================================================================
+// This is part of the Windows MIDI Services App API and should be used
+// in your Windows application via an official binary distribution.
+// Further information: https://github.com/microsoft/MIDI/
+// ============================================================================
+
 #pragma once
 
 class CMidi2KSMidiBiDi : 

--- a/src/api/Abstraction/KSAbstraction/Midi2.KSMidiEndpointManager.h
+++ b/src/api/Abstraction/KSAbstraction/Midi2.KSMidiEndpointManager.h
@@ -1,4 +1,11 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License
+// ============================================================================
+// This is part of the Windows MIDI Services App API and should be used
+// in your Windows application via an official binary distribution.
+// Further information: https://github.com/microsoft/MIDI/
+// ============================================================================
+
 #pragma once
 
 using namespace winrt::Windows::Devices::Enumeration;
@@ -54,5 +61,9 @@ private:
     winrt::impl::consume_Windows_Devices_Enumeration_IDeviceWatcher<IDeviceWatcher>::Stopped_revoker m_DeviceStopped;
     winrt::impl::consume_Windows_Devices_Enumeration_IDeviceWatcher<IDeviceWatcher>::EnumerationCompleted_revoker m_DeviceEnumerationCompleted;
     wil::unique_event m_EnumerationCompleted{wil::EventOptions::None};
+
+    // may want to change this to the actual json object.
+    winrt::Windows::Data::Json::JsonObject m_jsonObject{};
+    HRESULT ApplyUserConfiguration(_In_ std::wstring deviceInterfaceId);
 
 };

--- a/src/api/Abstraction/KSAbstraction/Midi2.KSMidiIn.h
+++ b/src/api/Abstraction/KSAbstraction/Midi2.KSMidiIn.h
@@ -1,4 +1,11 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License
+// ============================================================================
+// This is part of the Windows MIDI Services App API and should be used
+// in your Windows application via an official binary distribution.
+// Further information: https://github.com/microsoft/MIDI/
+// ============================================================================
+
 #pragma once
 
 class CMidi2KSMidiIn : 

--- a/src/api/Abstraction/KSAbstraction/Midi2.KSMidiOut.h
+++ b/src/api/Abstraction/KSAbstraction/Midi2.KSMidiOut.h
@@ -1,4 +1,12 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License
+// ============================================================================
+// This is part of the Windows MIDI Services App API and should be used
+// in your Windows application via an official binary distribution.
+// Further information: https://github.com/microsoft/MIDI/
+// ============================================================================
+
+
 #pragma once
 
 class CMidi2KSMidiOut : 

--- a/src/api/Abstraction/KSAbstraction/Resource.h
+++ b/src/api/Abstraction/KSAbstraction/Resource.h
@@ -1,4 +1,11 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License
+// ============================================================================
+// This is part of the Windows MIDI Services App API and should be used
+// in your Windows application via an official binary distribution.
+// Further information: https://github.com/microsoft/MIDI/
+// ============================================================================
+
 
 #define IDS_PROJNAME                    100
 #define IDR_MIDI2KSABSTRACTION          101

--- a/src/api/Abstraction/KSAbstraction/dllmain.h
+++ b/src/api/Abstraction/KSAbstraction/dllmain.h
@@ -1,4 +1,11 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License
+// ============================================================================
+// This is part of the Windows MIDI Services App API and should be used
+// in your Windows application via an official binary distribution.
+// Further information: https://github.com/microsoft/MIDI/
+// ============================================================================
+
 
 #pragma once
 

--- a/src/api/Abstraction/KSAbstraction/pch.h
+++ b/src/api/Abstraction/KSAbstraction/pch.h
@@ -1,4 +1,11 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License
+// ============================================================================
+// This is part of the Windows MIDI Services App API and should be used
+// in your Windows application via an official binary distribution.
+// Further information: https://github.com/microsoft/MIDI/
+// ============================================================================
+
 
 #pragma once
 
@@ -11,6 +18,7 @@
 #include <winrt/Windows.Foundation.h>
 #include <winrt/Windows.Foundation.Collections.h>
 #include <winrt/Windows.Devices.Enumeration.h>
+#include <winrt/Windows.Data.Json.h>
 #include <wrl\module.h>
 #include <wrl\event.h>
 #include <ks.h>
@@ -22,6 +30,9 @@
 #include <wil\tracelogging.h>
 
 #include <SDKDDKVer.h>
+
+namespace json = winrt::Windows::Data::Json;
+
 
 #define _ATL_APARTMENT_THREADED
 #define _ATL_NO_AUTOMATIC_NAMESPACE
@@ -46,6 +57,7 @@
 #include "strsafe.h"
 
 #include "abstraction_defs.h"
+#include "midi_config_json.h"
 
 #include "Midi2KSAbstraction_i.c"
 #include "Midi2KSAbstraction.h"

--- a/src/api/Inc/midi_config_json.h
+++ b/src/api/Inc/midi_config_json.h
@@ -1,0 +1,15 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License
+// ============================================================================
+// This is part of the Windows MIDI Services App API and should be used
+// in your Windows application via an official binary distribution.
+// Further information: https://github.com/microsoft/MIDI/
+// ============================================================================
+
+#pragma once
+
+#define MIDI_CONFIG_JSON_ENDPOINT_USER_SUPPLIED_NAME_PROPERTY_KEY               L"userSuppliedName"
+#define MIDI_CONFIG_JSON_ENDPOINT_USER_SUPPLIED_DESCRIPTION_PROPERTY_KEY        L"userSuppliedDescription"
+#define MIDI_CONFIG_JSON_ENDPOINT_FORCE_SINGLE_CLIENT_PROPERTY_KEY              L"forceSingleClientOnly"
+
+#define MIDI_CONFIG_JSON_ENDPOINT_IDENTIFIER_SWD                                L"SWD: "


### PR DESCRIPTION
Endpoint name and description can now be specified via the config file for any USB (KS) endpoint. Intent is to have the MIDI Settings app make the changes to this file, especially given that json isn't particularly forgiving.

So with this config file:

```json
{
    "header":
    {
        "_comment": "NOTE: All json keys are case-sensitive, including GUIDs.",
        "product" : "Windows MIDI Services",
        "fileVersion": 1.0
    },
    
    "endpointTransportPluginSettings":
    {
        "{26FA740D-469C-4D33-BEB1-3885DE7D6DF1}":
        {
            "_comment": "KS MIDI (USB etc.)",
            "SWD: \\\\?\\SWD#MIDISRV#MIDIU_KS_BIDI_6799286025327820155_OUTPIN.0_INPIN.2#{e7cce071-3c03-423f-88d3-f1045d02552b}":
            {
                "userSuppliedName" : "Pete's Kontrol S61",
                "userSuppliedDescription" : "This is my most favorite MIDI 2.0 controller in the whole world!"
            }
        },
        "{C95DCD1F-CDE3-4C2D-913C-528CB8A4CBE6}":
        {
            "_comment": "Network MIDI"
        },
        "{ABD5E0B9-C38C-48B7-AA56-19D9E26BAF1B}":
        {
            "_comment": "BLE MIDI 1.0"
        },
        "{B7C8E2D2-EE3B-4044-B9CF-6F29528AB46D}":
        {
            "_comment": "Virtual Patch Bay"
        },
        "{8FEAAD91-70E1-4A19-997A-377720A719C1}":
        {
            "_comment": "Virtual Device MIDI"
        }
    },
    "endpointProcessingPluginSettings":
    {

    }

}
```

Here are the properties. Note the user supplied name and description

![image](https://github.com/microsoft/MIDI/assets/1421146/3bd268c4-a0d0-4103-b665-6c252f22e03d)

The documentation (under get-started and user docs) describes the keys and the device lookup.

**Note that currently this does require a service restart to pick up the new data.**
