### PR TITLE
Loopbacks and scheduled messaging

### DIFF
--- a/build/staging/version/BundleInfo.wxi
+++ b/build/staging/version/BundleInfo.wxi
@@ -1,4 +1,4 @@
 <Include>
   <?define SetupVersionName="Developer Preview 5" ?>
-  <?define SetupVersionNumber="1.0.24044.1931" ?>
+  <?define SetupVersionNumber="1.0.24044.1942" ?>
 </Include>

--- a/build/staging/version/BundleInfo.wxi
+++ b/build/staging/version/BundleInfo.wxi
@@ -1,4 +1,4 @@
 <Include>
   <?define SetupVersionName="Developer Preview 5" ?>
-  <?define SetupVersionNumber="1.0.24044.0330" ?>
+  <?define SetupVersionNumber="1.0.24044.1320" ?>
 </Include>

--- a/build/staging/version/BundleInfo.wxi
+++ b/build/staging/version/BundleInfo.wxi
@@ -1,4 +1,4 @@
 <Include>
   <?define SetupVersionName="Developer Preview 5" ?>
-  <?define SetupVersionNumber="1.0.24044.1320" ?>
+  <?define SetupVersionNumber="1.0.24044.1931" ?>
 </Include>

--- a/docs/endpoints/virtual-device-app.md
+++ b/docs/endpoints/virtual-device-app.md
@@ -15,7 +15,7 @@ has_children: false
 
 ## Overview
 
-One way to have app-to-app MIDI on Windows is to use a simple loopback. That is typically created ahead of time, and is available for any applications to use to communicate with each other. The lifetime of these loopback endpoints are not tied to any one application.
+One way to have app-to-app MIDI on Windows is to use a simple loopback. That is typically created ahead of time, and is available for any applications to use to communicate with each other. The lifetime of these loopback endpoints are not tied to any one application. They are simply a pipe between applications.
 
 Another approach is to allow applications to create and publish an endpoint which is declared through settings inside the application itself. When the application closes, the endpoint closes. That is the model the Virtual Device App feature implements. (If you want the simple pre-created loopback, see the Virtual Loopback transport)
 

--- a/docs/endpoints/virtual-loopback.md
+++ b/docs/endpoints/virtual-loopback.md
@@ -88,5 +88,5 @@ Each loopback endpoint pair is identified by a GUID for the association id. The 
 
 # Implementation
 
-Internally, the Virtual Loopback is implemented as two endpoints which are cross-wired, so anything sent to Loopback A arrives on the input of Loopback B, and vice versa. Each declared pair has an exclusive relationship, and there's no practical limit to the number of loopback pairs you can define.
+Internally, the Virtual Loopback is implemented as two endpoints which are cross-wired, so anything sent out to Loopback A arrives on the input of Loopback B, and vice versa. Each declared pair has an exclusive relationship, and there's no practical limit to the number of loopback pairs you can define.
 

--- a/docs/endpoints/virtual-loopback.md
+++ b/docs/endpoints/virtual-loopback.md
@@ -85,6 +85,7 @@ Each loopback endpoint pair is identified by a GUID for the association id. The 
 | (endpoint) description | Optional. This becomes the transport-supplied description for the loopback endpoint. |
 | (endpoint) uniqueId | Required. This is a short (32 characters or fewer) case-insensitive unique Id for the endpoint. When combined with the loopback A/B prefixes in the service, it must be unique across all loopback endpoints in Windows. You can use the same unique id for each endpoint in the same pair, but not the same as other pairs. |
 
+> Note: Loopback endpoints created in the configuration file cannot be removed by the API. Only loopback endpoints created via the API can be removed via the API. This is by design to help avoid applications changing user configuration.
 
 # Implementation
 

--- a/samples/cpp-winrt/api-loopback-endpoints/PropertySheet.props
+++ b/samples/cpp-winrt/api-loopback-endpoints/PropertySheet.props
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ImportGroup Label="PropertySheets" />
+  <PropertyGroup Label="UserMacros" />
+    <!--
+    To customize common C++/WinRT project properties: 
+    * right-click the project node
+    * expand the Common Properties item
+    * select the C++/WinRT property page
+
+    For more advanced scenarios, and complete documentation, please see:
+    https://github.com/Microsoft/cppwinrt/tree/master/nuget 
+    -->
+  <PropertyGroup />
+  <ItemDefinitionGroup />
+</Project>

--- a/samples/cpp-winrt/api-loopback-endpoints/api-loopback-endpoints.sln
+++ b/samples/cpp-winrt/api-loopback-endpoints/api-loopback-endpoints.sln
@@ -1,0 +1,31 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.9.34526.213
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "api-loopback-endpoints", "api-loopback-endpoints.vcxproj", "{0F789250-75E9-47D3-B740-46547F2BC23C}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{0F789250-75E9-47D3-B740-46547F2BC23C}.Debug|x64.ActiveCfg = Debug|x64
+		{0F789250-75E9-47D3-B740-46547F2BC23C}.Debug|x64.Build.0 = Debug|x64
+		{0F789250-75E9-47D3-B740-46547F2BC23C}.Debug|x86.ActiveCfg = Debug|Win32
+		{0F789250-75E9-47D3-B740-46547F2BC23C}.Debug|x86.Build.0 = Debug|Win32
+		{0F789250-75E9-47D3-B740-46547F2BC23C}.Release|x64.ActiveCfg = Release|x64
+		{0F789250-75E9-47D3-B740-46547F2BC23C}.Release|x64.Build.0 = Release|x64
+		{0F789250-75E9-47D3-B740-46547F2BC23C}.Release|x86.ActiveCfg = Release|Win32
+		{0F789250-75E9-47D3-B740-46547F2BC23C}.Release|x86.Build.0 = Release|Win32
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {12CF8BB3-04D9-4E5D-B48C-0E39B828A727}
+	EndGlobalSection
+EndGlobal

--- a/samples/cpp-winrt/api-loopback-endpoints/api-loopback-endpoints.vcxproj
+++ b/samples/cpp-winrt/api-loopback-endpoints/api-loopback-endpoints.vcxproj
@@ -1,0 +1,126 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="packages\Windows.Devices.Midi2.1.0.0-preview.3-0156\build\native\Windows.Devices.Midi2.props" Condition="Exists('packages\Windows.Devices.Midi2.1.0.0-preview.3-0156\build\native\Windows.Devices.Midi2.props')" />
+  <Import Project="packages\Microsoft.Windows.CppWinRT.2.0.240111.5\build\native\Microsoft.Windows.CppWinRT.props" Condition="Exists('packages\Microsoft.Windows.CppWinRT.2.0.240111.5\build\native\Microsoft.Windows.CppWinRT.props')" />
+  <PropertyGroup Label="Globals">
+    <CppWinRTOptimized>true</CppWinRTOptimized>
+    <CppWinRTRootNamespaceAutoMerge>true</CppWinRTRootNamespaceAutoMerge>
+    <CppWinRTGenerateWindowsMetadata>true</CppWinRTGenerateWindowsMetadata>
+    <MinimalCoreWin>true</MinimalCoreWin>
+    <VCProjectVersion>15.0</VCProjectVersion>
+    <ProjectGuid>{0f789250-75e9-47d3-b740-46547f2bc23c}</ProjectGuid>
+    <Keyword>Win32Proj</Keyword>
+    <RootNamespace>api_loopback_endpoints</RootNamespace>
+    <WindowsTargetPlatformVersion Condition=" '$(WindowsTargetPlatformVersion)' == '' ">10.0.20348.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformMinVersion>10.0.20348.0</WindowsTargetPlatformMinVersion>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|x64">
+      <Configuration>Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|x64">
+      <Configuration>Release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <PropertyGroup Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <PlatformToolset>v143</PlatformToolset>
+    <PlatformToolset Condition="'$(VisualStudioVersion)' == '16.0'">v142</PlatformToolset>
+    <PlatformToolset Condition="'$(VisualStudioVersion)' == '15.0'">v141</PlatformToolset>
+    <PlatformToolset Condition="'$(VisualStudioVersion)' == '14.0'">v140</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)'=='Debug'" Label="Configuration">
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <LinkIncremental>true</LinkIncremental>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)'=='Release'" Label="Configuration">
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <LinkIncremental>false</LinkIncremental>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Label="Shared">
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets">
+    <Import Project="PropertySheet.props" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <ItemDefinitionGroup>
+    <ClCompile>
+      <PrecompiledHeader>Use</PrecompiledHeader>
+      <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
+      <PrecompiledHeaderOutputFile>$(IntDir)pch.pch</PrecompiledHeaderOutputFile>
+      <PreprocessorDefinitions>_CONSOLE;WIN32_LEAN_AND_MEAN;WINRT_LEAN_AND_MEAN;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <WarningLevel>Level4</WarningLevel>
+      <AdditionalOptions>%(AdditionalOptions) /permissive- /bigobj</AdditionalOptions>
+    </ClCompile>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)'=='Debug'">
+    <ClCompile>
+      <Optimization>Disabled</Optimization>
+      <PreprocessorDefinitions>_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <GenerateWindowsMetadata>false</GenerateWindowsMetadata>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Platform)'=='Win32'">
+    <ClCompile>
+      <PreprocessorDefinitions>WIN32;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)'=='Release'">
+    <ClCompile>
+      <Optimization>MaxSpeed</Optimization>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+      <GenerateWindowsMetadata>false</GenerateWindowsMetadata>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <ClInclude Include="pch.h" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="main.cpp" />
+    <ClCompile Include="pch.cpp">
+      <PrecompiledHeader>Create</PrecompiledHeader>
+    </ClCompile>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+    <None Include="PropertySheet.props" />
+    <Text Include="readme.txt">
+      <DeploymentContent>false</DeploymentContent>
+    </Text>
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+    <Import Project="packages\Microsoft.Windows.CppWinRT.2.0.240111.5\build\native\Microsoft.Windows.CppWinRT.targets" Condition="Exists('packages\Microsoft.Windows.CppWinRT.2.0.240111.5\build\native\Microsoft.Windows.CppWinRT.targets')" />
+    <Import Project="packages\Windows.Devices.Midi2.1.0.0-preview.3-0156\build\native\Windows.Devices.Midi2.targets" Condition="Exists('packages\Windows.Devices.Midi2.1.0.0-preview.3-0156\build\native\Windows.Devices.Midi2.targets')" />
+  </ImportGroup>
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('packages\Microsoft.Windows.CppWinRT.2.0.240111.5\build\native\Microsoft.Windows.CppWinRT.props')" Text="$([System.String]::Format('$(ErrorText)', 'packages\Microsoft.Windows.CppWinRT.2.0.240111.5\build\native\Microsoft.Windows.CppWinRT.props'))" />
+    <Error Condition="!Exists('packages\Microsoft.Windows.CppWinRT.2.0.240111.5\build\native\Microsoft.Windows.CppWinRT.targets')" Text="$([System.String]::Format('$(ErrorText)', 'packages\Microsoft.Windows.CppWinRT.2.0.240111.5\build\native\Microsoft.Windows.CppWinRT.targets'))" />
+    <Error Condition="!Exists('packages\Windows.Devices.Midi2.1.0.0-preview.3-0156\build\native\Windows.Devices.Midi2.props')" Text="$([System.String]::Format('$(ErrorText)', 'packages\Windows.Devices.Midi2.1.0.0-preview.3-0156\build\native\Windows.Devices.Midi2.props'))" />
+    <Error Condition="!Exists('packages\Windows.Devices.Midi2.1.0.0-preview.3-0156\build\native\Windows.Devices.Midi2.targets')" Text="$([System.String]::Format('$(ErrorText)', 'packages\Windows.Devices.Midi2.1.0.0-preview.3-0156\build\native\Windows.Devices.Midi2.targets'))" />
+  </Target>
+</Project>

