### PR TITLE
Multiple Canary bug fixes, plus tweak to MIDI 1 port names

### DIFF
--- a/src/api/Client/WinMM/MidiSrvPort.cpp
+++ b/src/api/Client/WinMM/MidiSrvPort.cpp
@@ -431,27 +431,106 @@ CMidiPort::Callback(_In_ PVOID data, _In_ UINT size, _In_ LONGLONG position, LON
         DWORD callbackDataRemaining {size};
         BYTE *callbackData = (BYTE *)data;
 
-        bool processingSysExStartByte = false;
+
+        // The data in here is all coming from midisrv, so we can make a few assumptions:
+        // 
+        // 1. No running status. Messages translated from UMP to bytestream do not use
+        //    running status at all. 
+        // 
+        // 2. Messages that fit into a single UMP will not be interrupted by system
+        //    real-time messages. So the MIDI 1.0 scenario where a clock message could
+        //    show up in between the data bytes in a channel voice message will not 
+        //    happen here.
+        // 
+        // 3. SysEx messages could be interrupted by system real-time messages, so 
+        //    we do need to handle that case. 
+        // 
+        // 4. SysEx messages could be interrupted by non-sysex, non-real-time messages
+        //
+        // 5. SysEx messages could be incomplete. It's possible to send a SysEx start
+        //    UMP and never send a SysEx complete UMP
+        //
+        // 6. SysEx start messages could be incorrect. For example, we could get a 
+        //    SysEx start message followed by another SysEx start message. This 
+        //    violates the protocol, but it's possible. We'd need to look into what
+        //    libmidi2 does in that case, but should also guard against that here.
+
+
+        // the message we're building
+        BYTE inProgressMidiMessage[3]{ 0 };         // status, data 1, data 2
+        BYTE countMidiMessageBytesReceived = 0;
+
+        LPMIDIHDR buffer{ nullptr };
 
         // keep processing until we run out of callback data
+        // we process one byte at a time here
         while (callbackDataRemaining > 0 && started)
         {
-            // If this is a sysex message, then go into InSysex
-            // state
-            if (MIDI_SYSEX == *callbackData)
+            if (MIDI_BYTE_IS_SYSTEM_REALTIME_STATUS(*callbackData))
             {
-                m_IsInSysex = true;
-                m_RunningStatus = 0;
-                processingSysExStartByte = true;
+                // Handle all system real-time messages
+
+                // send the single-byte message immediately
+                // do not add it to the inProgressMidiMessage or any buffer even though
+                // this shouldn't happen with midisrv-supplied message data (this is here
+                // in case libmidi2 promotes real-time when other messages are in progress)
+
+                // Convert from the QPC time to the number of ticks elapsed from the start time.
+                DWORD ticks = (DWORD)(((position - startTime) / m_qpcFrequency) * 1000.0);
+                UINT32 midiMessage = *callbackData;
+                WinmmClientCallback(MIM_DATA, midiMessage, ticks);
             }
-
-            if (m_IsInSysex)
+            else if (!m_IsInSysex)
             {
-                // if we're processing a sysex message, then we need a buffer to deliver
-                // the data in, retrieve it, getting either a previously incomplete buffer
-                // or a new one.
-                LPMIDIHDR buffer {nullptr};
+                if (MIDI_BYTE_IS_SYSEX_START_STATUS(*callbackData))
+                {
+                    // Handle putting us into SysEx transfer state if appropriate.
 
+                    m_IsInSysex = true;
+
+                    // start the buffer, add the F0
+
+                    {
+                        auto lock = m_BuffersLock.lock();
+                        if (!m_InBuffers.empty())
+                        {
+                            buffer = m_InBuffers.front();
+                        }
+                    }
+
+                    if (buffer)
+                    {
+                        BYTE* bufferData = (((BYTE*)buffer->lpData) + buffer->dwBytesRecorded);
+
+                        *bufferData = *callbackData;
+                        ++bufferData;
+                        ++buffer->dwBytesRecorded;
+                    }
+                }
+                else if (MIDI_BYTE_IS_STATUS_BYTE(*callbackData))
+                {
+                    // start a new message
+                    inProgressMidiMessage[0] = *callbackData;
+                    countMidiMessageBytesReceived = 1;
+                }
+                else if (MIDI_BYTE_IS_DATA_BYTE(*callbackData))
+                {
+                    // Handle a data byte, and not sysex.
+
+                    if (countMidiMessageBytesReceived > 0 && countMidiMessageBytesReceived < 3)
+                    {
+                        inProgressMidiMessage[countMidiMessageBytesReceived] = *callbackData;
+                        countMidiMessageBytesReceived++;
+                    }
+                    else
+                    {
+                        // > 3 message bytes received or we have no status byte. We got extra data somehow. This is an error. Discard
+                    }
+                }
+
+            }
+            else if (m_IsInSysex)
+            {
                 {
                     auto lock = m_BuffersLock.lock();
                     if (!m_InBuffers.empty())
@@ -460,208 +539,99 @@ CMidiPort::Callback(_In_ PVOID data, _In_ UINT size, _In_ LONGLONG position, LON
                     }
                 }
 
-                // we were able to successfully retrieve a buffer, now fill it.
                 if (buffer)
                 {
-                    bool sendThisSysExBuffer = false;
-
-                    // our data position within the buffer is the start of the buffer, indexed in
-                    // by how much has already been written.
-                    BYTE *bufferData = (((BYTE *)buffer->lpData) + buffer->dwBytesRecorded);
-
-                    // copy the data, inspecting them as we go looking for messages which would
-                    // cause us to complete the sysex message in progress.
-                    // We're done when we either run out of data to copy, run out of space to put it
-                    // in this buffer, or hit something that causes this sysex to end or be terminated.
-                    while (callbackDataRemaining > 0 &&
-                        (buffer->dwBytesRecorded < buffer->dwBufferLength))
+                    // Closing F7 needs to be added to the buffer, so we handle that here.
+                    if (MIDI_BYTE_IS_DATA_BYTE(*callbackData) || MIDI_BYTE_IS_SYSEX_END_STATUS(*callbackData))
                     {
-                        if (!processingSysExStartByte && 0 != (*callbackData & MIDI_STATUSBYTEFILTER))
+                        // either the end byte or a data byte, for sysex. Either way, add it to the buffer
+                        if (buffer)
                         {
-                            // this is a status byte message, we're going to need some additional checks.
+                            BYTE* bufferData = (((BYTE*)buffer->lpData) + buffer->dwBytesRecorded);
 
-                            // we're in a sysex block and somehow received a normal midi message,
-                            // that's an error, complete the sysex and exit out of processing sysex.
-                            if (*callbackData == MIDI_EOX)
+                            *bufferData = *callbackData;
+                            ++bufferData;
+                            ++buffer->dwBytesRecorded;
+
+                            // the byte we received is a proper sysex end byte, so complete it
+                            if (MIDI_BYTE_IS_SYSEX_END_STATUS(*callbackData))
                             {
-                                *bufferData = *callbackData;
-
-                                ++callbackData;
-                                ++bufferData;
-
-                                ++buffer->dwBytesRecorded;
-                                --callbackDataRemaining;
-
-                                sendThisSysExBuffer = true; // we want to just set a flag here, and not send, just in case we're also at the very end of the buffer
                                 m_IsInSysex = false;
-                                break;
-                            }
-                            else if (*callbackData < MIDI_SYSEX)
-                            {
-                                RETURN_IF_FAILED(CompleteLongBuffer(MIM_LONGERROR, position));
-                                m_IsInSysex = false;
-                                break;
-                            }
-                            else if (MIDI_SYSTEM_REALTIME_FILTER != (*callbackData & MIDI_SYSTEM_REALTIME_FILTER))
-                            {
-                                // a sys-ex block is supposed to end with a MIDI_EOX, however
-                                // any valid MIDI status byte CAN end a sys-ex block EXCEPT
-                                // for system real-time messages (0xF8 to 0xFF)
-
-                                // we have a valid end of sys-ex byte, so turn off
-                                // m_bIsInSysEx
                                 RETURN_IF_FAILED(CompleteLongBuffer(MIM_LONGDATA, position));
-                                m_IsInSysex = false;
-                                break;
                             }
+                            else if (buffer->dwBytesRecorded == buffer->dwBufferLength)
+                            {
+                                // The buffer is full, send what we have, but we are still in SysEx mode
+                                RETURN_IF_FAILED(CompleteLongBuffer(MIM_LONGDATA, position));
+                            }
+
+                        }
+                    }
+                    else if (MIDI_BYTE_IS_STATUS_BYTE(*callbackData))
+                    {
+                        // other statuses do not get added to the buffer, so we handle it here.
+
+                        m_IsInSysex = false;
+
+                        // send current SysEx buffer because any status byte that
+                        // is not a real-time status byte will terminate current SysEx
+                        if (buffer)
+                        {
+                            RETURN_IF_FAILED(CompleteLongBuffer(MIM_LONGERROR, position));
                         }
 
-
-                        // it's not an interrupting status byte, so copy it to the buffer and advance our positions.
-                        //*callbackData = *bufferData;
-                        *bufferData = *callbackData;
-
-                        ++callbackData;
-                        ++bufferData;
-
-                        ++buffer->dwBytesRecorded;
-                        --callbackDataRemaining;
-
-                        // if we were processing the F0 before, we are no longer
-                        processingSysExStartByte = false;
-                    }
-
-                    // if we are still in sysex and completed this buffer, we can deliver it, the
-                    // next iteration will require a new buffer.
-
-                    // NOTE to Gary: If any of the other cases above are true (real time etc.) and the 
-                    // buffer is also full, then we end up completing the buffer twice, which would cause
-                    // the data to be sent twice.
-                    if (sendThisSysExBuffer || (buffer->dwBufferLength == buffer->dwBytesRecorded))
-                    {
-                        RETURN_IF_FAILED(CompleteLongBuffer(MIM_LONGDATA, position));
+                        if (MIDI_BYTE_IS_SYSEX_START_STATUS(*callbackData))
+                        {
+                            continue;  // skip moving on to the next byte so this byte gets reprocessed
+                        }
+                        else
+                        {
+                            // it was a regular status byte that terminated SysEx. Start a new message
+                            inProgressMidiMessage[0] = *callbackData;
+                            countMidiMessageBytesReceived = 1;
+                        }
                     }
                 }
-                // we have remaining callback data, but no buffer available, wait for either a buffer
-                // or the port to be stopped.
                 else
                 {
-                    // Wait for either a buffer to be added, or the pin to be stopped,
-                    // it doesn't matter which wakes us.
+                    // we have remaining callback data, but no buffer available, wait for either a buffer
+                    // or the port to be stopped. Note: this blocks other data processing
+
                     HANDLE handles[] = { m_BuffersAdded.get(), m_Stopped.get() };
                     WaitForMultipleObjects(ARRAYSIZE(handles), handles, FALSE, INFINITE);
                 }
+
             }
-            else
+
+
+            // do we have a complete non-SysEx message to send? If so, send it
+            if (countMidiMessageBytesReceived == 3 && MIDI_MESSAGE_IS_THREE_BYTES(inProgressMidiMessage[0]) ||
+                countMidiMessageBytesReceived == 2 && MIDI_MESSAGE_IS_TWO_BYTES(inProgressMidiMessage[0]) ||
+                countMidiMessageBytesReceived == 1 && MIDI_MESSAGE_IS_ONE_BYTE(inProgressMidiMessage[0]))
             {
-                // Note to Gary: Technically, the flow below is not exactly correct.
-                // The reason is that a system real-time message in MIDI can interrupt
-                // even the data bytes of a message (and even when using running status). 
-                // So you have to process a byte at a time, allowing for those real-time 
-                // messages when present. From midi.org: 
-                // "To help ensure accurate timing, System Real Time messages 
-                //  are given priority over other messages, and these single-byte messages 
-                //  may occur anywhere in the data stream (a Real Time message may appear 
-                //  between the status byte and data byte of some other MIDI message)."
-                // Now, we're unlikely to run into that in data coming from the service
-                // but it could certainly be present in data coming from MIDI 1 apps
-                // More helpful info on running status http://midi.teragonaudio.com/tech/midispec/run.htm
-
-                // not in a sysex message, process this as a normal message
-                // Guaranteed to have at least 1 byte worth of data available
-                // at this point.
-                BYTE status = callbackData[0];
-                BYTE data1 = 0;
-                BYTE data2 = 0;
-                bool dataWritten = false;
-
-                // system messages which are not real-time terminate
-                // running status
-                if ((status >= MIDI_SYSEX) && (status <= MIDI_EOX))
+                // Convert from the QPC time to the number of ticks elapsed from the start time.
+                DWORD ticks = (DWORD)(((position - startTime) / m_qpcFrequency) * 1000.0);
+                UINT32 midiMessage{ inProgressMidiMessage[0] };
+                
+                if (MIDI_MESSAGE_IS_TWO_BYTES(inProgressMidiMessage[0]) || MIDI_MESSAGE_IS_THREE_BYTES(inProgressMidiMessage[0]))
                 {
-                    m_RunningStatus = 0;
+                    midiMessage |= (inProgressMidiMessage[1] << 8);
                 }
 
-                // tune request, timing, etc. are all 1 byte messages.
-                if (MIDI_MESSAGE_IS_ONE_BYTE(status) &&
-                    callbackDataRemaining >= 1)
+                if (MIDI_MESSAGE_IS_THREE_BYTES(inProgressMidiMessage[0]))
                 {
-                    callbackData+=1;
-                    callbackDataRemaining-=1;
-                    dataWritten = true;
-                }
-                // song select etc
-                else if (MIDI_MESSAGE_IS_TWO_BYTES(status) &&
-                    callbackDataRemaining >= 2)
-                {
-                    data1 = callbackData[1];
-                    callbackData+=2;
-                    callbackDataRemaining-=2;
-                    dataWritten = true;
-                }
-                // all other status byte messages are 3 bytes,
-                // MIDI_MTC, MIDI_SONGPP
-                else if (0 != (status & MIDI_STATUSBYTEFILTER) && 
-                    callbackDataRemaining >= 3)
-                {
-                    if(status < MIDI_SYSEX)  // don't save system common or system realtime as running status
-                    {
-                        m_RunningStatus = status;
-                    }
-
-                    data1 = callbackData[1];
-                    data2 = callbackData[2];
-                    callbackData+=3;
-                    callbackDataRemaining-=3;
-                    dataWritten = true;
+                    midiMessage |= (inProgressMidiMessage[2] << 16);
                 }
 
-                // if it's not a message with a status byte, it should be
-                // running status, which requires 2 bytes, and our running
-                // status should be valid.
-                // NOTE To Gary: Running status can be 1 or 2 bytes.
-                else if((0 == (status & MIDI_STATUSBYTEFILTER)) && 
-                    (0 != (m_RunningStatus & MIDI_STATUSBYTEFILTER)) &&
-                    callbackDataRemaining >= 2)
-                {
-                    status = m_RunningStatus;
-                    data1 = callbackData[0];
-                    data2 = callbackData[1];
+                WinmmClientCallback(MIM_DATA, midiMessage, ticks);
 
-                    // running status only consumes 2 bytes
-                    callbackData+=2;
-                    callbackDataRemaining-=2;
-                    dataWritten = true;
-                }
-                else
-                {
-                    // this is an unknown condition, the amount of available
-                    // data doesn't align to the type of message being processed,
-                    // or we don't have a status byte and aren't in a running status.
-
-                    assert(0);
-
-                    callbackData+=1;
-                    callbackDataRemaining-=1;
-                    // data not written, this byte ignored.
-
-                    TraceLoggingWrite(
-                        WdmAud2TelemetryProvider::Provider(),
-                        MIDI_TRACE_EVENT_WARNING,
-                        TraceLoggingString(__FUNCTION__, MIDI_TRACE_EVENT_LOCATION_FIELD),
-                        TraceLoggingLevel(WINEVENT_LEVEL_WARNING),
-                        TraceLoggingWideString(L"Invalid state, dropping data", MIDI_TRACE_EVENT_MESSAGE_FIELD),
-                        TraceLoggingPointer(this, "this"));
-                }
-
-                if (dataWritten)
-                {
-                    // Convert from the QPC time to the number of ticks elapsed from the start time.
-                    DWORD ticks = (DWORD) (((position - startTime) / m_qpcFrequency) * 1000.0);
-                    UINT32 midiMessage = status | (data1 << 8) | (data2 << 16);
-                    WinmmClientCallback(MIM_DATA, midiMessage, ticks);
-                }
+                countMidiMessageBytesReceived = 0;
+                inProgressMidiMessage[0] = 0;
             }
+
+            // move to the next byte of data in the loop
+            ++callbackData;
+            --callbackDataRemaining;
 
             // before we continue on to the next buffer, we need to find out if the
             // port is still running.

--- a/src/api/Client/WinMM/MidiSrvPort.h
+++ b/src/api/Client/WinMM/MidiSrvPort.h
@@ -66,6 +66,22 @@
                     status >= MIDI_NOTEOFF && \
                     status < MIDI_SYSEX)
 
+#define MIDI_BYTE_IS_STATUS_BYTE(b) (\
+                    (b & MIDI_STATUSBYTEFILTER) == MIDI_STATUSBYTEFILTER)
+
+#define MIDI_BYTE_IS_SYSTEM_REALTIME_STATUS(b) (\
+                    (b & MIDI_SYSTEM_REALTIME_FILTER) == MIDI_SYSTEM_REALTIME_FILTER)
+
+#define MIDI_BYTE_IS_SYSEX_START_STATUS(b) (\
+                    b == MIDI_SYSEX)
+
+#define MIDI_BYTE_IS_SYSEX_END_STATUS(b) (\
+                    b == MIDI_EOX)
+
+#define MIDI_BYTE_IS_DATA_BYTE(b) (\
+                    (b &  MIDI_STATUSBYTEFILTER) == 0)
+
+
 
 class CMidiPort :
     public Microsoft::WRL::RuntimeClass<

