### PR TITLE
Fix app-to-app MIDI stability problem

### DIFF
--- a/build/staging/version/BundleInfo.wxi
+++ b/build/staging/version/BundleInfo.wxi
@@ -1,4 +1,4 @@
 <Include>
   <?define SetupVersionName="Developer Preview 5" ?>
-  <?define SetupVersionNumber="1.0.24039.2325" ?>
+  <?define SetupVersionNumber="1.0.24040.2018" ?>
 </Include>

--- a/diagnostics/trace-logging/trace.bat
+++ b/diagnostics/trace-logging/trace.bat
@@ -1,0 +1,12 @@
+@echo off
+echo Must be run from an administrator command prompt
+
+wpr -start MidiServices.wprp -filemode
+
+echo Now go recreate the issue. Hit enter when done.
+
+pause
+
+wpr -stop TraceCaptureFile.etl
+
+start TraceCaptureFile.etl

--- a/samples/csharp-net/app-to-app-midi-cs/MainWindow.xaml.cs
+++ b/samples/csharp-net/app-to-app-midi-cs/MainWindow.xaml.cs
@@ -38,19 +38,19 @@ namespace MidiSample.AppToAppMidi
             
             Notes = notes.Select(n=>new Note() { NoteNumber = n, Connection = _connection, GroupIndex = 0, ChannelIndex = 0 }).ToList();
 
-            //this.Closed += MainWindow_Closed;
+            this.Closed += MainWindow_Closed;
 
             //this.AppWindow.MoveAndResize(new Windows.Graphics.RectInt32(100, 100, 600, 600));
 
             this.SetWindowSize(500, 550);
             this.SetIsAlwaysOnTop(true);
 
