### PR TITLE
Issues #357, #356 and 245

### DIFF
--- a/src/api/Drivers/USBMIDI2/Driver/Device.cpp
+++ b/src/api/Drivers/USBMIDI2/Driver/Device.cpp
@@ -3073,6 +3073,7 @@ Return Value:
         case UMP_SYSTEM_UNDEFINED_F4:
         case UMP_SYSTEM_UNDEFINED_F5:
         case UMP_SYSTEM_UNDEFINED_F9:
+        case UMP_SYSTEM_UNDEFINED_FD:
             code_index = MIDI_CIN_SYSEX_END_1BYTE;
             break;
 

--- a/src/api/Drivers/USBMIDI2/Driver/Device.cpp
+++ b/src/api/Drivers/USBMIDI2/Driver/Device.cpp
@@ -2375,28 +2375,28 @@ Return Value:Amy
             case UMP_MT_UTILITY:
             case UMP_MT_SYSTEM:
             case UMP_MT_MIDI1_CV:
-            case 0x60: // undefined
-            case 0x70: // undefined
+            case UMP_MT_RESERVED_6:
+            case UMP_MT_RESERVED_7:
                 umpPacket.wordCount = 1;
                 break;
 
             case UMP_MT_DATA_64:
             case UMP_MT_MIDI2_CV:
-            case 0x80: // undefined
-            case 0x90: // undefined
-            case 0xa0: // undefined
+            case UMP_MT_RESERVED_8:
+            case UMP_MT_RESERVED_9:
+            case UMP_MT_RESERVED_A:
                 umpPacket.wordCount = 2;
                 break;
 
-            case 0xb0: // undefined
-            case 0xc0: // undefined
+            case UMP_MT_RESERVED_B:
+            case UMP_MT_RESERVED_C:
                 umpPacket.wordCount = 3;
                 break;
 
             case UMP_MT_DATA_128:
             case UMP_MT_FLEX_128:
             case UMP_MT_STREAM_128:
-            case 0xe0: // undefined
+            case UMP_MT_RESERVED_E:
                 umpPacket.wordCount = 4;
                 break;
 