--- a/samples/cpp-winrt/api-loopback-endpoints/main.cpp
+++ b/samples/cpp-winrt/api-loopback-endpoints/main.cpp
@@ -1,0 +1,187 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License
+// Further information: https://github.com/microsoft/MIDI/
+// ============================================================================
+
+// Windows MIDI Services sample code
+
+#include "pch.h"
+#include <iostream>
+
+#include <winrt/Windows.Devices.Midi2.h>    // normally you'd put this in pch.h, but here for visibility
+
+using namespace winrt::Windows::Devices::Midi2;        // API
+
+// standard WinRT enumeration support. This is how you find attached devices.
+using namespace winrt::Windows::Devices::Enumeration;
+
+// where you find types like IAsyncOperation, IInspectable, etc.
+namespace foundation = winrt::Windows::Foundation;
+
+
+// we'll use these to keep track of the ids of the created endpoints
+winrt::hstring m_endpointAId{};
+winrt::hstring m_endpointBId{};
+winrt::guid m_associationId = winrt::Windows::Foundation::GuidHelper::CreateNewGuid();
+
+bool CreateLoopbackEndpoints()
+{
+    std::cout << "Creating loopback endpoints." << std::endl;
+
+    MidiServiceLoopbackEndpointDefinition definitionA;
+    MidiServiceLoopbackEndpointDefinition definitionB;
+
+    definitionA.Name(L"My App Loopback A");
+    definitionA.Description(L"The first description is optional, but is displayed to users. This becomes the transport-defined description.");
+    definitionA.UniqueId(L"8675309-OU812-5150");
+
+    definitionB.Name(L"My App Loopback B");
+    definitionB.Description(L"The second description is optional, but is displayed to users. This becomes the transport-defined description.");
+    definitionB.UniqueId(L"3263827-OU812-5150"); // can be the same as the first one, but doesn't need to be.
+
+    auto response = MidiService::CreateTemporaryLoopbackEndpoints(
+        m_associationId,
+        definitionA,
+        definitionB
+    );
+
+
+    if (response.Success())
+    {
+        std::wcout << L"Endpoint A: " << response.EndpointDeviceIdA().c_str() << std::endl;
+        std::wcout << L"Endpoint B: " << response.EndpointDeviceIdB().c_str() << std::endl;
+
+        m_endpointAId = response.EndpointDeviceIdA();
+        m_endpointBId = response.EndpointDeviceIdB();
+    }
+    else
+    {
+        std::cout << "Failed to create loopback endpoints." << std::endl;
+    }
+
+    return response.Success();
+}
+
+
+int main()
+{
+    winrt::init_apartment();
+
+    // create the MIDI session, giving us access to Windows MIDI Services. An app may open 
+    // more than one session. If so, the session name should be meaningful to the user, like
+    // the name of a browser tab, or a project.
+
+    std::cout << std::endl << "Creating session..." << std::endl;
+
+    auto session = MidiSession::CreateSession(L"Sample Session");
+
+
+
+    if (CreateLoopbackEndpoints())
+    {
+        auto sendEndpoint = session.CreateEndpointConnection(m_endpointAId);
+        std::cout << "Connected to sending endpoint: " << winrt::to_string(m_endpointAId) << std::endl;
+
+        auto receiveEndpoint = session.CreateEndpointConnection(m_endpointBId);
+        std::cout << "Connected to receiving endpoint: " << winrt::to_string(m_endpointBId) << std::endl;
+
+        // Wire up an event handler to receive the message. There is a single event handler type, but the
+        // MidiMessageReceivedEventArgs class provides the different ways to access the data
+        // Your event handlers should return quickly as they are called synchronously.
+
+        auto MessageReceivedHandler = [&](foundation::IInspectable const& sender, MidiMessageReceivedEventArgs const& args)
+            {
+                // there are several ways to get the message data from the arguments. If you want to use
+                // strongly-typed UMP classes, then you may start with the GetUmp() method. The GetXXX calls 
+                // are all generating something within the function, so you want to call them once and then
+                // keep the result around in a variable if you plan to refer to it multiple times. In 
+                // contrast, the FillXXX functions will update values in provided (pre-allocated) types
+                // passed in to the functions.
+                auto ump = args.GetMessagePacket();
+
+                std::cout << std::endl;
+                std::cout << "Received UMP" << std::endl;
+                std::cout << "- Current Timestamp: " << std::dec << MidiClock::Now() << std::endl;
+                std::cout << "- UMP Timestamp:     " << std::dec << ump.Timestamp() << std::endl;
+                std::cout << "- UMP Msg Type:      0x" << std::hex << (uint32_t)ump.MessageType() << std::endl;
+                std::cout << "- UMP Packet Type:   0x" << std::hex << (uint32_t)ump.PacketType() << std::endl;
+                std::cout << "- Message:           " << winrt::to_string(MidiMessageUtility::GetMessageFriendlyNameFromFirstWord(args.PeekFirstWord())) << std::endl;
+
+                // if you wish to cast the IMidiUmp to a specific Ump Type, you can do so using .as<T> WinRT extension
+
+                if (ump.PacketType() == MidiPacketType::UniversalMidiPacket32)
+                {
+                    // we'll use the Ump32 type here. This is a runtimeclass that the strongly-typed 
+                    // 32-bit messages derive from. There are also MidiUmp64/96/128 classes.
+                    auto ump32 = ump.as<MidiMessage32>();
+
+                    std::cout << "- Word 0:            0x" << std::hex << ump32.Word0() << std::endl;
+                }
+
+                std::cout << std::endl;
+
+            };
+
+        // the returned token is used to deregister the event later.
+        auto eventRevokeToken = receiveEndpoint.MessageReceived(MessageReceivedHandler);
+
+
+        std::cout << std::endl << "Opening endpoint connection" << std::endl;
+
+        // once you have wired up all your event handlers, added any filters/listeners, etc.
+        // You can open the connection. Doing this will query the cache for the in-protocol 
+        // endpoint information and function blocks. If not there, it will send out the requests
+        // which will come back asynchronously with responses.
+        sendEndpoint.Open();
+        receiveEndpoint.Open();
+
+
+        std::cout << std::endl << "Creating MIDI 1.0 Channel Voice 32-bit UMP..." << std::endl;
+
+        auto ump32 = MidiMessageBuilder::BuildMidi1ChannelVoiceMessage(
+            MidiClock::Now(), // use current timestamp
+            5,      // group 5
+            Midi1ChannelVoiceMessageStatus::NoteOn,     // 9
+            3,      // channel 3
+            120,    // note 120 - hex 0x78
+            100);   // velocity 100 hex 0x64
+
+        // here you would set other values in the UMP word(s)
+
+        std::cout << "Sending single UMP..." << std::endl;
+
+        auto ump = ump32.as<IMidiUniversalPacket>();
+        auto sendResult = sendEndpoint.SendMessagePacket(ump);          // could also use the SendWords methods, etc.
+
+        std::cout << std::endl << " ** Wait for the sent UMP to arrive, and then press enter to cleanup. **" << std::endl;
+
+        system("pause");
+
+        std::cout << std::endl << "Deregistering event handler..." << std::endl;
+
+        // deregister the event by passing in the revoke token
+        receiveEndpoint.MessageReceived(eventRevokeToken);
+
+        std::cout << "Disconnecting UMP Endpoint Connection..." << std::endl;
+
+
+        session.DisconnectEndpointConnection(sendEndpoint.ConnectionId());
+        session.DisconnectEndpointConnection(receiveEndpoint.ConnectionId());
+
+        // close the session, detaching all Windows MIDI Services resources and closing all connections
+        // You can also disconnect individual Endpoint Connections when you are done with them, as we did above
+        session.Close();
+
+
+        // remove the loopback endpoints
+
+        if (MidiService::RemoveTemporaryLoopbackEndpoints(m_associationId))
+        {
+            std::cout << "Endpoints removed." << std::endl;
+        }
+        else
+        {
+            std::cout << "There was a problem removing the endpoints." << std::endl;
+        }
+    }
+}