-            this.Closed += MainWindow_Closed;
-
         }
 
         private void MainWindow_Closed(object sender, WindowEventArgs args)
         {
+            System.Diagnostics.Debug.WriteLine("MainWindow_Closed");
+
             if (_connection != null)
             {
                 _session.DisconnectEndpointConnection(_connection.ConnectionId);

--- a/samples/csharp-net/app-to-app-midi-cs/MidiSample.AppToAppMidi.csproj
+++ b/samples/csharp-net/app-to-app-midi-cs/MidiSample.AppToAppMidi.csproj
@@ -29,7 +29,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.5.231202003-experimental1" />
     <PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.26031-preview" />
-    <PackageReference Include="Windows.Devices.Midi2" Version="1.0.0-preview.3-0145" />
+    <PackageReference Include="Windows.Devices.Midi2" Version="1.0.0-preview.3-0150" />
     <PackageReference Include="WinUIEx" Version="2.3.3" />
     <Manifest Include="$(ApplicationManifest)" />
   </ItemGroup>

--- a/src/api/Abstraction/VirtualMidiAbstraction/Midi2.VirtualMidiBidi.h
+++ b/src/api/Abstraction/VirtualMidiAbstraction/Midi2.VirtualMidiBidi.h
@@ -23,26 +23,52 @@ public:
 
     HRESULT LinkAssociatedBiDi(_In_ wil::com_ptr_nothrow<CMidi2VirtualMidiBiDi> biDi)
     {
-        m_linkedBiDi = biDi;
+        m_linkedBiDiConnections.push_back(biDi);
 
-        RETURN_IF_FAILED(biDi->QueryInterface(__uuidof(IMidiCallback), (void**)&m_linkedBiDiCallback));
+        //m_linkedBiDi = biDi;
+
+        //RETURN_IF_FAILED(biDi->QueryInterface(__uuidof(IMidiCallback), (void**)&m_linkedBiDiCallback));
 
         return S_OK;
     }
 
-    HRESULT UnlinkAssociatedBiDi()
+    HRESULT UnlinkAllAssociatedBiDi()
     {
-        m_linkedBiDi = nullptr;
-        m_linkedBiDiCallback = nullptr;
+        m_linkedBiDiConnections.clear();
 
         return S_OK;
+    }
+
+    HRESULT UnlinkAssociatedBiDi(CMidi2VirtualMidiBiDi* biDiToUnlink)
+    {
+        auto it = std::find_if(m_linkedBiDiConnections.begin(), m_linkedBiDiConnections.end(),
+                    [&](const wil::com_ptr_nothrow<CMidi2VirtualMidiBiDi> bidi) { return bidi == biDiToUnlink; });
+
+        if (it != m_linkedBiDiConnections.end())
+        {
+            it->reset();
+            m_linkedBiDiConnections.erase(it);
+        }
+
+        //m_linkedBiDiCallback = nullptr;
+
+        return S_OK;
+    }
+
+    IMidiCallback* GetCallback()
+    {
+        return m_callback.get();
     }
 
 private:
-    wil::com_ptr_nothrow<IMidiBiDi> m_linkedBiDi;
+    //wil::com_ptr_nothrow<IMidiBiDi> m_linkedBiDi;
 
-    wil::com_ptr_nothrow<IMidiCallback> m_linkedBiDiCallback;
+    std::vector<wil::com_ptr_nothrow<CMidi2VirtualMidiBiDi>> m_linkedBiDiConnections{};
+
+
+    //wil::com_ptr_nothrow<IMidiCallback> m_linkedBiDiCallback;
     wil::com_ptr_nothrow <IMidiCallback> m_callback;
+
 
     LONGLONG m_callbackContext;
 

--- a/src/api/Abstraction/VirtualMidiAbstraction/Midi2.VirtualMidiConfigurationManager.cpp
+++ b/src/api/Abstraction/VirtualMidiAbstraction/Midi2.VirtualMidiConfigurationManager.cpp
@@ -16,8 +16,6 @@ CMidi2VirtualMidiConfigurationManager::Initialize(
     IUnknown* MidiDeviceManager
 )
 {
-    OutputDebugString(L"" __FUNCTION__ " Enter");
-
     TraceLoggingWrite(
         MidiVirtualMidiAbstractionTelemetryProvider::Provider(),
         __FUNCTION__,
@@ -45,7 +43,7 @@ CMidi2VirtualMidiConfigurationManager::UpdateConfiguration(
         __FUNCTION__,
         TraceLoggingLevel(WINEVENT_LEVEL_INFO),
         TraceLoggingPointer(this, "this"),
-        TraceLoggingWideString(ConfigurationJsonSection)
+        TraceLoggingWideString(ConfigurationJsonSection, "json")
     );
 
 
@@ -64,8 +62,8 @@ CMidi2VirtualMidiConfigurationManager::UpdateConfiguration(
             __FUNCTION__,
             TraceLoggingLevel(WINEVENT_LEVEL_ERROR),
             TraceLoggingPointer(this, "this"),
-            TraceLoggingWideString(L"Failed to parse Configuration JSON"),
-            TraceLoggingWideString(ConfigurationJsonSection)
+            TraceLoggingWideString(L"Failed to parse Configuration JSON", "message"),
+            TraceLoggingWideString(ConfigurationJsonSection, "json")
         );
 
         return E_FAIL;
@@ -159,8 +157,6 @@ CMidi2VirtualMidiConfigurationManager::UpdateConfiguration(
 HRESULT
 CMidi2VirtualMidiConfigurationManager::Cleanup()
 {
-    OutputDebugString(L"" __FUNCTION__ " Enter");
-
     TraceLoggingWrite(
         MidiVirtualMidiAbstractionTelemetryProvider::Provider(),
         __FUNCTION__,

--- a/src/api/Abstraction/VirtualMidiAbstraction/Midi2.VirtualMidiEndpointManager.h
+++ b/src/api/Abstraction/VirtualMidiAbstraction/Midi2.VirtualMidiEndpointManager.h
@@ -37,6 +37,9 @@ public:
 
     HRESULT DeleteClientEndpoint(_In_ std::wstring clientShortInstanceId);
 
+    HRESULT DeleteDeviceEndpoint(_In_ std::wstring deviceShortInstanceId);
+
+
     //HRESULT DeleteEndpointPair(
     //    _In_ GUID const VirtualEndpointAssociationGuid
     //);

--- a/src/api/Abstraction/VirtualMidiAbstraction/MidiEndpointTable.h
+++ b/src/api/Abstraction/VirtualMidiAbstraction/MidiEndpointTable.h
@@ -58,19 +58,26 @@ struct MidiVirtualDeviceEndpointEntry
     std::wstring ShortUniqueId{ L"" };
 
     std::wstring CreatedDeviceEndpointId{ L"" };              // the device interface id
+    std::wstring CreatedShortDeviceInstanceId{ L"" };
+
     std::wstring CreatedClientEndpointId{ L"" };
     std::wstring CreatedShortClientInstanceId{ L"" };
 
 
     wil::com_ptr_nothrow<CMidi2VirtualMidiBiDi> MidiDeviceBiDi{ nullptr };
-    wil::com_ptr_nothrow<CMidi2VirtualMidiBiDi> MidiClientBiDi{ nullptr };
+
+
+ //   std::vector<wil::com_ptr_nothrow<CMidi2VirtualMidiBiDi>> MidiClientConnections{ };
 
     ~MidiVirtualDeviceEndpointEntry()
     {
+        //MidiClientConnections.clear();
+
         if (MidiDeviceBiDi)
         {
             MidiDeviceBiDi.reset();
         }
+
     }
 };
 
@@ -78,28 +85,20 @@ struct MidiVirtualDeviceEndpointEntry
 class MidiEndpointTable
 {
 public:
-
-    //void Initialize(_In_ CMidi2VirtualMidiEndpointManager *endpointManager)
-    //{
-    //    m_endpointManager = endpointManager;
-    //}
-
-
     HRESULT AddCreatedEndpointDevice(_In_ MidiVirtualDeviceEndpointEntry& entry) noexcept;
  
     HRESULT OnDeviceConnected(_In_ std::wstring deviceEndpointInterfaceId, _In_ CMidi2VirtualMidiBiDi* deviceBiDi) noexcept;
     HRESULT OnClientConnected(_In_ std::wstring clientEndpointInterfaceId, _In_ CMidi2VirtualMidiBiDi* clientBiDi) noexcept;
+
     HRESULT OnDeviceDisconnected(_In_ std::wstring deviceEndpointInterfaceId) noexcept;
+    HRESULT OnClientDisconnected(_In_ std::wstring clientEndpointInterfaceId, _In_ CMidi2VirtualMidiBiDi* clientBiDi) noexcept;
 
     HRESULT Cleanup();
 
 private:
-    void RemoveEndpointPair(_In_ GUID VirtualEndpointAssociationId) noexcept;
+    //void RemoveEndpointPair(_In_ GUID VirtualEndpointAssociationId) noexcept;
 
-    // key is EndpointDeviceId (the device interface id)
+    // key is the association id
     std::map<std::wstring, MidiVirtualDeviceEndpointEntry> m_endpoints;
-
-    // maybe this should be a weak_ptr, but those are a pain to work with
-//    wil::com_ptr_nothrow<CMidi2VirtualMidiEndpointManager> m_endpointManager;
 
 };

--- a/src/api/Client/Midi2Client/MidiChannelEndpointListener.cpp
+++ b/src/api/Client/Midi2Client/MidiChannelEndpointListener.cpp
@@ -16,16 +16,22 @@ namespace winrt::Windows::Devices::Midi2::implementation
     _Use_decl_annotations_
     void MidiChannelEndpointListener::Initialize(midi2::IMidiEndpointConnectionSource const& endpointConnection)
     {
+        internal::LogInfo(__FUNCTION__, L"Enter");
+
         m_endpointConnection = endpointConnection.as<midi2::MidiEndpointConnection>();
     }
 
     void MidiChannelEndpointListener::OnEndpointConnectionOpened()
     {
+        internal::LogInfo(__FUNCTION__, L"Enter");
+
         // Nothing special to do when connection is opened, so all good
     }
 
     void MidiChannelEndpointListener::Cleanup()
     {
+        internal::LogInfo(__FUNCTION__, L"Enter");
+
  //       m_endpointConnection = nullptr;
     }
 
@@ -35,6 +41,8 @@ namespace winrt::Windows::Devices::Midi2::implementation
         bool& skipFurtherListeners, 
         bool& skipMainMessageReceivedEvent)
     {
+        internal::LogInfo(__FUNCTION__, L"Enter");
+
         skipFurtherListeners = m_preventCallingFurtherListeners;
         skipMainMessageReceivedEvent = m_preventFiringMainMessageReceivedEvent;
 

--- a/src/api/Client/Midi2Client/MidiGroupEndpointListener.cpp
+++ b/src/api/Client/Midi2Client/MidiGroupEndpointListener.cpp
@@ -17,16 +17,21 @@ namespace winrt::Windows::Devices::Midi2::implementation
     _Use_decl_annotations_
     void MidiGroupEndpointListener::Initialize(midi2::IMidiEndpointConnectionSource const& endpointConnection)
     {        
+        internal::LogInfo(__FUNCTION__, L"Enter");
+
         m_endpointConnection = endpointConnection.as<midi2::MidiEndpointConnection>();
     }
 
     void MidiGroupEndpointListener::OnEndpointConnectionOpened()
     {        
+        internal::LogInfo(__FUNCTION__, L"Enter");
     }
 
     void MidiGroupEndpointListener::Cleanup()
     {        
- //       m_endpointConnection = nullptr;
+        internal::LogInfo(__FUNCTION__, L"Enter");
+        
+//       m_endpointConnection = nullptr;
     }
 
     _Use_decl_annotations_
@@ -35,6 +40,8 @@ namespace winrt::Windows::Devices::Midi2::implementation
         bool& skipFurtherListeners, 
         bool& skipMainMessageReceivedEvent)
     {
+        internal::LogInfo(__FUNCTION__, L"Enter");
+
         skipFurtherListeners = m_preventCallingFurtherListeners;
         skipMainMessageReceivedEvent = m_preventFiringMainMessageReceivedEvent;
 

--- a/src/api/Client/Midi2Client/MidiMessageTypeEndpointListener.cpp
+++ b/src/api/Client/Midi2Client/MidiMessageTypeEndpointListener.cpp
@@ -16,16 +16,20 @@ namespace winrt::Windows::Devices::Midi2::implementation
     _Use_decl_annotations_
     void MidiMessageTypeEndpointListener::Initialize(midi2::IMidiEndpointConnectionSource const& endpointConnection)
     {       
+        internal::LogInfo(__FUNCTION__, L"Enter");
+
         m_endpointConnection = endpointConnection.as<midi2::MidiEndpointConnection>();
     }
 
     void MidiMessageTypeEndpointListener::OnEndpointConnectionOpened()
     {
+        internal::LogInfo(__FUNCTION__, L"Enter");
     }
 
     void MidiMessageTypeEndpointListener::Cleanup()
     {
- //       m_endpointConnection = nullptr;
+        internal::LogInfo(__FUNCTION__, L"Enter");
+        //       m_endpointConnection = nullptr;
     }
 
     _Use_decl_annotations_
@@ -34,6 +38,8 @@ namespace winrt::Windows::Devices::Midi2::implementation
         bool& skipFurtherListeners, 
         bool& skipMainMessageReceivedEvent)
     {
+        internal::LogInfo(__FUNCTION__, L"Enter");
+
         skipFurtherListeners = m_preventCallingFurtherListeners;
         skipMainMessageReceivedEvent = m_preventFiringMainMessageReceivedEvent;
 

--- a/src/api/Client/Midi2Client/MidiSession.cpp
+++ b/src/api/Client/Midi2Client/MidiSession.cpp
@@ -26,7 +26,7 @@ namespace winrt::Windows::Devices::Midi2::implementation
         midi2::MidiSessionSettings const& settings
         ) noexcept
     {
-        internal::LogInfo(__FUNCTION__, L"Session create ");
+        internal::LogInfo(__FUNCTION__, L"Session create");
 
         try
         {
@@ -478,7 +478,10 @@ namespace winrt::Windows::Devices::Midi2::implementation
                 for (auto connection : m_connections)
                 {
                     // close the one connection
-                    connection.Value().as<foundation::IClosable>().Close();
+                    //connection.Value().as<foundation::IClosable>().Close();
+
+                    auto c = winrt::get_self<implementation::MidiEndpointConnection>(connection.Value());
+                    c->InternalClose();
                 }
 
                 m_serviceAbstraction = nullptr;

--- a/src/api/Client/Midi2Client/MidiVirtualEndpointDevice.cpp
+++ b/src/api/Client/Midi2Client/MidiVirtualEndpointDevice.cpp
@@ -19,6 +19,8 @@ namespace winrt::Windows::Devices::Midi2::implementation
     _Use_decl_annotations_
     void MidiVirtualEndpointDevice::UpdateFunctionBlock(midi2::MidiFunctionBlock const& block) noexcept
     {
+        internal::LogInfo(__FUNCTION__, L"Enter");
+
         UNREFERENCED_PARAMETER(block);
 
         // TODO
@@ -27,6 +29,8 @@ namespace winrt::Windows::Devices::Midi2::implementation
     _Use_decl_annotations_
     void MidiVirtualEndpointDevice::UpdateEndpointName(winrt::hstring const& name) noexcept
     {
+        internal::LogInfo(__FUNCTION__, L"Enter");
+
         UNREFERENCED_PARAMETER(name);
 
         // TODO
@@ -36,22 +40,30 @@ namespace winrt::Windows::Devices::Midi2::implementation
     _Use_decl_annotations_
     void MidiVirtualEndpointDevice::Initialize(midi2::IMidiEndpointConnectionSource const& endpointConnection) noexcept
     {
+        internal::LogInfo(__FUNCTION__, L"Enter");
+
         m_endpointConnection = endpointConnection.as<midi2::MidiEndpointConnection>();
     }
 
     void MidiVirtualEndpointDevice::OnEndpointConnectionOpened() noexcept
     {
+        internal::LogInfo(__FUNCTION__, L"Enter");
+
         // nothing to do here
     }
 
     void MidiVirtualEndpointDevice::Cleanup() noexcept
     {
+        internal::LogInfo(__FUNCTION__, L"Enter");
+
         // nothing to do here
     }
 
     _Use_decl_annotations_
     void MidiVirtualEndpointDevice::SendFunctionBlockInfoNotificationMessage(midi2::MidiFunctionBlock const& fb) noexcept
     {
+        internal::LogInfo(__FUNCTION__, L"Enter");
+
         auto functionBlockNotification = midi2::MidiStreamMessageBuilder::BuildFunctionBlockInfoNotificationMessage(
             0,
             true,
@@ -66,12 +78,17 @@ namespace winrt::Windows::Devices::Midi2::implementation
         );
 
         // TODO: Log if failed
-        m_endpointConnection.SendMessagePacket(functionBlockNotification);
+        if (midi2::MidiEndpointConnection::SendMessageFailed(m_endpointConnection.SendMessagePacket(functionBlockNotification)))
+        {
+            internal::LogGeneralError(__FUNCTION__, L"SendMessagePacket failed");
+        }
     }
 
     _Use_decl_annotations_
     void MidiVirtualEndpointDevice::SendFunctionBlockNameNotificationMessages(midi2::MidiFunctionBlock const& fb) noexcept
     {
+        internal::LogInfo(__FUNCTION__, L"Enter");
+
         if (fb.Name() == L"") return;
 
         auto nameMessages = midi2::MidiStreamMessageBuilder::BuildFunctionBlockNameNotificationMessages(
@@ -82,8 +99,10 @@ namespace winrt::Windows::Devices::Midi2::implementation
 
         for (uint32_t i = 0; i < nameMessages.Size(); i++)
         {
-            // TODO: Log if failed
-            m_endpointConnection.SendMessagePacket(nameMessages.GetAt(i));
+            if (midi2::MidiEndpointConnection::SendMessageFailed(m_endpointConnection.SendMessagePacket(nameMessages.GetAt(i))))
+            {
+                internal::LogGeneralError(__FUNCTION__, L"SendMessagePacket failed");
+            }
         }
 
     }
@@ -94,6 +113,8 @@ namespace winrt::Windows::Devices::Midi2::implementation
         bool& skipFurtherListeners,
         bool& skipMainMessageReceivedEvent)  noexcept
     {
+        internal::LogInfo(__FUNCTION__, L"Enter");
+
         bool handled = false;
 
         if (args.MessageType() == MidiMessageType::Stream128)
@@ -199,6 +220,7 @@ namespace winrt::Windows::Devices::Midi2::implementation
             else
             {
                 // something went wrong filling this message type
+                internal::LogGeneralError(__FUNCTION__, L"Error filling message type");
             }
             
 
@@ -231,6 +253,8 @@ namespace winrt::Windows::Devices::Midi2::implementation
     void MidiVirtualEndpointDevice::InternalSetDeviceDefinition(
         _In_ midi2::MidiVirtualEndpointDeviceDefinition definition)
     {
+        internal::LogInfo(__FUNCTION__, L"Enter");
+
         try
         {
             // populate all the views, properties, blocks, etc.
@@ -245,7 +269,7 @@ namespace winrt::Windows::Devices::Midi2::implementation
                 fb.Number(i);
 
                 // TODO: Set the fb as read-only
-
+                
 
                  
                 // add the block
@@ -266,6 +290,8 @@ namespace winrt::Windows::Devices::Midi2::implementation
         catch (...)
         {
             // todo log
+            internal::LogGeneralError(__FUNCTION__, L"Exception attempting to set device definition");
+
         }
 
     }

--- a/src/api/Service/Exe/MidiClientPipe.cpp
+++ b/src/api/Service/Exe/MidiClientPipe.cpp
@@ -34,7 +34,9 @@ CMidiClientPipe::Initialize(
         MidiSrvTelemetryProvider::Provider(),
         __FUNCTION__,
         TraceLoggingLevel(WINEVENT_LEVEL_INFO),
-        TraceLoggingPointer(this, "this")
+        TraceLoggingPointer(this, "this"),
+        TraceLoggingWideString(Device),
+        TraceLoggingGuid(SessionId)
     );
 
     // for tracking the client connection

--- a/src/api/Service/Exe/MidiConfigurationManager.cpp
+++ b/src/api/Service/Exe/MidiConfigurationManager.cpp
@@ -355,8 +355,7 @@ std::map<GUID, std::wstring, GUIDCompare> CMidiConfigurationManager::GetTranspor
         MidiSrvTelemetryProvider::Provider(),
         __FUNCTION__,
         TraceLoggingLevel(WINEVENT_LEVEL_INFO),
-        TraceLoggingPointer(this, "this"), 
-        TraceLoggingWideString(L"Enter")
+        TraceLoggingPointer(this, "this")
     );
 
 
@@ -492,10 +491,8 @@ HRESULT CMidiConfigurationManager::Initialize()
         MidiSrvTelemetryProvider::Provider(),
         __FUNCTION__,
         TraceLoggingLevel(WINEVENT_LEVEL_INFO),
-        TraceLoggingPointer(this, "this"),
-        TraceLoggingWideString(L"Enter")
+        TraceLoggingPointer(this, "this")
     );
-
 
     // load the current configuration
 
@@ -517,59 +514,70 @@ HRESULT CMidiConfigurationManager::Initialize()
 
         try
         {
-            //OutputDebugString(L"Opening json config file");
-
             // try to open the file
             auto file = winrt::Windows::Storage::StorageFile::GetFileFromPathAsync(fileName).get();
 
             // try to read the text from the file
             fileContents = winrt::Windows::Storage::FileIO::ReadTextAsync(file).get();
-
         }
         catch (...)
         {
-            OutputDebugString(L"Exception opening json config file\n");
-
             // file does not exist or we can't open it
             // we don't fail if no configuration file, we just don't config anything
 
-            // TODO: Need to log this
+            TraceLoggingWrite(
+                MidiSrvTelemetryProvider::Provider(),
+                __FUNCTION__,
+                TraceLoggingLevel(WINEVENT_LEVEL_WARNING),
+                TraceLoggingPointer(this, "this"),
+                TraceLoggingWideString(L"Missing or inaccessible MIDI configuration file")
+            );
 
             return S_OK;
         }
         
         if (!fileContents.empty())
         {
-            //OutputDebugString(L"Config file contents are NOT empty");
-
             // parse out the JSON.
             // If the JSON is bad, we still just run. We just don't config.
             // Config is a privilege, not a right, and is certainly not essential :)
 
             try
             {
-                if (json::JsonObject::TryParse(fileContents, m_jsonObject))
+                if (!json::JsonObject::TryParse(fileContents, m_jsonObject))
                 {
-                    // worked
-                    OutputDebugString(L"Parsing json worked\n");
-                }
-                else
-                {
-                    OutputDebugString(L"Parsing json failed\n");
+                    TraceLoggingWrite(
+                        MidiSrvTelemetryProvider::Provider(),
+                        __FUNCTION__,
+                        TraceLoggingLevel(WINEVENT_LEVEL_ERROR),
+                        TraceLoggingPointer(this, "this"),
+                        TraceLoggingWideString(L"Configuration file JSON parsing failed")
+                    );
                 }
             }
             CATCH_LOG()
         }
         else
         {
-            OutputDebugString(L"Config file contents are empty\n");
+            TraceLoggingWrite(
+                MidiSrvTelemetryProvider::Provider(),
+                __FUNCTION__,
+                TraceLoggingLevel(WINEVENT_LEVEL_WARNING),
+                TraceLoggingPointer(this, "this"),
+                TraceLoggingWideString(L"Configuration file JSON is empty")
+            );
         }
 
     }
     else
     {
-        // config file is missing
-        OutputDebugString(L"Config file is missing, but that's ok.\n");
+        TraceLoggingWrite(
+            MidiSrvTelemetryProvider::Provider(),
+            __FUNCTION__,
+            TraceLoggingLevel(WINEVENT_LEVEL_WARNING),
+            TraceLoggingPointer(this, "this"),
+            TraceLoggingWideString(L"Missing MIDI configuration file")
+        );
 
         return S_OK;
     }
@@ -586,10 +594,8 @@ std::wstring CMidiConfigurationManager::GetSavedConfigurationForTransportAbstrac
         __FUNCTION__,
         TraceLoggingLevel(WINEVENT_LEVEL_INFO),
         TraceLoggingPointer(this, "this"),
-        TraceLoggingWideString(L"Enter")
+        TraceLoggingGuid(abstractionGuid)
     );
-
-
 
 
     try
@@ -634,19 +640,13 @@ std::wstring CMidiConfigurationManager::GetSavedConfigurationForEndpointProcessi
         __FUNCTION__,
         TraceLoggingLevel(WINEVENT_LEVEL_INFO),
         TraceLoggingPointer(this, "this"),
-        TraceLoggingWideString(L"Enter")
+        TraceLoggingGuid(abstractionGuid)
     );
-
-
 
     
     try
     {
-        //   OutputDebugString(L"" __FUNCTION__);
-
         auto key = internal::GuidToString(abstractionGuid);
-
-        //    OutputDebugString(key.c_str());
 
         if (m_jsonObject != nullptr)
         {
@@ -660,8 +660,6 @@ std::wstring CMidiConfigurationManager::GetSavedConfigurationForEndpointProcessi
                     auto thisPlugin = plugins.GetNamedObject(key);
 
                     std::wstring jsonString = (std::wstring)thisPlugin.Stringify();
-
-                    OutputDebugString(jsonString.c_str());
 
                     return jsonString;
                 }
@@ -681,11 +679,8 @@ HRESULT CMidiConfigurationManager::Cleanup() noexcept
         MidiSrvTelemetryProvider::Provider(),
         __FUNCTION__,
         TraceLoggingLevel(WINEVENT_LEVEL_INFO),
-        TraceLoggingPointer(this, "this"),
-        TraceLoggingWideString(L"Enter")
+        TraceLoggingPointer(this, "this")
     );
-
-
 
 
 

--- a/src/api/Service/Exe/MidiPerformanceManager.cpp
+++ b/src/api/Service/Exe/MidiPerformanceManager.cpp
@@ -11,12 +11,26 @@
 HRESULT
 CMidiPerformanceManager::Initialize()
 {
+    TraceLoggingWrite(
+        MidiSrvTelemetryProvider::Provider(),
+        __FUNCTION__,
+        TraceLoggingLevel(WINEVENT_LEVEL_INFO),
+        TraceLoggingPointer(this, "this")
+    );
+
     return S_OK;
 }
 
 HRESULT
 CMidiPerformanceManager::Cleanup()
 {
+    TraceLoggingWrite(
+        MidiSrvTelemetryProvider::Provider(),
+        __FUNCTION__,
+        TraceLoggingLevel(WINEVENT_LEVEL_INFO),
+        TraceLoggingPointer(this, "this")
+    );
+
     return S_OK;
 }
 

--- a/src/api/Service/Exe/MidiSessionTracker.cpp
+++ b/src/api/Service/Exe/MidiSessionTracker.cpp
@@ -229,6 +229,12 @@ CMidiSessionTracker::GetSessionListJson(
 HRESULT
 CMidiSessionTracker::Cleanup()
 {
+    TraceLoggingWrite(
+        MidiSrvTelemetryProvider::Provider(),
+        __FUNCTION__,
+        TraceLoggingLevel(WINEVENT_LEVEL_INFO),
+        TraceLoggingPointer(this, "this")
+    );
 
 
 

--- a/src/api/Service/Exe/MidiTransformPipe.cpp
+++ b/src/api/Service/Exe/MidiTransformPipe.cpp
@@ -22,7 +22,8 @@ CMidiTransformPipe::Initialize(
         MidiSrvTelemetryProvider::Provider(),
         __FUNCTION__,
         TraceLoggingLevel(WINEVENT_LEVEL_INFO),
-        TraceLoggingPointer(this, "this")
+        TraceLoggingPointer(this, "this"),
+        TraceLoggingWideString(Device)
     );
 
 
@@ -60,9 +61,6 @@ CMidiTransformPipe::Cleanup()
         TraceLoggingLevel(WINEVENT_LEVEL_INFO),
         TraceLoggingPointer(this, "this")
     );
-
-
-    OutputDebugString(L"" __FUNCTION__);
 
     if (m_MidiDataTransform)
     {

--- a/src/user-tools/midi-console/Midi/Commands/Endpoint/EndpointPropertiesCommand.cs
+++ b/src/user-tools/midi-console/Midi/Commands/Endpoint/EndpointPropertiesCommand.cs
@@ -58,9 +58,22 @@ namespace Microsoft.Devices.Midi2.ConsoleApp
 
                 AnsiMarkupFormatter.SetTableBorderStyle(table);
 
+                TableColumn column1 = new TableColumn(AnsiMarkupFormatter.FormatTableColumnHeading(Resources.Strings.PropertiesTableColumnHeaderProperty));
+                column1.Width(45);
 
-                table.AddColumn(AnsiMarkupFormatter.FormatTableColumnHeading(Resources.Strings.PropertiesTableColumnHeaderProperty));
-                table.AddColumn(AnsiMarkupFormatter.FormatTableColumnHeading(Resources.Strings.PropertiesTableColumnHeaderValue));
+                table.AddColumn(column1);
+
+
+                TableColumn column2 = new TableColumn(AnsiMarkupFormatter.FormatTableColumnHeading(Resources.Strings.PropertiesTableColumnHeaderValue));
+
+                //Console.WriteLine("Window width " + Console.WindowWidth);
+
+                if (Console.WindowWidth > 140)
+                {
+                    column2.NoWrap = true;
+                }
+
+                table.AddColumn(column2);
 
 
                 MidiEndpointDeviceInformation di = MidiEndpointDeviceInformation.CreateFromId(endpointId);
@@ -69,8 +82,34 @@ namespace Microsoft.Devices.Midi2.ConsoleApp
                 table.AddRow(Resources.Strings.PropertiesTablePropertyLabelName, AnsiMarkupFormatter.FormatEndpointName(di.Name));
                 table.AddRow(Resources.Strings.PropertiesTablePropertyLabelId, AnsiMarkupFormatter.FormatFullEndpointInterfaceId(di.Id));
                 table.AddRow(Resources.Strings.PropertiesTablePropertyLabelPurpose, di.EndpointPurpose.ToString());
+
                 table.AddRow(Resources.Strings.PropertiesTablePropertyLabelSerialNumber, AnsiMarkupFormatter.EscapeString(di.TransportSuppliedSerialNumber));
                 table.AddRow(Resources.Strings.PropertiesTablePropertyLabelManufacturer, AnsiMarkupFormatter.EscapeString(di.ManufacturerName));
+                
+                if (di.TransportSuppliedDescription != string.Empty)
+                {
+                    table.AddRow(Resources.Strings.PropertiesTablePropertyLabelTransportSuppliedDescription, AnsiMarkupFormatter.EscapeString(di.TransportSuppliedDescription));
+                }
+
+                table.AddRow(Resources.Strings.PropertiesTablePropertyLabelMultiClient, di.SupportsMultiClient.ToString());
+
+
+                if (di.NativeDataFormat == MidiEndpointNativeDataFormat.UniversalMidiPacket)
+                {
+                    table.AddRow(Resources.Strings.PropertiesTablePropertyLabelNativeDataFormat, "Universal MIDI Packet (MIDI 2.0/UMP)");
+                }
+                else if (di.NativeDataFormat == MidiEndpointNativeDataFormat.ByteStream)
+                {
+                    table.AddRow(Resources.Strings.PropertiesTablePropertyLabelNativeDataFormat, "Byte Stream (MIDI 1.0)");
+                }
+                else
+                {
+                    table.AddRow(Resources.Strings.PropertiesTablePropertyLabelNativeDataFormat, "Unknown Data Format");
+                }
+
+
+
+
 
                 if (settings.Verbose)
                 {
@@ -79,30 +118,34 @@ namespace Microsoft.Devices.Midi2.ConsoleApp
                     table.AddRow(Resources.Strings.PropertiesTablePropertyLabelDeviceInstanceId, AnsiMarkupFormatter.FormatDeviceInstanceId(di.DeviceInstanceId));
                 }
 
-                if (settings.Verbose)
+
+                if (di.NativeDataFormat == MidiEndpointNativeDataFormat.UniversalMidiPacket)
                 {
-                    table.AddEmptyRow();
-                    table.AddRow(AnsiMarkupFormatter.FormatTableColumnHeading(Resources.Strings.PropertiesTableSectionHeaderEndpointMetadata), "");
-                    table.AddRow(Resources.Strings.PropertiesTablePropertyLabelProductInstanceId, AnsiMarkupFormatter.EscapeString(di.ProductInstanceId));
-                    table.AddRow(Resources.Strings.PropertiesTablePropertyLabelEndpointSuppliedName, AnsiMarkupFormatter.FormatEndpointName(di.EndpointSuppliedName));
-                    table.AddRow(Resources.Strings.PropertiesTablePropertyLabelSystemExclusiveId, 
-                        di.DeviceIdentitySystemExclusiveId[0].ToString("X2") + " " +
-                        di.DeviceIdentitySystemExclusiveId[1].ToString("X2") + " " +
-                        di.DeviceIdentitySystemExclusiveId[2].ToString("X2"));
+                    if (settings.Verbose)
+                    {
+                        table.AddEmptyRow();
+                        table.AddRow(AnsiMarkupFormatter.FormatTableColumnHeading(Resources.Strings.PropertiesTableSectionHeaderEndpointMetadata), "");
+                        table.AddRow(Resources.Strings.PropertiesTablePropertyLabelProductInstanceId, AnsiMarkupFormatter.EscapeString(di.ProductInstanceId));
+                        table.AddRow(Resources.Strings.PropertiesTablePropertyLabelEndpointSuppliedName, AnsiMarkupFormatter.FormatEndpointName(di.EndpointSuppliedName));
+                        table.AddRow(Resources.Strings.PropertiesTablePropertyLabelSystemExclusiveId,
+                            di.DeviceIdentitySystemExclusiveId[0].ToString("X2") + " " +
+                            di.DeviceIdentitySystemExclusiveId[1].ToString("X2") + " " +
+                            di.DeviceIdentitySystemExclusiveId[2].ToString("X2"));
 
-                    table.AddRow(Resources.Strings.PropertiesTablePropertyLabelDeviceFamily,
-                        di.DeviceIdentityDeviceFamilyMsb.ToString("X2") + " " +
-                        di.DeviceIdentityDeviceFamilyLsb.ToString("X2"));
+                        table.AddRow(Resources.Strings.PropertiesTablePropertyLabelDeviceFamily,
+                            di.DeviceIdentityDeviceFamilyMsb.ToString("X2") + " " +
+                            di.DeviceIdentityDeviceFamilyLsb.ToString("X2"));
 
-                    table.AddRow(Resources.Strings.PropertiesTablePropertyLabelDeviceFamilyModelNumber,
-                        di.DeviceIdentityDeviceFamilyModelNumberMsb.ToString("X2") + " " +
-                        di.DeviceIdentityDeviceFamilyModelNumberLsb.ToString("X2"));
+                        table.AddRow(Resources.Strings.PropertiesTablePropertyLabelDeviceFamilyModelNumber,
+                            di.DeviceIdentityDeviceFamilyModelNumberMsb.ToString("X2") + " " +
+                            di.DeviceIdentityDeviceFamilyModelNumberLsb.ToString("X2"));
 
-                    table.AddRow(Resources.Strings.PropertiesTablePropertyLabelSoftwareRevisionLevel,
-                        di.DeviceIdentitySoftwareRevisionLevel[0].ToString("X2") + " " +
-                        di.DeviceIdentitySoftwareRevisionLevel[1].ToString("X2") + " " +
-                        di.DeviceIdentitySoftwareRevisionLevel[2].ToString("X2") + " " +
-                        di.DeviceIdentitySoftwareRevisionLevel[3].ToString("X2"));
+                        table.AddRow(Resources.Strings.PropertiesTablePropertyLabelSoftwareRevisionLevel,
+                            di.DeviceIdentitySoftwareRevisionLevel[0].ToString("X2") + " " +
+                            di.DeviceIdentitySoftwareRevisionLevel[1].ToString("X2") + " " +
+                            di.DeviceIdentitySoftwareRevisionLevel[2].ToString("X2") + " " +
+                            di.DeviceIdentitySoftwareRevisionLevel[3].ToString("X2"));
+                    }
                 }
 
                 table.AddEmptyRow();
@@ -116,24 +159,25 @@ namespace Microsoft.Devices.Midi2.ConsoleApp
 
                 // TODO: Continue with localization
 
-
-                table.AddEmptyRow();
-                table.AddRow(AnsiMarkupFormatter.FormatTableColumnHeading("Active Configuration"), "");
-                table.AddRow("Protocol", di.ConfiguredProtocol.ToString());
-                table.AddRow("Sends JR Timestamps", di.ConfiguredToSendJRTimestamps.ToString());
-                table.AddRow("Receives JR Timestamps", di.ConfiguredToReceiveJRTimestamps.ToString());
-
-                table.AddEmptyRow();
-                table.AddRow(AnsiMarkupFormatter.FormatTableColumnHeading("Declared Capabilities"), "");
-                table.AddRow("Multi-client", di.SupportsMultiClient.ToString());
-                table.AddRow("MIDI 1.0 Protocol", di.SupportsMidi10Protocol.ToString());
-                table.AddRow("MIDI 2.0 Protocol", di.SupportsMidi20Protocol.ToString());
-
-                if (settings.Verbose)
+                if (di.NativeDataFormat == MidiEndpointNativeDataFormat.UniversalMidiPacket)
                 {
-                    table.AddRow("UMP Version", di.SpecificationVersionMajor + "." + di.SpecificationVersionMinor);
-                    table.AddRow("Sending JR Time", di.SupportsSendingJRTimestamps.ToString());
-                    table.AddRow("Receiving JR Time", di.SupportsReceivingJRTimestamps.ToString());
+                    table.AddEmptyRow();
+                    table.AddRow(AnsiMarkupFormatter.FormatTableColumnHeading("Active Configuration"), "");
+                    table.AddRow("Protocol", di.ConfiguredProtocol.ToString());
+                    table.AddRow("Sends JR Timestamps", di.ConfiguredToSendJRTimestamps.ToString());
+                    table.AddRow("Receives JR Timestamps", di.ConfiguredToReceiveJRTimestamps.ToString());
+
+                    table.AddEmptyRow();
+                    table.AddRow(AnsiMarkupFormatter.FormatTableColumnHeading("Declared Capabilities"), "");
+                    table.AddRow("MIDI 1.0 Protocol", di.SupportsMidi10Protocol.ToString());
+                    table.AddRow("MIDI 2.0 Protocol", di.SupportsMidi20Protocol.ToString());
+
+                    if (settings.Verbose)
+                    {
+                        table.AddRow("UMP Version", di.SpecificationVersionMajor + "." + di.SpecificationVersionMinor);
+                        table.AddRow("Sending JR Time", di.SupportsSendingJRTimestamps.ToString());
+                        table.AddRow("Receiving JR Time", di.SupportsReceivingJRTimestamps.ToString());
+                    }
                 }
 
                 if (settings.Verbose)
@@ -143,104 +187,107 @@ namespace Microsoft.Devices.Midi2.ConsoleApp
                     table.AddRow("Transport-supplied Name", AnsiMarkupFormatter.FormatEndpointName(di.TransportSuppliedName));
                     table.AddRow("Transport Id", AnsiMarkupFormatter.EscapeString(di.TransportId));
                     table.AddRow("Transport Mnemonic", AnsiMarkupFormatter.EscapeString(di.TransportMnemonic));
-                    table.AddRow("Native Data Format", di.NativeDataFormat.ToString());
                 }
 
                 table.AddEmptyRow();
-                table.AddEmptyRow();
-                table.AddRow(AnsiMarkupFormatter.FormatTableColumnHeading("Function Blocks"), "");
-                table.AddRow("Static Function Blocks?", di.HasStaticFunctionBlocks.ToString());
-                table.AddRow("Declared Function Block Count", di.FunctionBlockCount.ToString());
-                table.AddEmptyRow();
 
-                if (di.FunctionBlocks.Count > 0)
+                if (di.NativeDataFormat == MidiEndpointNativeDataFormat.UniversalMidiPacket)
                 {
-                    foreach (var functionBlock in di.FunctionBlocks.Values)
+                    table.AddEmptyRow();
+                    table.AddRow(AnsiMarkupFormatter.FormatTableColumnHeading("Function Blocks"), "");
+                    table.AddRow("Static Function Blocks?", di.HasStaticFunctionBlocks.ToString());
+                    table.AddRow("Declared Function Block Count", di.FunctionBlockCount.ToString());
+                    table.AddEmptyRow();
+
+                    if (di.FunctionBlocks.Count > 0)
                     {
-                        if (!settings.Verbose)
+                        foreach (var functionBlock in di.FunctionBlocks.Values)
                         {
-                            string functionInformation = string.Empty;
-                            ;
-
-                            if (functionBlock.GroupCount == 1)
+                            if (!settings.Verbose)
                             {
-                                functionInformation +=
-                                    $"[grey]Group[/] {functionBlock.FirstGroupIndex + 1} (Index {functionBlock.FirstGroupIndex})";
-                            }
-                            else
-                            {
-                                int stopGroupIndex = functionBlock.FirstGroupIndex + functionBlock.GroupCount - 1;
-                                functionInformation +=
-                                    $"[grey]Groups[/] {functionBlock.FirstGroupIndex + 1}-{stopGroupIndex + 1} (Indexes {functionBlock.FirstGroupIndex}-{stopGroupIndex})";
+                                string functionInformation = string.Empty;
+                                
 
-                            }
-
-                            functionInformation += ", [grey]MIDI[/] " + functionBlock.Midi10Connection.ToString();
-                            functionInformation += ", [grey]Direction[/] " + functionBlock.Direction.ToString();
-                            functionInformation += ", [grey]UI Hint[/] " + functionBlock.UIHint.ToString();
-
-                            string active = string.Empty;
-
-                            if (!functionBlock.IsActive)
-                            {
-                                active = " [grey](inactive)[/] ";
-                            }
-                            else
-                            {
-                                // if it's active, we don't show anything special
-                                active = string.Empty;
-                            }
-
-                            table.AddRow(
-                                AnsiMarkupFormatter.FormatBlockNumber(functionBlock.Number) + " " +
-                                AnsiMarkupFormatter.FormatBlockName(functionBlock.Name) +
-                                active, 
-                                functionInformation);
-                        }
-                        else
-                        {
-                            table.AddEmptyRow();
-                            table.AddRow("Function Block", AnsiMarkupFormatter.FormatBlockNumber(functionBlock.Number) + " " + AnsiMarkupFormatter.FormatBlockName(functionBlock.Name));
-                            table.AddRow("Active", functionBlock.IsActive.ToString());
-                            table.AddRow("First Group Index", functionBlock.FirstGroupIndex.ToString());
-                            table.AddRow("Group Count", functionBlock.GroupCount.ToString());
-
-                            if (settings.Verbose)
-                            {
-                                table.AddRow("Direction", functionBlock.Direction.ToString());
-                                table.AddRow("UI Hint", functionBlock.UIHint.ToString());
-
-                                string sysexStreams = string.Empty;
-                                if (functionBlock.MaxSystemExclusive8Streams == 0)
+                                if (functionBlock.GroupCount == 1)
                                 {
-                                    sysexStreams = "SysEx 8 Not Supported";
-                                }
-                                else if (functionBlock.MaxSystemExclusive8Streams == 1)
-                                {
-                                    sysexStreams = "Single SysEx Stream";
+                                    functionInformation +=
+                                        $"[grey]Group[/] {functionBlock.FirstGroupIndex + 1} (Index {functionBlock.FirstGroupIndex})";
                                 }
                                 else
                                 {
-                                    sysexStreams = functionBlock.MaxSystemExclusive8Streams + " SysEx Streams";
+                                    int stopGroupIndex = functionBlock.FirstGroupIndex + functionBlock.GroupCount - 1;
+                                    functionInformation +=
+                                        $"[grey]Groups[/] {functionBlock.FirstGroupIndex + 1}-{stopGroupIndex + 1} (Indexes {functionBlock.FirstGroupIndex}-{stopGroupIndex})";
+
                                 }
 
-                                table.AddRow("Max SysEx 8 Streams", sysexStreams);
-                                table.AddRow("MIDI 1.0", functionBlock.Midi10Connection.ToString());
-                                table.AddRow("MIDI CI Version Format", functionBlock.MidiCIMessageVersionFormat.ToString());
-                            }
+                                functionInformation += ", [grey]MIDI[/] " + functionBlock.Midi10Connection.ToString();
+                                functionInformation += ", [grey]Direction[/] " + functionBlock.Direction.ToString();
+                                functionInformation += ", [grey]UI Hint[/] " + functionBlock.UIHint.ToString();
 
+                                string active = string.Empty;
 
-                            if (functionBlock.GroupCount == 1)
-                            {
-                                table.AddRow("Group", $"{functionBlock.FirstGroupIndex + 1} (Index {functionBlock.FirstGroupIndex})");
+                                if (!functionBlock.IsActive)
+                                {
+                                    active = " [grey](inactive)[/] ";
+                                }
+                                else
+                                {
+                                    // if it's active, we don't show anything special
+                                    active = string.Empty;
+                                }
+
+                                table.AddRow(
+                                    AnsiMarkupFormatter.FormatBlockNumber(functionBlock.Number) + " " +
+                                    AnsiMarkupFormatter.FormatBlockName(functionBlock.Name) +
+                                    active,
+                                    functionInformation);
                             }
                             else
                             {
-                                int stopGroupIndex = functionBlock.FirstGroupIndex + functionBlock.GroupCount - 1;
-                                table.AddRow("Groups", $"{functionBlock.FirstGroupIndex + 1}-{stopGroupIndex + 1} (Indexes {functionBlock.FirstGroupIndex}-{stopGroupIndex})");
-                            }
+                                table.AddEmptyRow();
+                                table.AddRow("Function Block", AnsiMarkupFormatter.FormatBlockNumber(functionBlock.Number) + " " + AnsiMarkupFormatter.FormatBlockName(functionBlock.Name));
+                                table.AddRow("Active", functionBlock.IsActive.ToString());
+                                table.AddRow("First Group Index", functionBlock.FirstGroupIndex.ToString());
+                                table.AddRow("Group Count", functionBlock.GroupCount.ToString());
 
-                            table.AddRow("Group Count", functionBlock.GroupCount.ToString());
+                                if (settings.Verbose)
+                                {
+                                    table.AddRow("Direction", functionBlock.Direction.ToString());
+                                    table.AddRow("UI Hint", functionBlock.UIHint.ToString());
+
+                                    string sysexStreams = string.Empty;
+                                    if (functionBlock.MaxSystemExclusive8Streams == 0)
+                                    {
+                                        sysexStreams = "SysEx 8 Not Supported";
+                                    }
+                                    else if (functionBlock.MaxSystemExclusive8Streams == 1)
+                                    {
+                                        sysexStreams = "Single SysEx Stream";
+                                    }
+                                    else
+                                    {
+                                        sysexStreams = functionBlock.MaxSystemExclusive8Streams + " SysEx Streams";
+                                    }
+
+                                    table.AddRow("Max SysEx 8 Streams", sysexStreams);
+                                    table.AddRow("MIDI 1.0", functionBlock.Midi10Connection.ToString());
+                                    table.AddRow("MIDI CI Version Format", functionBlock.MidiCIMessageVersionFormat.ToString());
+                                }
+
+
+                                if (functionBlock.GroupCount == 1)
+                                {
+                                    table.AddRow("Group", $"{functionBlock.FirstGroupIndex + 1} (Index {functionBlock.FirstGroupIndex})");
+                                }
+                                else
+                                {
+                                    int stopGroupIndex = functionBlock.FirstGroupIndex + functionBlock.GroupCount - 1;
+                                    table.AddRow("Groups", $"{functionBlock.FirstGroupIndex + 1}-{stopGroupIndex + 1} (Indexes {functionBlock.FirstGroupIndex}-{stopGroupIndex})");
+                                }
+
+                                table.AddRow("Group Count", functionBlock.GroupCount.ToString());
+                            }
                         }
                     }
                 }
@@ -252,7 +299,7 @@ namespace Microsoft.Devices.Midi2.ConsoleApp
                     
                     if (di.FunctionBlocks.Count > 0)
                     {
-                        table.AddRow("Function blocks are present. Applications should use the Function Blocks and their group declarations instead of the Group Terminal Blocks.", "");
+                        table.AddRow("Use the present Function Blocks instead.", "");
                     }
 
                     foreach (var groupTerminalBlock in di.GroupTerminalBlocks)

--- a/src/user-tools/midi-console/Midi/Resources/Strings.Designer.cs
+++ b/src/user-tools/midi-console/Midi/Resources/Strings.Designer.cs
@@ -1200,11 +1200,29 @@ namespace Microsoft.Devices.Midi2.ConsoleApp.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Multi-client.
+        /// </summary>
+        internal static string PropertiesTablePropertyLabelMultiClient {
+            get {
+                return ResourceManager.GetString("PropertiesTablePropertyLabelMultiClient", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Name.
         /// </summary>
         internal static string PropertiesTablePropertyLabelName {
             get {
                 return ResourceManager.GetString("PropertiesTablePropertyLabelName", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Native data format.
+        /// </summary>
+        internal static string PropertiesTablePropertyLabelNativeDataFormat {
+            get {
+                return ResourceManager.GetString("PropertiesTablePropertyLabelNativeDataFormat", resourceCulture);
             }
         }
         
@@ -1259,6 +1277,15 @@ namespace Microsoft.Devices.Midi2.ConsoleApp.Resources {
         internal static string PropertiesTablePropertyLabelSystemExclusiveId {
             get {
                 return ResourceManager.GetString("PropertiesTablePropertyLabelSystemExclusiveId", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Description.
+        /// </summary>
+        internal static string PropertiesTablePropertyLabelTransportSuppliedDescription {
+            get {
+                return ResourceManager.GetString("PropertiesTablePropertyLabelTransportSuppliedDescription", resourceCulture);
             }
         }
         

--- a/src/user-tools/midi-console/Midi/Resources/Strings.resx
+++ b/src/user-tools/midi-console/Midi/Resources/Strings.resx
@@ -506,8 +506,14 @@ Timestamp</value>
   <data name="PropertiesTablePropertyLabelManufacturer" xml:space="preserve">
     <value>Manufacturer</value>
   </data>
+  <data name="PropertiesTablePropertyLabelMultiClient" xml:space="preserve">
+    <value>Multi-client</value>
+  </data>
   <data name="PropertiesTablePropertyLabelName" xml:space="preserve">
     <value>Name</value>
+  </data>
+  <data name="PropertiesTablePropertyLabelNativeDataFormat" xml:space="preserve">
+    <value>Native data format</value>
   </data>
   <data name="PropertiesTablePropertyLabelProductInstanceId" xml:space="preserve">
     <value>Product Instance Id</value>
@@ -526,6 +532,9 @@ Timestamp</value>
   </data>
   <data name="PropertiesTablePropertyLabelSystemExclusiveId" xml:space="preserve">
     <value>System Exclusive Id</value>
+  </data>
+  <data name="PropertiesTablePropertyLabelTransportSuppliedDescription" xml:space="preserve">
+    <value>Description</value>
   </data>
   <data name="PropertiesTablePropertyLabelUserSuppliedName" xml:space="preserve">
     <value>User-Supplied Name</value>


### PR DESCRIPTION
Previously, if you created an app endpoint, had a client connect to it, and then disconnected the endpoint, subsequent re-opens of that endpoint would result in no messages getting through. That is fixed now.