### PR TITLE
Issues #309 NOOP and #363

### DIFF
--- a/src/api/Drivers/USBMIDI2/Driver/Device.cpp
+++ b/src/api/Drivers/USBMIDI2/Driver/Device.cpp
@@ -2103,16 +2103,16 @@ Return Value:
 
         while (receivedIndex < receivedNumWords)
         {
-            // Do not need to process any NULL data (NOOP in UMP)
-            if (!pReceivedWords[receivedIndex])
-            {
-                receivedIndex++;
-                continue;
-            }
-
             // If indicating USB MIDI 1.0
             if (pDeviceContext->UsbMIDIbcdMSC == MIDI_CS_BCD_MIDI1)
             {
+                // Do not need to process any NULL data (NOOP in UMP)
+                if (!pReceivedWords[receivedIndex])
+                {
+                    receivedIndex++;
+                    continue;
+                }
+
                 // Need Cable Number
                 PUINT8 pBuffer = (PUINT8)&pReceivedWords[receivedIndex];
                 UINT8 cbl_num = (pBuffer[0] & 0xf0) >> 4;
@@ -2550,7 +2550,7 @@ Return Value:Amy
                 // How many bytes available in BS
                 numberBytes = (pDeviceContext->midi1OutSysex[cbl_num].usbMIDI1Head > pDeviceContext->midi1OutSysex[cbl_num].usbMIDI1Tail)
                     ? pDeviceContext->midi1OutSysex[cbl_num].usbMIDI1Head - pDeviceContext->midi1OutSysex[cbl_num].usbMIDI1Tail
-                    : (SYSEX_BS_RB_SIZE - pDeviceContext->midi1OutSysex[cbl_num].usbMIDI1Head) + pDeviceContext->midi1OutSysex[cbl_num].usbMIDI1Tail;
+                    : (SYSEX_BS_RB_SIZE - pDeviceContext->midi1OutSysex[cbl_num].usbMIDI1Tail) + pDeviceContext->midi1OutSysex[cbl_num].usbMIDI1Head;
 
                 while (numberBytes && umpWritePacket.wordCount < 4)
                 {


### PR DESCRIPTION
PR to pull in latest fixes to items identified:

Issue #309: NOOP
- driver was dropping any transmitted NOOP regardless if USB MIDI 1 or USB MIDI 2 device attached. Should only be USB MIDI 1 devices where NOOP is dropped as valid in case of USB MIDI 2. Resolved

Issue #363: MT3 to MIDI 1.0 conversion issue.
- Ring buffer management error discovered with certain SYSEX7 data being send to USB MIDI 1 device. Resolved and testing properly now.

Under Investigation:
- Issue#362 may have implications to the USB MIDI2 driver.