--- a/samples/cpp-winrt/api-loopback-endpoints/packages.config
+++ b/samples/cpp-winrt/api-loopback-endpoints/packages.config
@@ -1,0 +1,5 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Microsoft.Windows.CppWinRT" version="2.0.240111.5" targetFramework="native" />
+  <package id="Windows.Devices.Midi2" version="1.0.0-preview.3-0156" targetFramework="native" />
+</packages>

--- a/samples/cpp-winrt/api-loopback-endpoints/pch.cpp
+++ b/samples/cpp-winrt/api-loopback-endpoints/pch.cpp
@@ -1,0 +1,1 @@
+﻿#include "pch.h"

--- a/samples/cpp-winrt/api-loopback-endpoints/pch.h
+++ b/samples/cpp-winrt/api-loopback-endpoints/pch.h
@@ -1,0 +1,5 @@
+﻿#pragma once
+#include <winrt/Windows.Foundation.h>
+#include <winrt/Windows.Foundation.Collections.h>
+
+

--- a/samples/cpp-winrt/api-loopback-endpoints/readme.txt
+++ b/samples/cpp-winrt/api-loopback-endpoints/readme.txt
@@ -1,0 +1,30 @@
+========================================================================
+    C++/WinRT api-loopback-endpoints Project Overview
+========================================================================
+
+This project demonstrates how to get started consuming Windows Runtime 
+classes directly from standard C++, using platform projection headers
+generated from Windows SDK metadata files.
+
+Steps to generate and consume SDK platform projection:
+1. Build project initially to generate platform projection headers into
+    your Generated Files folder.
+2. Include a projection namespace header in your pch.h, such as 
+    <winrt/Windows.Foundation.h>.
+3. Consume winrt namespace and any Windows Runtime namespaces, such as 
+    winrt::Windows::Foundation, from source code.
+4. Initialize apartment via init_apartment() and consume winrt classes.
+
+Steps to generate and consume a projection from third party metadata:
+1. Add a WinMD reference by right-clicking the References project node
+    and selecting "Add Reference...".  In the Add References dialog, 
+    browse to the component WinMD you want to consume and add it.
+2. Build the project once to generate projection headers for the 
+    referenced WinMD file under the "Generated Files" subfolder.
+3. As above, include projection headers in pch or source code 
+    to consume projected Windows Runtime classes.
+
+========================================================================
+Learn more about C++/WinRT here:
+http://aka.ms/cppwinrt/
+========================================================================