--- a/src/api/Libs/MidiKs/MidiKs.cpp
+++ b/src/api/Libs/MidiKs/MidiKs.cpp
@@ -280,12 +280,16 @@ KSMidiOutDevice::SendMidiMessage(
 
     if (m_CrossProcessMidiPump)
     {
-        return m_CrossProcessMidiPump->SendMidiMessage(midiData, length, position);
+        auto hr = m_CrossProcessMidiPump->SendMidiMessage(midiData, length, position);
+        LOG_IF_FAILED(hr);
+        return hr;
     }
     else
     {
         // using standard, write via standard streaming ioctls
-        return WritePacketMidiData(midiData, length, position);
+        auto hr = WritePacketMidiData(midiData, length, position);
+        LOG_IF_FAILED(hr);
+        return hr;
     }
 }
 

--- a/src/api/Libs/MidiXProc/MidiXProc.cpp
+++ b/src/api/Libs/MidiXProc/MidiXProc.cpp
@@ -408,6 +408,9 @@ CMidiXProc::SendMidiMessage(
                 retry = true;
                 continue;
             }
+
+            // couldn't find room. 
+
         }
     }while (retry);
 

--- a/src/api/Libs/MidiXProc/MidiXProc.cpp
+++ b/src/api/Libs/MidiXProc/MidiXProc.cpp
@@ -26,7 +26,7 @@
 #include "MidiXProc.h"
 
 // infinite timeouts when waiting for read events cause the server to just hang
