### PR TITLE
fix driver test hang when switching state fast, fix build issues due to missing headers

### DIFF
--- a/src/api/Drivers/MinMidi/Driver/MidiPin.cpp
+++ b/src/api/Drivers/MinMidi/Driver/MidiPin.cpp
@@ -621,7 +621,6 @@ MidiPin::HandleIo()
 
     // start with the even reset to indicate that the thread is running
     m_ThreadExitedEvent.clear();
-    m_ThreadExitEvent.clear();
 
     if (m_Pin->DataFlow == KSPIN_DATAFLOW_IN)
     {
@@ -753,7 +752,7 @@ MidiPin::HandleIo()
                             PVOID midiInWaitObjects[] = { m_ThreadExitEvent.get(), g_MidiInPin->m_ReadEvent };
 
                             // Wait for either room in the output buffer, or thread exit.
-                            status = KeWaitForMultipleObjects(2, waitObjects, WaitAny, Executive, KernelMode, FALSE, nullptr, nullptr);
+                            status = KeWaitForMultipleObjects(2, midiInWaitObjects, WaitAny, Executive, KernelMode, FALSE, nullptr, nullptr);
                             if (STATUS_WAIT_1 == status)
                             {
                                 // we have room, retry writing this pass
@@ -884,6 +883,8 @@ MidiPin::SetDeviceState(
                     // midi out
                     if (This->m_IsLooped)
                     {
+                        This->m_ThreadExitEvent.clear();
+
                         // Create and start the midi out worker thread for the cyclic buffer.
                         HANDLE handle = NULL;
                         NT_RETURN_IF_NTSTATUS_FAILED(PsCreateSystemThread(&handle, THREAD_ALL_ACCESS, 0, 0, 0, MidiPin::WorkerThread, This));

--- a/src/api/Drivers/MinMidi2/Driver/StreamEngine.cpp
+++ b/src/api/Drivers/MinMidi2/Driver/StreamEngine.cpp
@@ -269,7 +269,7 @@ StreamEngine::HandleIo()
                             PVOID midiInWaitObjects[] = { m_ThreadExitEvent.get(), g_MidiInStreamEngine->m_ReadEvent };
 
                             // Wait for either room in the output buffer, or thread exit.
-                            status = KeWaitForMultipleObjects(2, waitObjects, WaitAny, Executive, KernelMode, FALSE, nullptr, nullptr);
+                            status = KeWaitForMultipleObjects(2, midiInWaitObjects, WaitAny, Executive, KernelMode, FALSE, nullptr, nullptr);
                             if (STATUS_WAIT_1 == status)
                             {
                                 // we have room in the input pin buffer, set the write event and break

--- a/src/api/Drivers/USBMIDI2/Driver/StreamEngine.cpp
+++ b/src/api/Drivers/USBMIDI2/Driver/StreamEngine.cpp
@@ -150,7 +150,6 @@ StreamEngine::HandleIo()
 
     // start with the even reset to indicate that the thread is running
     m_ThreadExitedEvent.clear();
-    m_ThreadExitEvent.clear();
 
     if (AcxPinGetId(m_Pin) == MidiPinTypeMidiOut)
     {
@@ -574,6 +573,8 @@ StreamEngine::Run()
     // transition from paused to run
     if (AcxPinGetId(m_Pin) == MidiPinTypeMidiOut)
     {
+        m_ThreadExitEvent.clear();
+
         // Create and start the midi out worker thread for the cyclic buffer.
         HANDLE handle = nullptr;
         NT_RETURN_IF_NTSTATUS_FAILED(PsCreateSystemThread(&handle, THREAD_ALL_ACCESS, 0, 0, 0, StreamEngine::WorkerThread, this));

--- a/src/api/Service/Exe/stdafx.h
+++ b/src/api/Service/Exe/stdafx.h
@@ -19,6 +19,7 @@
 #include <string>
 #include <iterator>
 #include <strsafe.h>
+#include <mmsystem.h>
 #include <wrl\module.h>
 #include <wrl\event.h>
 #include <avrt.h>

--- a/src/api/Transport/KSAggregateTransport/pch.h
+++ b/src/api/Transport/KSAggregateTransport/pch.h
@@ -19,8 +19,10 @@
 #include <winrt/Windows.Foundation.Collections.h>
 #include <winrt/Windows.Devices.Enumeration.h>
 
+#include <mmsystem.h>
 #include <wrl\module.h>
 #include <wrl\event.h>
+#include <devioctl.h>
 #include <ks.h>
 #include <ksmedia.h>
 #include <avrt.h>


### PR DESCRIPTION
recent change to use manual reset event would sometimes cause driver test failure due to the worker thread resetting the terminate event when the thread started, after the test that quickly transitioned the state from run to pause had set the event. The event needs to be reset before the thread is started, not in the thread startup.

Add some missing headers that caused build issues.