--- a/src/api/Abstraction/LoopbackMidiAbstraction/Midi2.LoopbackMidiConfigurationManager.cpp
+++ b/src/api/Abstraction/LoopbackMidiAbstraction/Midi2.LoopbackMidiConfigurationManager.cpp
@@ -52,11 +52,9 @@ CMidi2LoopbackMidiConfigurationManager::UpdateConfiguration(
     //if (ConfigurationJsonSection == L"") return S_OK;
 
     json::JsonObject jsonObject;
-    json::JsonObject responseObject;
 
     // default to failure
-    internal::JsonSetBoolProperty(responseObject, MIDI_CONFIG_JSON_ENDPOINT_LOOPBACK_DEVICE_RESPONSE_SUCCESS_PROPERTY_KEY, false);
-
+    auto responseObject = internal::BuildConfigurationResponseObject(false);
 
     try
     {
@@ -100,25 +98,7 @@ CMidi2LoopbackMidiConfigurationManager::UpdateConfiguration(
                 //json::JsonObject associationObj;
 
                 auto associationObj = o.Current().Value().GetObject();
-
-                //if (!o.Current().Value().try_as<json::JsonObject>(associationObj))
-                //{
-                //    TraceLoggingWrite(
-                //        MidiLoopbackMidiAbstractionTelemetryProvider::Provider(),
-                //        __FUNCTION__,
-                //        TraceLoggingLevel(WINEVENT_LEVEL_ERROR),
-                //        TraceLoggingPointer(this, "this"),
-                //        TraceLoggingWideString(L"Unable to read the property as a json object", "message"),
-                //        TraceLoggingWideString(associationKey.c_str(), "key")
-                //        TraceLoggingWideString(o.Current().Value().Stringify(), "stringify")
-                //    );
-
-                //    internal::JsonStringifyObjectToOutParam(responseObject, &Response);
-
-                //    return E_FAIL;
-                //}              
-
-                
+               
                 if (associationObj)
                 {
                     definitionA->AssociationId = associationKey;
@@ -175,7 +155,7 @@ CMidi2LoopbackMidiConfigurationManager::UpdateConfiguration(
                         }
 
 
-                        if (SUCCEEDED(AbstractionState::Current().GetEndpointManager()->CreateEndpointPair(definitionA, definitionB)))
+                        if (SUCCEEDED(AbstractionState::Current().GetEndpointManager()->CreateEndpointPair(definitionA, definitionB, IsFromConfigurationFile)))
                         {
                             TraceLoggingWrite(
                                 MidiLoopbackMidiAbstractionTelemetryProvider::Provider(),
@@ -189,7 +169,7 @@ CMidi2LoopbackMidiConfigurationManager::UpdateConfiguration(
 
                             internal::JsonSetBoolProperty(
                                 responseObject,
-                                MIDI_CONFIG_JSON_ENDPOINT_LOOPBACK_DEVICE_RESPONSE_SUCCESS_PROPERTY_KEY,
+                                MIDI_CONFIG_JSON_CONFIGURATION_RESPONSE_SUCCESS_PROPERTY_KEY,
                                 true);
 
                             // update the return json with the new Ids
@@ -263,7 +243,6 @@ CMidi2LoopbackMidiConfigurationManager::UpdateConfiguration(
             // nothing to create.
         }
 
-
         // update and delete are runtime operations, not config file operations
 
         if (!IsFromConfigurationFile)
@@ -272,20 +251,56 @@ CMidi2LoopbackMidiConfigurationManager::UpdateConfiguration(
 
             // Create ----------------------------------
 
-            if (deleteArray != nullptr && createObject.Size() > 0)
+            if (deleteArray != nullptr && deleteArray.Size() > 0)
             {
-                auto o = createObject.First();
+                auto o = deleteArray.First();
 
                 while (o.HasCurrent())
                 {
                     // each entry is an association id
 
+                    auto associationId = o.Current().GetString();
+
                     // if the entry was runtime-created and not from the config file, we can delete both endpoints 
+
+                    auto device = AbstractionState::Current().GetEndpointTable()->GetDevice(associationId.c_str());
+
+                    // we can only delete runtime-created devices here
+
+                    if (!device->IsFromConfigurationFile)
+                    {
+                        auto removalHr = AbstractionState::Current().GetEndpointManager()->DeleteEndpointPair(device->DefinitionA, device->DefinitionB);
+
+                        LOG_IF_FAILED(removalHr);
+
+                        if (SUCCEEDED(removalHr))
+                        {
+                            AbstractionState::Current().GetEndpointTable()->RemoveDevice(associationId.c_str());
+
+                            internal::JsonSetBoolProperty(
+                                responseObject,
+                                MIDI_CONFIG_JSON_CONFIGURATION_RESPONSE_SUCCESS_PROPERTY_KEY,
+                                true);
+                        }
+                        else
+                        {
+                            // failed to remove device
+
+                            TraceLoggingWrite(
+                                MidiLoopbackMidiAbstractionTelemetryProvider::Provider(),
+                                __FUNCTION__,
+                                TraceLoggingLevel(WINEVENT_LEVEL_ERROR),
+                                TraceLoggingPointer(this, "this"),
+                                TraceLoggingWideString(L"Failed to remove device", "message"),
+                                TraceLoggingWideString(ConfigurationJsonSection, "json")
+                            );
+                        }
+                    }
+
 
                     o.MoveNext();
                 }
             }
-
 
             //auto updateArray = internal::JsonGetArrayProperty(jsonObject, MIDI_CONFIG_JSON_ENDPOINT_LOOPBACK_DEVICES_UPDATE_KEY);
 

--- a/src/api/Abstraction/LoopbackMidiAbstraction/Midi2.LoopbackMidiConfigurationManager.cpp
+++ b/src/api/Abstraction/LoopbackMidiAbstraction/Midi2.LoopbackMidiConfigurationManager.cpp
@@ -130,6 +130,8 @@ CMidi2LoopbackMidiConfigurationManager::UpdateConfiguration(
 
                     if (endpointAObject != nullptr && endpointBObject != nullptr)
                     {
+                        // we don't look for user-specified names and descriptions here. There's no need to.
+
                         definitionA->EndpointName = endpointAObject.GetNamedString(MIDI_CONFIG_JSON_ENDPOINT_COMMON_NAME_PROPERTY, L"");
                         definitionA->EndpointDescription = endpointAObject.GetNamedString(MIDI_CONFIG_JSON_ENDPOINT_COMMON_DESCRIPTION_PROPERTY, L"");
                         definitionA->EndpointUniqueIdentifier = endpointAObject.GetNamedString(MIDI_CONFIG_JSON_ENDPOINT_COMMON_UNIQUE_ID_PROPERTY, L"");
@@ -262,33 +264,44 @@ CMidi2LoopbackMidiConfigurationManager::UpdateConfiguration(
         }
 
 
-        //auto deleteArray = internal::JsonGetArrayProperty(jsonObject, MIDI_CONFIG_JSON_ENDPOINT_LOOPBACK_DEVICES_REMOVE_KEY);
+        // update and delete are runtime operations, not config file operations
 
-        //// Remove ----------------------------------
+        if (!IsFromConfigurationFile)
+        {
+            auto deleteArray = jsonObject.GetNamedArray(MIDI_CONFIG_JSON_ENDPOINT_LOOPBACK_DEVICES_REMOVE_KEY, nullptr);
 
-        //if (deleteArray.Size() > 0)
-        //{
-        //    // TODO : Delete endpoints if they aren't in the config file
+            // Create ----------------------------------
 
-        //}
-        //else
-        //{
-        //    // nothing to remove.
-        //}
+            if (deleteArray != nullptr && createObject.Size() > 0)
+            {
+                auto o = createObject.First();
+
+                while (o.HasCurrent())
+                {
+                    // each entry is an association id
+
+                    // if the entry was runtime-created and not from the config file, we can delete both endpoints 
+
+                    o.MoveNext();
+                }
+            }
 
 
-        //auto updateArray = internal::JsonGetArrayProperty(jsonObject, MIDI_CONFIG_JSON_ENDPOINT_LOOPBACK_DEVICES_UPDATE_KEY);
+            //auto updateArray = internal::JsonGetArrayProperty(jsonObject, MIDI_CONFIG_JSON_ENDPOINT_LOOPBACK_DEVICES_UPDATE_KEY);
 
-        //// Update ----------------------------------
+            //// Update ----------------------------------
 
-        //if (updateArray.Size() > 0)
-        //{
-        //    // TODO
-        //}
-        //else
-        //{
-        //    // TODO : Update endpoints
-        //}
+            //if (updateArray.Size() > 0)
+            //{
+            //    // TODO
+            //}
+            //else
+            //{
+            //    // TODO : Update endpoints
+            //}
+
+        }
+
 
         internal::JsonStringifyObjectToOutParam(responseObject, &Response);
 

--- a/src/api/Abstraction/LoopbackMidiAbstraction/Midi2.LoopbackMidiEndpointManager.cpp
+++ b/src/api/Abstraction/LoopbackMidiAbstraction/Midi2.LoopbackMidiEndpointManager.cpp
@@ -101,8 +101,8 @@ CMidi2LoopbackMidiEndpointManager::CreateParentDevice()
 _Use_decl_annotations_
 HRESULT
 CMidi2LoopbackMidiEndpointManager::DeleteEndpointPair(
-    _In_ std::shared_ptr<MidiLoopbackDeviceDefinition> definitionA,
-    _In_ std::shared_ptr<MidiLoopbackDeviceDefinition> definitionB)
+    _In_ MidiLoopbackDeviceDefinition const& definitionA,
+    _In_ MidiLoopbackDeviceDefinition const& definitionB)
 {
     TraceLoggingWrite(
         MidiLoopbackMidiAbstractionTelemetryProvider::Provider(),
@@ -123,24 +123,23 @@ CMidi2LoopbackMidiEndpointManager::DeleteEndpointPair(
 _Use_decl_annotations_
 HRESULT
 CMidi2LoopbackMidiEndpointManager::DeleteSingleEndpoint(
-    std::shared_ptr<MidiLoopbackDeviceDefinition> definition
+    MidiLoopbackDeviceDefinition const& definition
 )
 {
-    RETURN_HR_IF_NULL(E_INVALIDARG, definition);
 
     TraceLoggingWrite(
         MidiLoopbackMidiAbstractionTelemetryProvider::Provider(),
         __FUNCTION__,
         TraceLoggingLevel(WINEVENT_LEVEL_INFO),
         TraceLoggingPointer(this, "this"),
-        TraceLoggingWideString(definition->AssociationId.c_str(), "association id"),
-        TraceLoggingWideString(definition->EndpointUniqueIdentifier.c_str(), "unique identifier"),
-        TraceLoggingWideString(definition->InstanceIdPrefix.c_str(), "prefix"),
-        TraceLoggingWideString(definition->EndpointName.c_str(), "name"),
-        TraceLoggingWideString(definition->EndpointDescription.c_str(), "description")
+        TraceLoggingWideString(definition.AssociationId.c_str(), "association id"),
+        TraceLoggingWideString(definition.EndpointUniqueIdentifier.c_str(), "unique identifier"),
+        TraceLoggingWideString(definition.InstanceIdPrefix.c_str(), "prefix"),
+        TraceLoggingWideString(definition.EndpointName.c_str(), "name"),
+        TraceLoggingWideString(definition.EndpointDescription.c_str(), "description")
     );
 
-    return m_MidiDeviceManager->DeactivateEndpoint(definition->CreatedShortClientInstanceId.c_str());
+    return m_MidiDeviceManager->DeactivateEndpoint(definition.CreatedShortClientInstanceId.c_str());
 }
 
 
@@ -323,7 +322,8 @@ _Use_decl_annotations_
 HRESULT 
 CMidi2LoopbackMidiEndpointManager::CreateEndpointPair(
     std::shared_ptr<MidiLoopbackDeviceDefinition> definitionA,
-    std::shared_ptr<MidiLoopbackDeviceDefinition> definitionB
+    std::shared_ptr<MidiLoopbackDeviceDefinition> definitionB,
+    bool isFromConfigurationFile
 )
 {
     TraceLoggingWrite(
@@ -344,6 +344,7 @@ CMidi2LoopbackMidiEndpointManager::CreateEndpointPair(
 
             auto device = MidiLoopbackDevice{};
 
+            device.IsFromConfigurationFile = isFromConfigurationFile;
             device.DefinitionA = *definitionA;
             device.DefinitionB = *definitionB;
 
@@ -363,7 +364,7 @@ CMidi2LoopbackMidiEndpointManager::CreateEndpointPair(
             );
 
             // we can't do anything with the return value here
-            DeleteSingleEndpoint(definitionA);
+            DeleteSingleEndpoint(*definitionA);
 
             return E_FAIL;
         }

--- a/src/api/Abstraction/LoopbackMidiAbstraction/Midi2.LoopbackMidiEndpointManager.h
+++ b/src/api/Abstraction/LoopbackMidiAbstraction/Midi2.LoopbackMidiEndpointManager.h
@@ -26,12 +26,13 @@ public:
 
     HRESULT CreateEndpointPair(
         _In_ std::shared_ptr<MidiLoopbackDeviceDefinition> definitionA,
-        _In_ std::shared_ptr<MidiLoopbackDeviceDefinition> definitionB
+        _In_ std::shared_ptr<MidiLoopbackDeviceDefinition> definitionB,
+        _In_ bool isFromConfigurationFile
     );
 
     HRESULT DeleteEndpointPair(
-        _In_ std::shared_ptr<MidiLoopbackDeviceDefinition> definitionA,
-        _In_ std::shared_ptr<MidiLoopbackDeviceDefinition> definitionB
+        _In_ MidiLoopbackDeviceDefinition const& definitionA,
+        _In_ MidiLoopbackDeviceDefinition const& definitionB
     );
 
 
@@ -53,7 +54,7 @@ private:
     }
 
     HRESULT CreateSingleEndpoint(_In_ std::shared_ptr<MidiLoopbackDeviceDefinition> definition);
-    HRESULT DeleteSingleEndpoint(_In_ std::shared_ptr<MidiLoopbackDeviceDefinition> definition);
+    HRESULT DeleteSingleEndpoint(_In_ MidiLoopbackDeviceDefinition const& definition);
 
 
     GUID m_ContainerId{};

--- a/src/api/Abstraction/LoopbackMidiAbstraction/MidiLoopbackDevice.h
+++ b/src/api/Abstraction/LoopbackMidiAbstraction/MidiLoopbackDevice.h
@@ -18,6 +18,24 @@ public:
     MidiLoopbackDeviceDefinition DefinitionA;
     MidiLoopbackDeviceDefinition DefinitionB;
 
+    bool IsFromConfigurationFile{ true };
+
+    void Cleanup()
+    {
+        if (m_callbackA != nullptr)
+        {
+            m_callbackA = nullptr;
+        }
+
+        if (m_callbackB != nullptr)
+        {
+            m_callbackB = nullptr;
+        }
+    }
+
+
+
+
 
     void RegisterEndpointA(/*_In_ wil::com_ptr_nothrow<CMidi2LoopbackMidiBiDi> endpoint,*/ _In_ wil::com_ptr_nothrow<IMidiCallback> callback)
     {
@@ -57,8 +75,7 @@ public:
         //m_bidiA = nullptr;
         //m_bidiB = nullptr;
 
-        m_callbackA = nullptr;
-        m_callbackB = nullptr;
+        Cleanup();
     }
 
 private:

--- a/src/api/Abstraction/LoopbackMidiAbstraction/MidiLoopbackDeviceTable.h
+++ b/src/api/Abstraction/LoopbackMidiAbstraction/MidiLoopbackDeviceTable.h
@@ -31,6 +31,16 @@ public:
         m_devices[associationId] = device;
     }
 
+    void RemoveDevice(std::wstring associationId)
+    {
+        if (auto device = m_devices.find(associationId); device != m_devices.end())
+        {
+            device->second.Cleanup();
+
+            m_devices.erase(associationId);
+        }
+    }
+
 
 private:
     std::map<std::wstring, MidiLoopbackDevice> m_devices{};

--- a/src/api/Abstraction/VirtualMidiAbstraction/Midi2.VirtualMidiConfigurationManager.cpp
+++ b/src/api/Abstraction/VirtualMidiAbstraction/Midi2.VirtualMidiConfigurationManager.cpp
@@ -156,7 +156,7 @@ CMidi2VirtualMidiConfigurationManager::UpdateConfiguration(
     // TODO: Actual Success or fail response
     internal::JsonSetBoolProperty(
         responseObject,
-        MIDI_CONFIG_JSON_ENDPOINT_VIRTUAL_DEVICE_RESPONSE_SUCCESS_PROPERTY_KEY,
+        MIDI_CONFIG_JSON_CONFIGURATION_RESPONSE_SUCCESS_PROPERTY_KEY,
         true);
 
     TraceLoggingWrite(

--- a/src/api/Client/Midi2Client-Projection/nuget/Windows.Devices.Midi2.nuspec
+++ b/src/api/Client/Midi2Client-Projection/nuget/Windows.Devices.Midi2.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2012/06/nuspec.xsd">
 	<metadata>
 		<id>Windows.Devices.Midi2</id>
-		<version>1.0.0-preview.3-0155</version>
+		<version>1.0.0-preview.3-0156</version>
 		<authors>Microsoft Corporation</authors>
 		<description>Windows MIDI Services API. Minimum package necessary to use Windows MIDI Services from an app on a PC that has Windows MIDI Services installed.</description>
 		<license type="expression">MIT</license>

--- a/src/api/Client/Midi2Client/MidiEndpointDeviceInformation.cpp
+++ b/src/api/Client/Midi2Client/MidiEndpointDeviceInformation.cpp
@@ -111,13 +111,15 @@ namespace winrt::Windows::Devices::Midi2::implementation
         // Basics ============================================================================
         additionalProperties.Append(STRING_PKEY_MIDI_AbstractionLayer);
         additionalProperties.Append(STRING_PKEY_MIDI_TransportMnemonic);
+
         additionalProperties.Append(STRING_PKEY_MIDI_NativeDataFormat);
         additionalProperties.Append(STRING_PKEY_MIDI_SupportedDataFormats);
-        additionalProperties.Append(STRING_PKEY_MIDI_SupportsMulticlient);
-        additionalProperties.Append(STRING_PKEY_MIDI_TransportSuppliedEndpointName);
-        additionalProperties.Append(STRING_PKEY_MIDI_GenerateIncomingTimestamp);
 
-        additionalProperties.Append(STRING_PKEY_MIDI_TransportSuppliedDescription);       
+        additionalProperties.Append(STRING_PKEY_MIDI_TransportSuppliedEndpointName);
+        additionalProperties.Append(STRING_PKEY_MIDI_TransportSuppliedDescription);
+
+        additionalProperties.Append(STRING_PKEY_MIDI_SupportsMulticlient);
+        additionalProperties.Append(STRING_PKEY_MIDI_GenerateIncomingTimestamp);
 
         // USB / KS Properties ===============================================================
         // TODO: Group Terminal Blocks will likely be a single property

--- a/src/api/Client/Midi2Client/MidiService.cpp
+++ b/src/api/Client/Midi2Client/MidiService.cpp
@@ -357,7 +357,7 @@ namespace winrt::Windows::Devices::Midi2::implementation
         //   {
         //     "create"
         //     {
-        //        associationGuid:
+        //        "{associationGuid}":
         //        {
         //            "endpointA":
         //            {
@@ -374,34 +374,38 @@ namespace winrt::Windows::Devices::Midi2::implementation
 
         // build Endpoint A
 
-        internal::JsonGetWStringProperty(
+        internal::JsonSetWStringProperty(
             endpointDeviceAObject,
             MIDI_CONFIG_JSON_ENDPOINT_COMMON_NAME_PROPERTY,
             endpointDefinitionA.Name().c_str());
 
-        internal::JsonGetWStringProperty(
+        internal::JsonSetWStringProperty(
             endpointDeviceAObject,
             MIDI_CONFIG_JSON_ENDPOINT_COMMON_DESCRIPTION_PROPERTY,
             endpointDefinitionA.Description().c_str());
 
-        internal::JsonGetWStringProperty(
+        internal::JsonSetWStringProperty(
             endpointDeviceAObject,
             MIDI_CONFIG_JSON_ENDPOINT_COMMON_UNIQUE_ID_PROPERTY,
             endpointDefinitionA.UniqueId().c_str());
 
+
+        //MIDI_CONFIG_JSON_ENDPOINT_COMMON_MANUFACTURER_PROPERTY
+
+
         // build Endpoint B
 
-        internal::JsonGetWStringProperty(
+        internal::JsonSetWStringProperty(
             endpointDeviceBObject,
             MIDI_CONFIG_JSON_ENDPOINT_COMMON_NAME_PROPERTY,
             endpointDefinitionB.Name().c_str());
 
-        internal::JsonGetWStringProperty(
+        internal::JsonSetWStringProperty(
             endpointDeviceBObject,
             MIDI_CONFIG_JSON_ENDPOINT_COMMON_DESCRIPTION_PROPERTY,
             endpointDefinitionB.Description().c_str());
 
-        internal::JsonGetWStringProperty(
+        internal::JsonSetWStringProperty(
             endpointDeviceBObject,
             MIDI_CONFIG_JSON_ENDPOINT_COMMON_UNIQUE_ID_PROPERTY,
             endpointDefinitionB.UniqueId().c_str());
@@ -488,6 +492,8 @@ namespace winrt::Windows::Devices::Midi2::implementation
 
             auto jsonPayload = wrapperObject.Stringify();
 
+            // send up the payload
+
             internal::LogInfo(__FUNCTION__, jsonPayload.c_str());
             auto configUpdateResult = configManager->UpdateConfiguration(jsonPayload.c_str(), false, &response);
 
@@ -513,10 +519,8 @@ namespace winrt::Windows::Devices::Midi2::implementation
 
             internal::LogInfo(__FUNCTION__, L"JsonObjectFromBSTR success");
 
+            // parse the results
 
-
-
-            // check for actual success
             auto successResult = internal::JsonGetBoolProperty(responseObject, MIDI_CONFIG_JSON_ENDPOINT_LOOPBACK_DEVICE_RESPONSE_SUCCESS_PROPERTY_KEY, false);
 
             if (successResult)
@@ -555,7 +559,7 @@ namespace winrt::Windows::Devices::Midi2::implementation
             {
                 internal::LogGeneralError(__FUNCTION__, L"Loopback device creation failed (payload has false success value)");
 
-                return nullptr;
+                return *result;
             }
 
             internal::LogInfo(__FUNCTION__, L"Loopback device creation worked.");

--- a/src/api/Client/Midi2Client/MidiService.cpp
+++ b/src/api/Client/Midi2Client/MidiService.cpp
@@ -337,7 +337,7 @@ namespace winrt::Windows::Devices::Midi2::implementation
         auto result = winrt::make_self<implementation::MidiServiceLoopbackEndpointCreationResult>();
 
         // todo: grab this from a constant
-        winrt::hstring loopbackDeviceAbstractionId = L"{942BF02D-93C0-4EA8-B03E-D51156CA75E1}";
+        winrt::guid loopbackDeviceAbstractionId = internal::StringToGuid(L"{942BF02D-93C0-4EA8-B03E-D51156CA75E1}");
 
 
         json::JsonObject wrapperObject;
@@ -440,7 +440,7 @@ namespace winrt::Windows::Devices::Midi2::implementation
 
         internal::JsonSetObjectProperty(
             topLevelTransportPluginSettingsObject,
-            loopbackDeviceAbstractionId.c_str(),
+            internal::GuidToString(loopbackDeviceAbstractionId),
             abstractionObject);
 
 
@@ -453,11 +453,59 @@ namespace winrt::Windows::Devices::Midi2::implementation
 
         // send it up
 
+        json::JsonObject responseObject = InternalSendConfigurationJsonAndGetResponse(loopbackDeviceAbstractionId, wrapperObject);
 
+        // parse the results
+        auto successResult = internal::JsonGetBoolProperty(responseObject, MIDI_CONFIG_JSON_CONFIGURATION_RESPONSE_SUCCESS_PROPERTY_KEY, false);
+
+        if (successResult)
+        {
+            internal::LogInfo(__FUNCTION__, L"JSON payload indicates success");
+
+            auto deviceIdA = internal::JsonGetWStringProperty(responseObject, MIDI_CONFIG_JSON_ENDPOINT_LOOPBACK_DEVICE_RESPONSE_CREATED_ENDPOINT_A_ID_KEY, L"");
+            auto deviceIdB = internal::JsonGetWStringProperty(responseObject, MIDI_CONFIG_JSON_ENDPOINT_LOOPBACK_DEVICE_RESPONSE_CREATED_ENDPOINT_B_ID_KEY, L"");
+
+            if (deviceIdA.empty())
+            {
+                internal::LogGeneralError(__FUNCTION__, L"Unexpected empty Device Id A");
+
+                return *result;
+            }
+
+            if (deviceIdB.empty())
+            {
+                internal::LogGeneralError(__FUNCTION__, L"Unexpected empty Device Id B");
+
+                return *result;
+            }
+
+
+            // update the response object with the new ids
+
+            result->SetSuccess(associationId, deviceIdA.c_str(), deviceIdB.c_str());
+
+        }
+        else
+        {
+            internal::LogGeneralError(__FUNCTION__, L"Device creation failed (payload has false success value)");
+        }
+
+        return *result;
+    }
+
+
+    _Use_decl_annotations_
+    json::JsonObject MidiService::InternalSendConfigurationJsonAndGetResponse(
+        winrt::guid const& abstractionId, json::JsonObject const& configObject) noexcept
+    {
         auto iid = __uuidof(IMidiAbstractionConfigurationManager);
         winrt::com_ptr<IMidiAbstractionConfigurationManager> configManager;
 
         auto serviceAbstraction = winrt::create_instance<IMidiAbstraction>(__uuidof(Midi2MidiSrvAbstraction), CLSCTX_ALL);
+
+        // default to failed
+        auto response = internal::BuildConfigurationResponseObject(false);
+
 
         if (serviceAbstraction)
         {
@@ -465,126 +513,153 @@ namespace winrt::Windows::Devices::Midi2::implementation
 
             internal::LogInfo(__FUNCTION__, L"config manager activate call completed");
 
-
             if (FAILED(activateConfigManagerResult) || configManager == nullptr)
             {
-                internal::LogGeneralError(__FUNCTION__, L"Failed to create device. Config manager is null or call failed.");
+                internal::LogGeneralError(__FUNCTION__, L"Config manager is null or call failed.");
 
-                // return a fail result
-                return *result;
+                return response;
             }
 
-            internal::LogInfo(__FUNCTION__, L"config manager activate call SUCCESS");
+            internal::LogInfo(__FUNCTION__, L"Config manager activate call SUCCESS");
 
-            auto initializeResult = configManager->Initialize(internal::StringToGuid(loopbackDeviceAbstractionId.c_str()), nullptr);
-
+            auto initializeResult = configManager->Initialize(abstractionId, nullptr);
 
             if (FAILED(initializeResult))
             {
-                internal::LogGeneralError(__FUNCTION__, L"failed to initialize config manager");
+                internal::LogGeneralError(__FUNCTION__, L"Failed to initialize config manager");
 
                 // return a fail result
-                return *result;
+                return response;
             }
 
-            CComBSTR response{};
-            response.Empty();
+            CComBSTR responseString{};
+            responseString.Empty();
 
-            auto jsonPayload = wrapperObject.Stringify();
+            auto jsonPayload = configObject.Stringify();
 
             // send up the payload
 
             internal::LogInfo(__FUNCTION__, jsonPayload.c_str());
-            auto configUpdateResult = configManager->UpdateConfiguration(jsonPayload.c_str(), false, &response);
+            auto configUpdateResult = configManager->UpdateConfiguration(jsonPayload.c_str(), false, &responseString);
+
+            internal::LogInfo(__FUNCTION__, responseString);
+
 
             if (FAILED(configUpdateResult))
             {
                 internal::LogGeneralError(__FUNCTION__, L"Failed to configure endpoint");
 
                 // return a failed result
-                return *result;
-            }
-
-            internal::LogInfo(__FUNCTION__, L"configManager->UpdateConfiguration success");
-
-            json::JsonObject responseObject;
-
-            if (!internal::JsonObjectFromBSTR(&response, responseObject))
-            {
-                internal::LogGeneralError(__FUNCTION__, L"Failed to read json response object from loopback device creation");
-
-                // return a failed result
-                return *result;
-            }
-
-            internal::LogInfo(__FUNCTION__, L"JsonObjectFromBSTR success");
-
-            // parse the results
-
-            auto successResult = internal::JsonGetBoolProperty(responseObject, MIDI_CONFIG_JSON_ENDPOINT_LOOPBACK_DEVICE_RESPONSE_SUCCESS_PROPERTY_KEY, false);
-
-            if (successResult)
-            {
-                internal::LogInfo(__FUNCTION__, L"JSON payload indicates success");
-
-
-                // TODO: A and B are simple properties here. We don't need
-                // an array because we create one at a time through the API. And when
-                // created through the config file, there's no response object to 
-                // worry about.
-
-                auto deviceIdA = internal::JsonGetWStringProperty(responseObject, MIDI_CONFIG_JSON_ENDPOINT_LOOPBACK_DEVICE_RESPONSE_CREATED_ENDPOINT_A_ID_KEY, L"");
-                auto deviceIdB = internal::JsonGetWStringProperty(responseObject, MIDI_CONFIG_JSON_ENDPOINT_LOOPBACK_DEVICE_RESPONSE_CREATED_ENDPOINT_B_ID_KEY, L"");
-
-                if (deviceIdA.empty())
-                {
-                    internal::LogGeneralError(__FUNCTION__, L"Unexpected empty Device Id A");
-
-                    return *result;
-                }
-
-                if (deviceIdB.empty())
-                {
-                    internal::LogGeneralError(__FUNCTION__, L"Unexpected empty Device Id B");
-
-                    return *result;
-                }
-
-
-                // update the response object with the new ids
-
-                result->SetSuccess(associationId, deviceIdA.c_str(), deviceIdB.c_str());
+                return response;
             }
             else
             {
-                internal::LogGeneralError(__FUNCTION__, L"Loopback device creation failed (payload has false success value)");
+                json::JsonObject responseObject;
 
-                return *result;
+                if (internal::JsonObjectFromBSTR(&responseString, responseObject))
+                {
+                    return responseObject;
+                }
+                else
+                {
+                    // failed
+
+                    internal::LogGeneralError(__FUNCTION__, L"Unable to read response object from BSTR");
+
+                    return response;
+                }
             }
-
-            internal::LogInfo(__FUNCTION__, L"Loopback device creation worked.");
-
         }
         else
         {
             // failed
             internal::LogGeneralError(__FUNCTION__, L"Failed to create service abstraction");
 
+            return response;
         }
 
-        return *result;
     }
+
 
     _Use_decl_annotations_
     bool MidiService::RemoveTemporaryLoopbackEndpoints(_In_ winrt::guid const& associationId) noexcept
     {
         internal::LogInfo(__FUNCTION__, L"Enter");
 
-        UNREFERENCED_PARAMETER(associationId);
-        // TODO:
+        // todo: grab this from a constant
+        winrt::guid loopbackDeviceAbstractionId = internal::StringToGuid(L"{942BF02D-93C0-4EA8-B03E-D51156CA75E1}");
 
-        return false;
+        json::JsonObject wrapperObject;
+        json::JsonObject topLevelTransportPluginSettingsObject;
+        json::JsonObject abstractionObject;
+        json::JsonArray endpointDeletionArray;
+        
+        internal::LogInfo(__FUNCTION__, L" setting json properties");
+
+        // "endpointTransportPluginSettings":
+        // {
+        //   loopback endpoint abstraction guid :
+        //   {
+        //     "remove"
+        //     {
+        //        "{associationGuid}"
+        //     }
+        //   }
+        // }
+
+
+        // create the deletion node with the association object as the child property
+
+        json::JsonValue endpointDeletionAssociationId = json::JsonValue::CreateStringValue(internal::GuidToString(associationId).c_str());
+
+        endpointDeletionArray.Append(endpointDeletionAssociationId);
+
+        // create the abstraction object with the child creation node
+
+        internal::JsonSetArrayProperty(
+            abstractionObject,
+            MIDI_CONFIG_JSON_ENDPOINT_LOOPBACK_DEVICES_REMOVE_KEY,
+            endpointDeletionArray);
+
+        // create the main node
+
+        internal::JsonSetObjectProperty(
+            topLevelTransportPluginSettingsObject,
+            internal::GuidToString(loopbackDeviceAbstractionId),
+            abstractionObject);
+
+
+        // wrap it all up so the json is valid
+
+        internal::JsonSetObjectProperty(
+            wrapperObject,
+            MIDI_CONFIG_JSON_TRANSPORT_PLUGIN_SETTINGS_OBJECT,
+            topLevelTransportPluginSettingsObject);
+
+        // send it up
+
+        internal::LogInfo(__FUNCTION__, L"configManager->UpdateConfiguration success");
+
+        json::JsonObject responseObject = InternalSendConfigurationJsonAndGetResponse(loopbackDeviceAbstractionId, wrapperObject);
+
+
+
+        // parse the results
+        auto successResult = internal::JsonGetBoolProperty(responseObject, MIDI_CONFIG_JSON_CONFIGURATION_RESPONSE_SUCCESS_PROPERTY_KEY, false);
+
+        if (successResult)
+        {
+            internal::LogInfo(__FUNCTION__, L"JSON payload indicates success");
+        }
+        else
+        {
+            internal::LogGeneralError(__FUNCTION__, L"Loopback device removal failed (payload has false success value)");
+        }
+
+        return successResult;
     }
+
+
 
     _Use_decl_annotations_
     midi2::MidiServiceConfigurationResponse MidiService::UpdateTransportPluginConfiguration(
@@ -592,10 +667,42 @@ namespace winrt::Windows::Devices::Midi2::implementation
     {
         internal::LogInfo(__FUNCTION__, L"Enter");
         
-        UNREFERENCED_PARAMETER(configurationUpdate);
-        // TODO:
-
+        // this initializes to a failure state, so we can just return it when we have a fail
         auto response = winrt::make_self<implementation::MidiServiceConfigurationResponse>();
+
+
+        if (configurationUpdate != nullptr)
+        {
+            if (configurationUpdate.SettingsJson() != nullptr)
+            {
+                json::JsonObject responseJsonObject = InternalSendConfigurationJsonAndGetResponse(
+                    configurationUpdate.TransportId(),
+                    configurationUpdate.SettingsJson()
+                );
+
+
+
+
+                // TODO: Process return result
+
+
+
+
+            }
+            else
+            {
+                internal::LogGeneralError(__FUNCTION__, L"Configuration object SettingsJson is null");
+
+            }
+
+            // TODO: Process the return object
+
+        }
+        else
+        {
+            internal::LogGeneralError(__FUNCTION__, L"Configuration object is null");
+
+        }
 
         return *response;
 
@@ -608,9 +715,17 @@ namespace winrt::Windows::Devices::Midi2::implementation
         internal::LogInfo(__FUNCTION__, L"Enter");
         
         UNREFERENCED_PARAMETER(configurationUpdate);
-        // TODO:
-
+        // initializes to a failed value
         auto response = winrt::make_self<implementation::MidiServiceConfigurationResponse>();
+
+
+
+
+        // TODO: Implement this in service and API
+
+
+
+
 
         return *response;
     }

--- a/src/api/Client/Midi2Client/MidiService.h
+++ b/src/api/Client/Midi2Client/MidiService.h
@@ -45,8 +45,11 @@ namespace winrt::Windows::Devices::Midi2::implementation
             _In_ midi2::IMidiServiceMessageProcessingPluginConfiguration const& configurationUpdate) noexcept;
 
 
-    private:
 
+
+        static json::JsonObject MidiService::InternalSendConfigurationJsonAndGetResponse(_In_ winrt::guid const& abstractionId, _In_ json::JsonObject const& configObject) noexcept;
+
+    private:
 
 
     };

--- a/src/api/Client/Midi2Client/MidiServiceConfigurationResponse.cpp
+++ b/src/api/Client/Midi2Client/MidiServiceConfigurationResponse.cpp
@@ -12,12 +12,5 @@
 
 namespace winrt::Windows::Devices::Midi2::implementation
 {
-    winrt::Windows::Devices::Midi2::MidiServiceConfigurationResponseStatus MidiServiceConfigurationResponse::Status()
-    {
-        throw hresult_not_implemented();
-    }
-    hstring MidiServiceConfigurationResponse::ResponseJson()
-    {
-        throw hresult_not_implemented();
-    }
+
 }

--- a/src/api/Client/Midi2Client/MidiServiceConfigurationResponse.h
+++ b/src/api/Client/Midi2Client/MidiServiceConfigurationResponse.h
@@ -15,7 +15,16 @@ namespace winrt::Windows::Devices::Midi2::implementation
     {
         MidiServiceConfigurationResponse() = default;
 
-        winrt::Windows::Devices::Midi2::MidiServiceConfigurationResponseStatus Status();
-        hstring ResponseJson();
+        midi2::MidiServiceConfigurationResponseStatus Status() noexcept { return m_status; }
+
+        winrt::hstring ResponseJson() { return m_responseJson; }
+
+        void InternalSetStatus(_In_ midi2::MidiServiceConfigurationResponseStatus const status) noexcept { m_status = status; }
+        void InternalSetResponseJson(_In_ winrt::hstring const& responseJson) noexcept { m_responseJson = responseJson; }
+
+    private:
+        midi2::MidiServiceConfigurationResponseStatus m_status{ midi2::MidiServiceConfigurationResponseStatus::ErrorOther };
+
+        winrt::hstring m_responseJson{};
     };
 }

--- a/src/api/Client/Midi2Client/MidiSession.cpp
+++ b/src/api/Client/Midi2Client/MidiSession.cpp
@@ -319,6 +319,10 @@ namespace winrt::Windows::Devices::Midi2::implementation
         }
 
 
+
+        // TODO: Use the service function to send this.
+
+
         internal::LogInfo(__FUNCTION__, L"config manager initialize call SUCCESS");
 
         CComBSTR response;
@@ -328,6 +332,7 @@ namespace winrt::Windows::Devices::Midi2::implementation
         internal::LogInfo(__FUNCTION__, topLevelTransportPluginSettingsObject.Stringify().c_str());
 
         auto configUpdateResult = configManager->UpdateConfiguration(topLevelTransportPluginSettingsObject.Stringify().c_str(), false, &response);
+
 
         internal::LogInfo(__FUNCTION__, L"UpdateConfiguration returned");
 
@@ -352,7 +357,7 @@ namespace winrt::Windows::Devices::Midi2::implementation
         internal::LogInfo(__FUNCTION__, L"JsonObjectFromBSTR success");
 
         // check for actual success
-        auto successResult = internal::JsonGetBoolProperty(responseObject, MIDI_CONFIG_JSON_ENDPOINT_VIRTUAL_DEVICE_RESPONSE_SUCCESS_PROPERTY_KEY, false);
+        auto successResult = internal::JsonGetBoolProperty(responseObject, MIDI_CONFIG_JSON_CONFIGURATION_RESPONSE_SUCCESS_PROPERTY_KEY, false);
 
         if (successResult)
         {

--- a/src/api/Libs/AbstractionUtilities/inc/json_helpers.h
+++ b/src/api/Libs/AbstractionUtilities/inc/json_helpers.h
@@ -41,6 +41,7 @@ namespace json = ::winrt::Windows::Data::Json;
 #define MIDI_CONFIG_JSON_ENDPOINT_COMMON_NAME_PROPERTY                          L"name"
 #define MIDI_CONFIG_JSON_ENDPOINT_COMMON_DESCRIPTION_PROPERTY                   L"description"
 #define MIDI_CONFIG_JSON_ENDPOINT_COMMON_UNIQUE_ID_PROPERTY                     L"uniqueIdentifier"
+#define MIDI_CONFIG_JSON_ENDPOINT_COMMON_MANUFACTURER_PROPERTY                  L"manufacturer"
 
 
 #define MIDI_CONFIG_JSON_ENDPOINT_COMMON_USER_SUPPLIED_NAME_PROPERTY            L"userSuppliedName"

--- a/src/api/Libs/AbstractionUtilities/inc/json_helpers.h
+++ b/src/api/Libs/AbstractionUtilities/inc/json_helpers.h
@@ -49,6 +49,9 @@ namespace json = ::winrt::Windows::Data::Json;
 #define MIDI_CONFIG_JSON_ENDPOINT_COMMON_USER_SUPPLIED_SMALL_IMAGE_PROPERTY     L"userSuppliedSmallImage"
 #define MIDI_CONFIG_JSON_ENDPOINT_COMMON_USER_SUPPLIED_LARGE_IMAGE_PROPERTY     L"userSuppliedLargeImage"
 
+#define MIDI_CONFIG_JSON_CONFIGURATION_RESPONSE_SUCCESS_PROPERTY_KEY            L"success"
+#define MIDI_CONFIG_JSON_CONFIGURATION_RESPONSE_MESSAGE_PROPERTY_KEY            L"message"
+
 
 // Virtual MIDI (here because also needed by the client API)
 
@@ -60,7 +63,6 @@ namespace json = ::winrt::Windows::Data::Json;
 #define MIDI_CONFIG_JSON_ENDPOINT_VIRTUAL_DEVICE_UNIQUE_ID_MAX_LEN  32
 
 
-#define MIDI_CONFIG_JSON_ENDPOINT_VIRTUAL_DEVICE_RESPONSE_SUCCESS_PROPERTY_KEY          L"success"
 #define MIDI_CONFIG_JSON_ENDPOINT_VIRTUAL_DEVICE_RESPONSE_CREATED_DEVICES_ARRAY_KEY     L"createdDevices"
 #define MIDI_CONFIG_JSON_ENDPOINT_VIRTUAL_DEVICE_RESPONSE_CREATED_ID_PROPERTY_KEY       L"id"
 
@@ -74,7 +76,6 @@ namespace json = ::winrt::Windows::Data::Json;
 #define MIDI_CONFIG_JSON_ENDPOINT_LOOPBACK_DEVICE_ENDPOINT_B_KEY                    L"endpointB"
 
 
-#define MIDI_CONFIG_JSON_ENDPOINT_LOOPBACK_DEVICE_RESPONSE_SUCCESS_PROPERTY_KEY         L"success"
 #define MIDI_CONFIG_JSON_ENDPOINT_LOOPBACK_DEVICE_RESPONSE_CREATED_ENDPOINT_A_ID_KEY    L"endpointA"
 #define MIDI_CONFIG_JSON_ENDPOINT_LOOPBACK_DEVICE_RESPONSE_CREATED_ENDPOINT_B_ID_KEY    L"endpointB"
 
@@ -101,6 +102,11 @@ namespace json = ::winrt::Windows::Data::Json;
 
 namespace Windows::Devices::Midi2::Internal
 {
+    json::JsonObject BuildConfigurationResponseObject(_In_ bool const success);
+
+    void SetConfigurationResponseObjectFail(_In_ json::JsonObject& object, _In_ std::wstring message);
+
+
     bool JsonObjectFromBSTR(_In_ BSTR* const bstr, _Out_ json::JsonObject& obj) noexcept;
 
     bool JsonStringifyObjectToOutParam(_In_ json::JsonObject const& obj, _Out_ BSTR** outParam) noexcept;

--- a/src/api/Libs/AbstractionUtilities/src/json_helpers.cpp
+++ b/src/api/Libs/AbstractionUtilities/src/json_helpers.cpp
@@ -11,6 +11,37 @@
 namespace Windows::Devices::Midi2::Internal
 {
     _Use_decl_annotations_
+    void SetConfigurationResponseObjectFail(
+        json::JsonObject& object,
+        std::wstring message)
+    {
+        auto messageVal = json::JsonValue::CreateStringValue(message.c_str());
+        object.SetNamedValue(MIDI_CONFIG_JSON_CONFIGURATION_RESPONSE_MESSAGE_PROPERTY_KEY, messageVal);
+
+        auto successVal = json::JsonValue::CreateBooleanValue(false);
+        object.SetNamedValue(MIDI_CONFIG_JSON_CONFIGURATION_RESPONSE_SUCCESS_PROPERTY_KEY, messageVal);
+    }
+
+
+
+    _Use_decl_annotations_
+    json::JsonObject BuildConfigurationResponseObject(_In_ bool const success)
+    {
+        // the root object just has a wrapper with a success or fail property. Additional 
+        // properties depend on the specific use case and so are added in those cases.
+
+        json::JsonObject response;
+
+        json::JsonValue successValue = json::JsonValue::CreateBooleanValue(success);
+
+        response.SetNamedValue(MIDI_CONFIG_JSON_CONFIGURATION_RESPONSE_SUCCESS_PROPERTY_KEY, successValue);
+
+        return response;
+    }
+
+
+
+    _Use_decl_annotations_
     bool JsonObjectFromBSTR(BSTR* const bstr, json::JsonObject& obj) noexcept
     {
         if (bstr == nullptr) return false;

--- a/src/api/Test/Midi2.Client.unittests/MidiMessageSchedulerTests.cpp
+++ b/src/api/Test/Midi2.Client.unittests/MidiMessageSchedulerTests.cpp
@@ -48,9 +48,10 @@ void MidiMessageSchedulerTests::TestScheduledMessagesTiming(uint16_t const messa
 
     
     // calculate an acceptable timestamp offset
-    uint32_t acceptableTimestampDeltaMicroseconds = 200;    // 0.2ms
+    // We'll likely want to do better than this in the future, but 100 microseconds for scheduling isn't bad.
+    uint32_t acceptableTimestampDeltaMicroseconds = 100;    // 0.1ms
 
-    uint64_t acceptableTimestampDeltaTicks = (acceptableTimestampDeltaMicroseconds * MidiClock::TimestampFrequency()) / 1000000;
+    uint64_t acceptableTimestampDeltaTicks = (uint64_t)((acceptableTimestampDeltaMicroseconds * MidiClock::TimestampFrequency()) / 1000000.0);
 
 
     std::cout << "Acceptable timestamp delta is +/- " << std::dec << acceptableTimestampDeltaTicks << " ticks" << std::endl;
@@ -111,6 +112,11 @@ void MidiMessageSchedulerTests::TestScheduledMessagesTiming(uint16_t const messa
         auto sendResult = connSend.SendMessageWords(MidiClock::OffsetTimestampByMilliseconds(MidiClock::Now(), scheduledTimeStampOffsetMS), word);
 
         VERIFY_IS_TRUE(MidiEndpointConnection::SendMessageSucceeded(sendResult));
+
+        // if we don't sleep here, the send and receive, and the TAEF output, get in the 
+        // way of each other and mess up timing. That's entirely a client-side problem
+        // and isn't how "normal" apps would work anyway.
+        Sleep(1);
     }
 
     std::cout << "Waiting for response" << std::endl;

--- a/src/api/Transform/SchedulerTransform/Midi2.SchedulerMidiTransform.cpp
+++ b/src/api/Transform/SchedulerTransform/Midi2.SchedulerMidiTransform.cpp
@@ -239,11 +239,10 @@ CMidi2SchedulerMidiTransform::SendMidiMessage(
         }
         else
         {
-            // bypass scheduling for a stable release
-            auto hr = SendMidiMessageNow(data, size, timestamp);
-            return hr;
+            //// bypass scheduling for a stable release
+            //auto hr = SendMidiMessageNow(data, size, timestamp);
+            //return hr;
 
-#if false
             // otherwise, we schedule the message
 
             if (size >= MINIMUM_UMP_DATASIZE && size <= MAXIMUM_UMP_DATASIZE)
@@ -281,8 +280,6 @@ CMidi2SchedulerMidiTransform::SendMidiMessage(
                 // invalid data size
                 return HR_E_MIDI_SENDMSG_INVALID_MESSAGE;
             }
-#endif
-
         }
 
  //       return S_OK;


### PR DESCRIPTION
- Re-enabled scheduled message sending. We'll continue to test and monitor
- In the TAEF scheduler tests, lowered acceptable delta to 100 microseconds (1/10 millisecond) for the scheduler. We may do better over time, but this is a decent place to start.
- Rounded out the loopback MIDI API support to include full create and delete, all through the `MidiService` class
- Added example for creating simple loopback endpoints through the API