-#define MIDI_XPROC_BUFFER_FULL_WAIT_TIMEOUT 2000
+#define MIDI_XPROC_BUFFER_FULL_WAIT_TIMEOUT 5000
 
 _Use_decl_annotations_
 HRESULT

--- a/src/api/Midi2.sln
+++ b/src/api/Midi2.sln
@@ -114,7 +114,7 @@ Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "Midi2.VirtualMidiTransport"
 		{EFB7CF90-7DEF-44CF-868A-191CA30E0FCF} = {EFB7CF90-7DEF-44CF-868A-191CA30E0FCF}
 	EndProjectSection
 EndProject
-Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Endpoint Transport Transports", "Endpoint Transport Transports", "{69CC5CD9-47DC-4118-A3C7-E0D071407185}"
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Endpoint Transports", "Endpoint Transports", "{69CC5CD9-47DC-4118-A3C7-E0D071407185}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Drivers", "Drivers", "{DDB8BEE6-BEDC-4AE8-8E61-67EE655E35EF}"
 EndProject

--- a/src/api/Service/Exe/MidiDeviceManager.cpp
+++ b/src/api/Service/Exe/MidiDeviceManager.cpp
@@ -1489,11 +1489,11 @@ CMidiDeviceManager::UpdateEndpointProperties
                 { PKEY_MIDI_CustomPortNumber, false, 0, 0 },
                 { PKEY_MIDI_CustomEndpointName, false, 0, 0 },
                 { PKEY_MIDI_GroupTerminalBlocks, false, 0, 0 },