@@ -2773,11 +2773,11 @@ Return Value:Amy
             if (pushUSBTransfer || !isMoreData)
             {
                 // Fill rest of buffer
-                while (pDeviceContext->DeviceWriteBufferIndex * sizeof(UINT32) < pDeviceContext->MidiOutMaxSize)
+/*                while (pDeviceContext->DeviceWriteBufferIndex * sizeof(UINT32) < pDeviceContext->MidiOutMaxSize)
                 {
                     pWriteMem[pDeviceContext->DeviceWriteBufferIndex++] = 0;
                 }
-
+*/
                 // Write to buffer
                 if (!USBMIDI2DriverSendToUSB(
                     pDeviceContext->DeviceUSBWriteRequest,

--- a/src/api/Drivers/USBMIDI2/Driver/Device.cpp
+++ b/src/api/Drivers/USBMIDI2/Driver/Device.cpp
@@ -2175,17 +2175,28 @@ Return Value:
                     case UMP_MT_UTILITY:
                     case UMP_MT_SYSTEM:
                     case UMP_MT_MIDI1_CV:
+                    case UMP_MT_RESERVED_6:
+                    case UMP_MT_RESERVED_7:
                         umpPacket.wordCount = 1;
                         break;
 
                     case UMP_MT_DATA_64:
                     case UMP_MT_MIDI2_CV:
+                    case UMP_MT_RESERVED_8:
+                    case UMP_MT_RESERVED_9:
+                    case UMP_MT_RESERVED_A:
                         umpPacket.wordCount = 2;
+                        break;
+
+                    case UMP_MT_RESERVED_B:
+                    case UMP_MT_RESERVED_C:
+                        umpPacket.wordCount = 3;
                         break;
 
                     case UMP_MT_DATA_128:
                     case UMP_MT_FLEX_128:
                     case UMP_MT_STREAM_128:
+                    case UMP_MT_RESERVED_E:
                         umpPacket.wordCount = 4;
                         break;
 
@@ -2772,12 +2783,6 @@ Return Value:Amy
 
             if (pushUSBTransfer || !isMoreData)
             {
-                // Fill rest of buffer
-/*                while (pDeviceContext->DeviceWriteBufferIndex * sizeof(UINT32) < pDeviceContext->MidiOutMaxSize)
-                {
-                    pWriteMem[pDeviceContext->DeviceWriteBufferIndex++] = 0;
-                }
-*/
                 // Write to buffer
                 if (!USBMIDI2DriverSendToUSB(
                     pDeviceContext->DeviceUSBWriteRequest,

--- a/src/api/Drivers/USBMIDI2/Driver/ump.h
+++ b/src/api/Drivers/USBMIDI2/Driver/ump.h
@@ -116,6 +116,7 @@ Environment:
 #define UMP_SYSTEM_START        0xfa  // status byte only
 #define UMP_SYSTEM_CONTINUE     0xfb  // status byte only
 #define UMP_SYSTEM_STOP         0xfc  // status byte only
+#define UMP_SYSTEM_UNDEFINED_FD 0xfd  // undefined
 #define UMP_SYSTEM_ACTIVE_SENSE 0xfe  // status byte only
 #define UMP_SYSTEM_RESET        0xff  // status byte only
 

--- a/src/api/Drivers/USBMIDI2/Driver/ump.h
+++ b/src/api/Drivers/USBMIDI2/Driver/ump.h
@@ -92,7 +92,7 @@ Environment:
 #define UMP_MT_DATA_128     0x50
 #define UMP_MT_RESERVED_6   0x60 // 32bits reserved future
 #define UMP_MT_RESERVED_7   0x70 // 32bits reserved future
-#define UMP_MT_RESERVED_8   0x80 // 54bits reserved future
+#define UMP_MT_RESERVED_8   0x80 // 64bits reserved future
 #define UMP_MT_RESERVED_9   0x90 // 64bits reserved future
 #define UMP_MT_RESERVED_A   0xA0 // 64bits reserved future
 #define UMP_MT_RESERVED_B   0xB0 // 96bits reserved future

--- a/src/api/Drivers/USBMIDI2/Driver/ump.h
+++ b/src/api/Drivers/USBMIDI2/Driver/ump.h
@@ -83,15 +83,23 @@ Environment:
 // UMP Protocol definitions
 //--------------------------------------------------------------------+
 // Message Types
-#define UMP_MT_MASK       0xf0
-#define UMP_MT_UTILITY    0x00
-#define UMP_MT_SYSTEM     0x10
-#define UMP_MT_MIDI1_CV   0x20
-#define UMP_MT_DATA_64    0x30
-#define UMP_MT_MIDI2_CV   0x40
-#define UMP_MT_DATA_128   0x50
-#define UMP_MT_FLEX_128   0xd0
-#define UMP_MT_STREAM_128 0xf0
+#define UMP_MT_MASK         0xf0
+#define UMP_MT_UTILITY      0x00
+#define UMP_MT_SYSTEM       0x10
+#define UMP_MT_MIDI1_CV     0x20
+#define UMP_MT_DATA_64      0x30
+#define UMP_MT_MIDI2_CV     0x40
+#define UMP_MT_DATA_128     0x50
+#define UMP_MT_RESERVED_6   0x60 // 32bits reserved future
+#define UMP_MT_RESERVED_7   0x70 // 32bits reserved future
+#define UMP_MT_RESERVED_8   0x80 // 54bits reserved future
+#define UMP_MT_RESERVED_9   0x90 // 64bits reserved future
+#define UMP_MT_RESERVED_A   0xA0 // 64bits reserved future
+#define UMP_MT_RESERVED_B   0xB0 // 96bits reserved future
+#define UMP_MT_RESERVED_C   0xC0 // 96bits reserved future
+#define UMP_MT_FLEX_128     0xd0
+#define UMP_MT_RESERVED_E   0xE0 // 128bits reserved future
+#define UMP_MT_STREAM_128   0xf0
 
 // Group Number
 #define UMP_GROUP_MASK    0x0f


### PR DESCRIPTION
PR Resolves Issues as follows:

#357 USB OUT packet is padded with NOOP up to the max packet size.
- removed addition of NOOPs in USB Packet OUT processing.

#356 usbmidi 2 isn't handling message type 0xb correctly
- filtering on USB IN packets of any reserved Message Types (not just 0xb). Removed filter.

#245 MIDI Service gets stuck.
- Missed one undefined system real-time type. Added to handling 0xfd.

