### PR TITLE
review feedback for improved parameter validation

### DIFF
--- a/src/api/Drivers/MinMidi/Driver/Common.h
+++ b/src/api/Drivers/MinMidi/Driver/Common.h
@@ -7,6 +7,7 @@
 #include <ks.h>
 #include <ksmedia.h>
 #include <wil\resource.h>
+#include <ntintsafe.h>
 
 #include "NewDelete.h"
 

--- a/src/api/Drivers/MinMidi2/Driver/StreamEngine.cpp
+++ b/src/api/Drivers/MinMidi2/Driver/StreamEngine.cpp
@@ -23,6 +23,10 @@ StreamEngine* g_MidiInStreamEngine {nullptr};
 // UMP 128 is 16 bytes
 #define MAXIMUM_UMP_DATASIZE 16
 
+// maximum buffer size is 0x100 pages.
+#define MAXIMUM_LOOPED_BUFFER_SIZE (PAGE_SIZE * 0x100)
+static_assert(    MAXIMUM_LOOPED_BUFFER_SIZE < ULONG_MAX/2, "The maximum looped buffer size may not exceed 1/2 MAX_ULONG");
+
 _Use_decl_annotations_
 StreamEngine::StreamEngine(
     _In_ ACXPIN Pin
@@ -562,6 +566,9 @@ StreamEngine::GetSingleBufferMapping(
 {
     PAGED_CODE();
 
+    // The allocation must not be 0
+    NT_RETURN_NTSTATUS_IF(STATUS_INVALID_PARAMETER, BufferSize == 0);
+
     // The allocation must be a multiple of the page size,
     // as entire pages are mapped.
     NT_RETURN_NTSTATUS_IF(STATUS_INVALID_PARAMETER, (BufferSize % PAGE_SIZE) != 0);
@@ -891,13 +898,23 @@ StreamEngine::GetLoopedStreamingBuffer(
     // so that we can double map it on the page boundary, so we're
     // going to round this number up to the nearest page.
     ULONG bufferSize = BufferSize;
+    ULONG testResult {0};
+
+    // The allocation must not be 0
+    NT_RETURN_NTSTATUS_IF(STATUS_INVALID_PARAMETER, bufferSize == 0);
 
     // if adding a page to the buffer size causes it to overflow, the requested size is
     // an invalid parameter.
-    NT_RETURN_NTSTATUS_IF(STATUS_INVALID_PARAMETER, (bufferSize + PAGE_SIZE) < bufferSize);
+    NT_RETURN_NTSTATUS_IF(STATUS_INVALID_PARAMETER, !NT_SUCCESS(RtlULongAdd(bufferSize, PAGE_SIZE, &testResult)));
 
     // round to the nearest page
     bufferSize = ROUND_TO_PAGES(bufferSize);
+
+    // If the adjusted buffer size is larger than the maximum permitted, fail the request.
+    NT_RETURN_NTSTATUS_IF(STATUS_INVALID_PARAMETER, bufferSize > MAXIMUM_LOOPED_BUFFER_SIZE);
+
+    // If the adjusted buffer size cannot be doubled, fail the request.
+    NT_RETURN_NTSTATUS_IF(STATUS_INVALID_PARAMETER, !NT_SUCCESS(RtlULongMult(bufferSize, 2, &testResult)));
 
     // Create our mapping to user mode w/ the double buffer.
     NT_RETURN_IF_NTSTATUS_FAILED(GetDoubleBufferMapping(bufferSize, UserMode, nullptr, &m_ClientBufferMapping));
@@ -934,6 +951,9 @@ StreamEngine::GetLoopedStreamingRegisters(
 
     // this is only applicable if this is a looped pin instance.
     NT_RETURN_NTSTATUS_IF(STATUS_NOT_IMPLEMENTED, FALSE == m_IsLooped);
+
+    // registers already created, can't create again.
+    NT_RETURN_NTSTATUS_IF(STATUS_ALREADY_INITIALIZED, nullptr != m_ReadRegister);
 
     // in the event of failure, clean up any partial mappings.
     auto cleanupOnFailure = wil::scope_exit([&]() {
@@ -986,7 +1006,7 @@ StreamEngine::SetLoopedStreamingNotificationEvent(
     NT_RETURN_IF_NTSTATUS_FAILED(ObReferenceObjectByHandle(Buffer->WriteEvent,
                                               EVENT_MODIFY_STATE,
                                               *ExEventObjectType,
-                                              ExGetPreviousMode(),
+                                              UserMode,
                                               (PVOID*)&m_WriteEvent,
                                               nullptr));
 
@@ -997,7 +1017,7 @@ StreamEngine::SetLoopedStreamingNotificationEvent(
     NT_RETURN_IF_NTSTATUS_FAILED(ObReferenceObjectByHandle(Buffer->ReadEvent,
                                               EVENT_MODIFY_STATE,
                                               *ExEventObjectType,
-                                              ExGetPreviousMode(),
+                                              UserMode,
                                               (PVOID*)&m_ReadEvent,
                                               nullptr));
 

--- a/src/api/Drivers/USBMIDI2/Driver/Device.cpp
+++ b/src/api/Drivers/USBMIDI2/Driver/Device.cpp
@@ -1025,10 +1025,14 @@ Return Value:
         pSettingPairs[interfaceCount].SettingIndex = pDeviceContext->UsbMIDIStreamingAlt;
 
         // Determine Version of the selected MIDI Interface
-        PUSB_INTERFACE_DESCRIPTOR pInterfaceDescriptor = USBD_ParseConfigurationDescriptor(
+        PUSB_INTERFACE_DESCRIPTOR pInterfaceDescriptor = USBD_ParseConfigurationDescriptorEx(
             pConfigurationDescriptor,               // Descriptor Buffer
+            pConfigurationDescriptor,               // Start Position
             pDeviceContext->UsbMIDIInterfaceNumber, // Interface Number
-            pDeviceContext->UsbMIDIStreamingAlt     // Alternate Setting
+            pDeviceContext->UsbMIDIStreamingAlt,    // Alternate Setting
+            -1,                                     // Interface Class
+            -1,                                     // Interface Subclass
+            -1                                      // Interfae Protocol
         );
         if (!pInterfaceDescriptor)
         {
@@ -1639,11 +1643,16 @@ Return Value:
     }
 
     // Find the relevant interface
-    PUSB_INTERFACE_DESCRIPTOR pInterfaceDescriptor = USBD_ParseConfigurationDescriptor(
+    PUSB_INTERFACE_DESCRIPTOR pInterfaceDescriptor = USBD_ParseConfigurationDescriptorEx(
         pConfigurationDescriptor,        // Descriptor Buffer
+        pConfigurationDescriptor,        // Start Position
         pDevCtx->UsbMIDIInterfaceNumber, // Interface Number
-        pDevCtx->UsbMIDIStreamingAlt     // Alternate Setting
+        pDevCtx->UsbMIDIStreamingAlt,    // Alternate Setting
+        -1,                              // Interface Class
+        -1,                              // Interface Subclass
+        -1                               // Interfae Protocol
     );
+
     if (!pInterfaceDescriptor)
     {
         status = STATUS_INSUFFICIENT_RESOURCES;
@@ -1940,10 +1949,14 @@ Return Value:
     }
  
     // Find the relevant interface
-    PUSB_INTERFACE_DESCRIPTOR pInterfaceDescriptor = USBD_ParseConfigurationDescriptor(
+    PUSB_INTERFACE_DESCRIPTOR pInterfaceDescriptor = USBD_ParseConfigurationDescriptorEx(
         pConfigurationDescriptor,        // Descriptor Buffer
+        pConfigurationDescriptor,        // Start Position
         pDevCtx->UsbMIDIInterfaceNumber, // Interface Number
-        pDevCtx->UsbMIDIStreamingAlt     // Alternate Setting
+        pDevCtx->UsbMIDIStreamingAlt,    // Alternate Setting
+        -1,                              // Interface Class
+        -1,                              // Interface Subclass
+        -1                               // Interfae Protocol
     );
     if (!pInterfaceDescriptor)
     {

--- a/src/api/Inc/MidiDefs.h
+++ b/src/api/Inc/MidiDefs.h
@@ -49,6 +49,10 @@
 // per message
 #define MAXIMUM_LIBMIDI2_BYTESTREAM_DATASIZE 20
 
+// maximum buffer size is 0x100 pages.
+#define MAXIMUM_LOOPED_BUFFER_SIZE (PAGE_SIZE * 0x100)
+static_assert(    MAXIMUM_LOOPED_BUFFER_SIZE < ULONG_MAX/2, "The maximum looped buffer size may not exceed 1/2 MAX_ULONG");
+
 // speed of a standard MIDI 1.0 connection. Used in the SDK, and will be used in
 // transforms or service in the future when we introduce optional throttling
 #define MIDI_1_STANDARD_BITS_PER_SECOND 31250

--- a/src/api/Service/Exe/MidiClientManager.cpp
+++ b/src/api/Service/Exe/MidiClientManager.cpp
@@ -918,6 +918,11 @@ CMidiClientManager::CreateMidiClient(
     BOOL internalProtocolNegotiationUseOnly
 )
 {
+    // Reject invalid data flows
+    RETURN_HR_IF(E_INVALIDARG, creationParams->Flow != MidiFlowIn && 
+                                creationParams->Flow != MidiFlowOut && 
+                                creationParams->Flow != MidiFlowBidirectional);
+
     TraceLoggingWrite(
         MidiSrvTelemetryProvider::Provider(),
         MIDI_TRACE_EVENT_INFO,

--- a/src/api/Test/Midi2.Driver.unittests/Midi2DriverTests.h
+++ b/src/api/Test/Midi2.Driver.unittests/Midi2DriverTests.h
@@ -34,6 +34,7 @@ public:
     TEST_METHOD(TestCyclicUMPMidiIO_ManyMessages);
     TEST_METHOD(TestCyclicByteStreamMidiIO_ManyMessages);
     TEST_METHOD(TestStandardMidiIO_ManyMessages);
+    TEST_METHOD(TestCyclicUMPMidiIO_ManyMessages_BufferSizes);
 
     TEST_METHOD(TestCyclicUMPMidiIO_Latency);
     TEST_METHOD(TestCyclicByteStreamMidiIO_Latency);
@@ -42,6 +43,14 @@ public:
     TEST_METHOD(TestCyclicUMPMidiIOSlowMessages_Latency);
     TEST_METHOD(TestCyclicByteStreamMidiIOSlowMessages_Latency);
     TEST_METHOD(TestStandardMidiIOSlowMessages_Latency);
+
+    TEST_METHOD(TestBufferAllocationLimits);
+
+    TEST_METHOD(TestExtraPinCreation);
+    TEST_METHOD(TestLoopedBufferInitialization);
+    TEST_METHOD(TestLoopedRegisterInitialization);
+    TEST_METHOD(TestLoopedEventInitialization);
+    TEST_METHOD(TestSetState);
 
     Midi2DriverTests()
     {}
@@ -62,7 +71,7 @@ public:
 
 private:
     void TestMidiIO(MidiTransport transport);
-    void TestMidiIO_ManyMessages(MidiTransport transport);
+    void TestMidiIO_ManyMessages(MidiTransport transport, ULONG bufferSize);
     void TestMidiIO_Latency(MidiTransport transport, BOOL delayedMessages);
     
     std::function<void(PVOID, UINT32, LONGLONG, LONGLONG)> m_MidiInCallback;

--- a/src/api/Test/Midi2.Service.unittests/Midi2ServiceTests.h
+++ b/src/api/Test/Midi2.Service.unittests/Midi2ServiceTests.h
@@ -33,6 +33,7 @@ public:
 
     //Generic Tests
     TEST_METHOD(TestMidiServiceClientRPC);
+    TEST_METHOD(TestMidiServiceInvalidCreationParams);
 
     Midi2ServiceTests()
     {}


### PR DESCRIPTION
Improved validation and testing of buffer size requests, prefer use of USBD_ParseConfigurationDescriptorEx, add "GenericMidiEndpoint" compat id, and MIDISRV\MidiEndpoints for hardware id to midi 2 swd's, to enable future grouping in device manager. Add test cases for buffer size validation.