-                { PKEY_MIDI_FunctionBlockDeclaredCount, false, 0, 0 },
+              /*  {PKEY_MIDI_FunctionBlockDeclaredCount, false, 0, 0},
                 { PKEY_MIDI_FunctionBlocksAreStatic, false, 0, 0 },
                 { PKEY_MIDI_FunctionBlocksLastUpdateTime, false, 0, 0 },
                 { PKEY_MIDI_FunctionBlock00, true, PKEY_MIDI_FunctionBlock00.pid, PKEY_MIDI_FunctionBlock31.pid },
-                { PKEY_MIDI_FunctionBlockName00, true, PKEY_MIDI_FunctionBlockName00.pid, PKEY_MIDI_FunctionBlockName31.pid },
+                { PKEY_MIDI_FunctionBlockName00, true, PKEY_MIDI_FunctionBlockName00.pid, PKEY_MIDI_FunctionBlockName31.pid }, */
                 { PKEY_MIDI_EndpointDiscoveryProcessComplete, false, 0, 0 },
                 };
 

--- a/src/api/Service/Exe/MidiDeviceManager.cpp
+++ b/src/api/Service/Exe/MidiDeviceManager.cpp
@@ -2529,15 +2529,31 @@ CMidiDeviceManager::SyncMidi1Ports(
                     friendlyName = baseFriendlyName;
                 }
 
-                // append the flow(Input or Output) & group number (group index + 1) to the friendly name.
-                if (MidiFlowIn == (MidiFlow) flow)
+
+                // if the device is a new MIDI 2 device, we'll add the group number. Otherwise, we'll leave
+                // off the differentiator. This is in testing with community. If you still see this in 
+                // after the Canary period ends, then this was preferred :)
+                //
+                // The next step if this doesn't work is to see if the name is already used, and then
+                // add the differentiator only in that case.
+
+                if (nativeDataFormat == MidiDataFormats::MidiDataFormats_UMP)
                 {
-                    friendlyName = friendlyName + L" I-" + std::to_wstring(groupIndex+1);
+                    // append the flow(Input or Output) & group number (group index + 1) to the friendly name.
+                    if (MidiFlowIn == (MidiFlow)flow)
+                    {
+                        friendlyName = friendlyName + L" I-" + std::to_wstring(groupIndex + 1);
+                    }
+                    else
+                    {
+                        friendlyName = friendlyName + L" O-" + std::to_wstring(groupIndex + 1);
+                    }
                 }
                 else
                 {
-                    friendlyName = friendlyName + L" O-" + std::to_wstring(groupIndex+1);
+                    // native bytestream port. Leaving off the differentiator for now per Canary note above.
                 }
+
                 interfaceProperties.push_back(DEVPROPERTY{ {DEVPKEY_DeviceInterface_FriendlyName, DEVPROP_STORE_SYSTEM, nullptr},
                     DEVPROP_TYPE_STRING, (ULONG)(sizeof(wchar_t) * (wcslen(friendlyName.c_str()) + 1)), (PVOID)friendlyName.c_str() });
 

--- a/src/api/Service/Exe/MidiDevicePipe.cpp
+++ b/src/api/Service/Exe/MidiDevicePipe.cpp
@@ -224,15 +224,6 @@ CMidiDevicePipe::SendMidiMessage(
     LONGLONG timestamp
 )
 {
-    // TODO: 
-    // Figure out how to most efficiently handle real-time messages
-    // - Should we allow them to be scheduled?
-    // - Should they bypass plugins?
-    // Run message through plugins
-    // - The plugins may produce additional messages, or delete the message
-    // - If device is currently in the middle of SysEx7, we will want to park messages that aren't allowed to interrupt that
-    // - After plugin processing, it goes to the scheduler
-
     // TODO: What happens with outgoing JR clock/timestamp messages? They can't take a different path
     // from the message they are attached to. If they follow the same path, aren't excepted, and have
     // the right timestamp order, they should be ok, but that's a "should" not a "will".

--- a/src/api/Service/Exe/MidiEndpointProtocolManager.cpp
+++ b/src/api/Service/Exe/MidiEndpointProtocolManager.cpp
@@ -45,7 +45,8 @@ CMidiEndpointProtocolManager::Initialize(
     }
     else
     {
-        m_discoveryAndProtocolNegotiationEnabled = false;
+        // default discovery to enabled if the reg key is inaccessible in some way
+        m_discoveryAndProtocolNegotiationEnabled = true;
     }
 
     // we only spin this all up if negotiation is enabled

--- a/src/api/Service/Exe/MidiEndpointProtocolWorker.cpp
+++ b/src/api/Service/Exe/MidiEndpointProtocolWorker.cpp
@@ -245,7 +245,7 @@ CMidiEndpointProtocolWorker::Start(
         LOG_IF_FAILED(RequestAllEndpointDiscoveryInformation());
 
         // hang out until all info comes in or we time out
-        DWORD timeoutMilliseconds{ 15000 };
+        DWORD timeoutMilliseconds{ 20000 };
         m_allInitialDiscoveryAndNegotiationMessagesReceived.wait(timeoutMilliseconds);
 
         RETURN_IF_FAILED(UpdateAllFunctionBlockPropertiesIfComplete());
@@ -286,7 +286,7 @@ HRESULT
 CMidiEndpointProtocolWorker::CheckIfDiscoveryComplete()
 {
     if (m_taskEndpointInfoReceived &&
-        m_taskFinalStreamNegotiationResponseReceived &&
+        /*m_taskFinalStreamNegotiationResponseReceived && */
         m_taskEndpointNameReceived &&
         m_taskEndpointProductInstanceIdReceived &&
         m_taskDeviceIdentityReceived &&
@@ -625,12 +625,12 @@ CMidiEndpointProtocolWorker::ProcessFunctionBlockNameNotificationMessage(interna
         TraceLoggingWideString(m_endpointDeviceInterfaceId.c_str(), MIDI_TRACE_EVENT_DEVICE_SWD_ID_FIELD)
     );
 
-    if (!m_inInitialFunctionBlockDiscovery && m_functionBlocksAreStatic)
-    {
-        // we reject this function block because the initial ones were declared static,
-        // meaning no changes are allowed
-        return S_OK;
-    }
+    //if (!m_inInitialFunctionBlockDiscovery && m_functionBlocksAreStatic)
+    //{
+    //    // we reject this function block because the initial ones were declared static,
+    //    // meaning no changes are allowed
+    //    return S_OK;
+    //}
 
     uint8_t functionBlockNumber = MIDIWORDBYTE3(ump.word0);
 
@@ -1355,10 +1355,10 @@ CMidiEndpointProtocolWorker::UpdateAllFunctionBlockPropertiesIfComplete()
 
     // we only check blocks, not names, because names are optional
     // this may lead to a bit of a race, but it's the best we can do
-    if (m_functionBlocks.size() != m_declaredFunctionBlockCount)
-    {
-        return S_OK;
-    }
+    //if (m_functionBlocks.size() != m_declaredFunctionBlockCount)
+    //{
+    //    return S_OK;
+    //}
 
     // this is for efficiency during initial discovery. This function is called when all 
     // function blocks have been received. It's possible not all names have been received
@@ -1391,7 +1391,7 @@ CMidiEndpointProtocolWorker::UpdateAllFunctionBlockPropertiesIfComplete()
             else
             {
                 props.push_back({{ FunctionBlockNamePropertyKeyFromNumber(fbname.first), DEVPROP_STORE_SYSTEM, nullptr},
-                DEVPROP_TYPE_EMPTY, 0, nullptr });
+                    DEVPROP_TYPE_EMPTY, 0, nullptr });
             }
         }
     }

--- a/src/api/Test/Midi2.Transform.unittests/LibMidi2Tests.cpp
+++ b/src/api/Test/Midi2.Transform.unittests/LibMidi2Tests.cpp
@@ -13,6 +13,7 @@
 
 #include "LibMidi2Tests.h"
 #include "libmidi2\bytestreamToUMP.h"
+#include "libmidi2\umpToBytestream.h"
 
 _Use_decl_annotations_
 void LibMidi2Tests::InternalTestSysEx(
@@ -69,6 +70,66 @@ void LibMidi2Tests::InternalTestSysEx(
     VERIFY_ARE_EQUAL(expectedWords.size(), countWordsCreated);
 }
 
+_Use_decl_annotations_
+void LibMidi2Tests::InternalTestSysExFromBytes(
+    std::vector<uint32_t> messageWords,
+    std::vector<uint8_t> const expectedBytes)
+{
+    umpToBytestream ump2bs{};
+
+    std::vector<uint8_t> generatedBytes;
+    generatedBytes.reserve(expectedBytes.size());
+
+    std::cout << "bytes created: " << std::endl;
+
+    uint16_t generatedBytesIndex{ 0 };
+    uint32_t countBytesCreated{ 0 };
+
+    std::cout << std::endl;
+
+    for (uint32_t i = 0; i < messageWords.size(); i++)
+    {
+        std::cout << std::setfill('0') << std::setw(8) << std::hex << messageWords[i] << " ";
+
+        ump2bs.UMPStreamParse(messageWords[i]);
+
+        if (ump2bs.availableBS())
+        {
+            std::cout << std::endl;
+
+            while (ump2bs.availableBS())
+            {
+                auto b = ump2bs.readBS();
+                countBytesCreated++;
+
+                if (countBytesCreated <= expectedBytes.size())
+                {
+                    std::cout
+                        << std::setfill('0') << std::setw(2) << std::hex << (uint16_t)b
+                        << "(" << std::setfill('0') << std::setw(2) << std::hex << (uint16_t)(expectedBytes[generatedBytesIndex]) << ") ";
+
+                    VERIFY_ARE_EQUAL(expectedBytes[generatedBytesIndex], b);
+
+                    generatedBytesIndex++;
+                }
+                else
+                {
+                    std::cout << std::endl;
+                    VERIFY_FAIL();
+                }
+            }
+
+            std::cout << std::endl;
+        }
+    }
+    //std::cout << std::endl << std::endl;
+
+    std::cout << std::endl;
+
+    VERIFY_ARE_EQUAL(expectedBytes.size(), countBytesCreated);
+}
+
+
 void LibMidi2Tests::TestTranslateFromBytesWithSysEx7()
 {
     const uint8_t sysexBytes[] = { 
@@ -109,18 +170,18 @@ void LibMidi2Tests::TestTranslateFromBytesWithEmbeddedRealTimeAndSysEx7()
 {
     const uint8_t sysexBytes[] =
     {
-        0xf0, 
+        0xf0,
         0x0a, 0x0b, 0x0c, 0x0d, 0x0f,           // 5-data-byte sysex message
         0xF8,                                   // real-time clock. because this arrives before previous message created, this ends up first
         0x2a, 0x2b, 0x2c, 0x2d, 0x2e, 0x2f,     // 6-data-byte sysex message
-        0xf7,       
+        0xf7,
     };
 
     std::vector<uint32_t> expectedWords
     {
         0x10f80000,                 // RT gets moved to first because full sysex message not yet generated
         0x30160a0b, 0x0c0d0f2a,
-        0x30352b2c, 0x2d2e2f00 
+        0x30352b2c, 0x2d2e2f00
     };
 
     InternalTestSysEx(0, sysexBytes, _countof(sysexBytes), expectedWords);
@@ -141,7 +202,7 @@ void LibMidi2Tests::TestTranslateFromBytesWithEmbeddedStartStopSysEx7()
 
 
     std::vector<uint32_t> expectedWords
-    { 
+    {
         0x30160a0b, 0x0c0d0e1a,   0x30351b1c, 0x1d1e1f00,
         0x30162a2b, 0x2c2d2e3a,   0x30353b3c, 0x3d3e3f00,
         0x30054a4b, 0x4c4d4e00,
@@ -194,4 +255,72 @@ void LibMidi2Tests::TestTranslateFromBytesWithShortSysEx7()
     std::vector<uint32_t> expectedWords{ 0x30020a0b, 0x00000000 };
 
     InternalTestSysEx(0, sysexBytes, _countof(sysexBytes), expectedWords);
+}
+
+
+
+void LibMidi2Tests::TestTranslateToBytesWithSysEx7()
+{
+    std::vector<uint32_t> input =
+    {
+        0x30010100, 0x00000000,
+        0x30160801, 0x02030405,
+        0x30320607, 0x00000000
+    };
+
+    std::vector<uint8_t> expectedOutput =
+    {
+        0xF0, 0x01, 0xF7,
+        0xF0, 0x08, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0xF7
+    };
+
+    InternalTestSysExFromBytes(input, expectedOutput);
+
+}
+
+void LibMidi2Tests::TestTranslateToBytesWithInterruptedSysEx7()
+{
+    std::vector<uint32_t> input =
+    {
+        0x30010100, 0x00000000,
+        0x30160801, 0x02030405,
+        0x10FE0000,
+        0x30320607, 0x00000000
+    };
+
+    std::vector<uint8_t> expectedOutput =
+    {
+        0xF0, 0x01, 0xF7,
+        0xF0, 0x08, 0x01, 0x02, 0x03, 0x04, 0x05, 
+        0xFE, 
+        0x06, 0x07, 0xF7
+    };
+
+    InternalTestSysExFromBytes(input, expectedOutput);
+}
+
+void LibMidi2Tests::TestTranslateToBytesWithCanceledSysEx7()
+{
+    std::vector<uint32_t> input =
+    {
+        0x30010100, 0x00000000,
+        0x30160801, 0x02030405,
+        0x20905050,
+        0x20806060,
+        0x30320607, 0x00000000
+    };
+
+    // verifying this behavior stays consistent. LibMidi2 will pick up the rest
+    // of the sysex, and will just embed the note on/off messages inside it
+    std::vector<uint8_t> expectedOutput =
+    {
+        0xF0, 0x01, 0xF7,
+        0xF0, 0x08, 0x01, 0x02, 0x03, 0x04, 0x05,
+        0x90, 0x50, 0x50,   // note off
+        0x80, 0x60, 0x60,   // note on
+        0x06, 0x07, 0xF7    // rest of sysex, including F7
+    };
+
+    InternalTestSysExFromBytes(input, expectedOutput);
+
 }

--- a/src/api/Test/Midi2.Transform.unittests/LibMidi2Tests.h
+++ b/src/api/Test/Midi2.Transform.unittests/LibMidi2Tests.h
@@ -40,11 +40,21 @@ public:
         TEST_METHOD(TestTranslateFromBytesWithShortSysEx7);
         TEST_METHOD(TestTranslateFromBytesWithLongSysEx7);
 
+        TEST_METHOD(TestTranslateToBytesWithSysEx7);
+        TEST_METHOD(TestTranslateToBytesWithInterruptedSysEx7);
+        TEST_METHOD(TestTranslateToBytesWithCanceledSysEx7);
+
     void InternalTestSysEx(
         _In_ uint8_t const groupIndex, 
         _In_reads_bytes_(byteCount) uint8_t const sysexBytes[], 
         _In_ uint32_t const byteCount, 
         _In_ std::vector<uint32_t> const expectedWords);
+
+    void InternalTestSysExFromBytes(
+        _In_ std::vector<uint32_t> const messageWords,
+        _In_ std::vector<uint8_t> const expectedBytes);
+
+
 
 private:
 

--- a/src/api/Transport/KSAggregateTransport/Midi2.KSAggregateMidiInProxy.cpp
+++ b/src/api/Transport/KSAggregateTransport/Midi2.KSAggregateMidiInProxy.cpp
@@ -115,16 +115,16 @@ CMidi2KSAggregateMidiInProxy::Callback(
     RETURN_HR_IF_NULL(E_POINTER, m_callback);
     RETURN_HR_IF_NULL(E_POINTER, m_bs2UmpTransform);
 
-    //TraceLoggingWrite(
-    //    MidiKSAggregateTransportTelemetryProvider::Provider(),
-    //    MIDI_TRACE_EVENT_VERBOSE,
-    //    TraceLoggingString(__FUNCTION__, MIDI_TRACE_EVENT_LOCATION_FIELD),
-    //    TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE),
-    //    TraceLoggingPointer(this, "this"),
-    //    TraceLoggingWideString(L"Callback received from device. Sending data to next callback.", MIDI_TRACE_EVENT_MESSAGE_FIELD),
-    //    TraceLoggingUInt32(length, "data length"),
-    //    TraceLoggingUInt64(timestamp, MIDI_TRACE_EVENT_MESSAGE_TIMESTAMP_FIELD)
-    //);
+    TraceLoggingWrite(
+        MidiKSAggregateTransportTelemetryProvider::Provider(),
+        MIDI_TRACE_EVENT_VERBOSE,
+        TraceLoggingString(__FUNCTION__, MIDI_TRACE_EVENT_LOCATION_FIELD),
+        TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE),
+        TraceLoggingPointer(this, "this"),
+        TraceLoggingWideString(L"MidiIn Callback received from device. Sending data to bs2UmpTransform.", MIDI_TRACE_EVENT_MESSAGE_FIELD),
+        TraceLoggingUInt32(length, "data length"),
+        TraceLoggingUInt64(timestamp, MIDI_TRACE_EVENT_MESSAGE_TIMESTAMP_FIELD)
+    );
 
     // the callback for the transform is wired up in initialize
     return m_bs2UmpTransform->SendMidiMessage(data, length, timestamp);

--- a/src/api/Transport/KSAggregateTransport/Midi2.KSAggregateMidiOutProxy.cpp
+++ b/src/api/Transport/KSAggregateTransport/Midi2.KSAggregateMidiOutProxy.cpp
@@ -108,11 +108,12 @@ CMidi2KSAggregateMidiOutProxy::SendMidiMessage(
 )
 {
     RETURN_HR_IF_NULL(E_INVALIDARG, data);
-    //RETURN_HR_IF_NULL(E_POINTER, m_callback);
     RETURN_HR_IF_NULL(E_POINTER, m_ump2BSTransform);
 
     // get the message translated. Comes back via the callback
-    return m_ump2BSTransform->SendMidiMessage(data, length, timestamp);
+    RETURN_IF_FAILED(m_ump2BSTransform->SendMidiMessage(data, length, timestamp));
+
+    return S_OK;
 }
 
 _Use_decl_annotations_
@@ -127,16 +128,16 @@ CMidi2KSAggregateMidiOutProxy::Callback(
     RETURN_HR_IF_NULL(E_INVALIDARG, data);
     RETURN_HR_IF_NULL(E_POINTER, m_device);
 
-    //TraceLoggingWrite(
-    //    MidiKSAggregateTransportTelemetryProvider::Provider(),
-    //    MIDI_TRACE_EVENT_VERBOSE,
-    //    TraceLoggingString(__FUNCTION__, MIDI_TRACE_EVENT_LOCATION_FIELD),
-    //    TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE),
-    //    TraceLoggingPointer(this, "this"),
-    //    TraceLoggingWideString(L"Callback received from device. Sending data to next callback.", MIDI_TRACE_EVENT_MESSAGE_FIELD),
-    //    TraceLoggingUInt32(length, "data length"),
-    //    TraceLoggingUInt64(timestamp, MIDI_TRACE_EVENT_MESSAGE_TIMESTAMP_FIELD)
-    //);
+    TraceLoggingWrite(
+        MidiKSAggregateTransportTelemetryProvider::Provider(),
+        MIDI_TRACE_EVENT_VERBOSE,
+        TraceLoggingString(__FUNCTION__, MIDI_TRACE_EVENT_LOCATION_FIELD),
+        TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE),
+        TraceLoggingPointer(this, "this"),
+        TraceLoggingWideString(L"MidiOut callback received from translation. Sending data to device.", MIDI_TRACE_EVENT_MESSAGE_FIELD),
+        TraceLoggingUInt32(length, "data length"),
+        TraceLoggingUInt64(timestamp, MIDI_TRACE_EVENT_MESSAGE_TIMESTAMP_FIELD)
+    );
 
     // Send transformed message to device
     RETURN_IF_FAILED(m_device->SendMidiMessage(data, length, timestamp));


### PR DESCRIPTION
Fix function blocks not being discovered
Fix problems with WinMM apps crashing due to handling of < 3 byte messages
Change WinMM port names to remove the suffix (O-1, I-5, etc.) unless the originating device is a MIDI 2.0 / UMP device.
