### PR TITLE
Ticks Calculation Fix for CMidiPort + more small fixes

### DIFF
--- a/samples/cpp-winrt/static-enum-endpoints/main.cpp
+++ b/samples/cpp-winrt/static-enum-endpoints/main.cpp
@@ -208,7 +208,7 @@ int main()
 
         for (auto const& functionBlock : functionBlocks)
         {
-            std::cout << "  - " << functionBlock.Number() << " : " << winrt::to_string(functionBlock.Name()) << std::endl;
+            std::cout << "  - " << int(functionBlock.Number()) << " : " << winrt::to_string(functionBlock.Name()) << std::endl;
         }
         
 
@@ -219,7 +219,7 @@ int main()
 
         for (auto const& groupTerminalBlock : groupTerminalBlocks)
         {
-            std::cout << "  - " << groupTerminalBlock.Number() << " : " << winrt::to_string(groupTerminalBlock.Name()) << std::endl;
+            std::cout << "  - " << int(groupTerminalBlock.Number()) << " : " << winrt::to_string(groupTerminalBlock.Name()) << std::endl;
         }
 
 

--- a/src/api/Client/WinMM/MidiSrvPort.cpp
+++ b/src/api/Client/WinMM/MidiSrvPort.cpp
@@ -3,6 +3,8 @@
 #include "pch.h"
 #include "MidiSrvPort.h"
 
+#define CALC_TICKS(pos) ((DWORD) (((pos) * 1000.0) / m_qpcFrequency))
+
 CMidiPort::CMidiPort()
 {
     TraceLoggingWrite(
@@ -354,7 +356,7 @@ CMidiPort::CompleteLongBuffer(UINT message, LONGLONG position)
     }
 
     // calculate the timestamp for the message
-    DWORD ticks = (DWORD) (((position - m_StartTime) / m_qpcFrequency) * 1000.0);
+    DWORD ticks = CALC_TICKS(position - m_StartTime);
 
     // mark it completed
     buffer->dwFlags &= (~MHDR_INQUEUE);
@@ -489,7 +491,7 @@ CMidiPort::Callback(_In_ PVOID data, _In_ UINT size, _In_ LONGLONG position, LON
                     // we're not in SysEx mode, but this byte was provided
                     // so we'll send it anyway
                     // Convert from the QPC time to the number of ticks elapsed from the start time.
-                    DWORD ticks = (DWORD)(((position - startTime) / m_qpcFrequency) * 1000.0);
+                    DWORD ticks = CALC_TICKS(position - startTime);
                     DWORD_PTR midiMessage = *callbackData;
                     WinmmClientCallback(MIM_ERROR, midiMessage, ticks);
                 }
@@ -553,7 +555,7 @@ CMidiPort::Callback(_In_ PVOID data, _In_ UINT size, _In_ LONGLONG position, LON
                         // to do that. We could even put in a reg setting to control this behavior.
 
                         // Convert from the QPC time to the number of ticks elapsed from the start time.
-                        //DWORD ticks = (DWORD)(((position - startTime) / m_qpcFrequency) * 1000.0);
+                        //DWORD ticks = CALC_TICKS(position - startTime);
                         //DWORD_PTR midiMessage = *callbackData;
                         //WinmmClientCallback(MIM_ERROR, midiMessage, ticks);
                     }
@@ -627,7 +629,7 @@ CMidiPort::Callback(_In_ PVOID data, _In_ UINT size, _In_ LONGLONG position, LON
             if (MIDI_BYTE_IS_STATUS_BYTE(prioritySingleByteMessage))
             {
                 // Convert from the QPC time to the number of ticks elapsed from the start time.
-                DWORD ticks = (DWORD)(((position - startTime) / m_qpcFrequency) * 1000.0);
+                DWORD ticks = CALC_TICKS(position - startTime);
                 DWORD_PTR midiMessage{ prioritySingleByteMessage };
                 WinmmClientCallback(MIM_DATA, midiMessage, ticks);
 
@@ -642,7 +644,7 @@ CMidiPort::Callback(_In_ PVOID data, _In_ UINT size, _In_ LONGLONG position, LON
                     countMidiMessageBytesReceived == 1 && MIDI_MESSAGE_IS_ONE_BYTE(inProgressMidiMessage[0]))
                 {
                     // Convert from the QPC time to the number of ticks elapsed from the start time.
-                    DWORD ticks = (DWORD)(((position - startTime) / m_qpcFrequency) * 1000.0);
+                    DWORD ticks = CALC_TICKS(position - startTime);
                     DWORD_PTR midiMessage{ static_cast<DWORD_PTR>(inProgressMidiMessage[0]) };
 
                     if (MIDI_MESSAGE_IS_TWO_BYTES(inProgressMidiMessage[0]) || 

--- a/src/api/Service/Exe/MidiDeviceManager.cpp
+++ b/src/api/Service/Exe/MidiDeviceManager.cpp
@@ -2130,7 +2130,7 @@ CMidiDeviceManager::GetFunctionBlockPortInfo(
                 portInfo[MidiFlowOut][i].Flow = (MidiFlow) MidiFlowOut;
                 portInfo[MidiFlowOut][i].IsEnabled = portInfo[MidiFlowOut][i].IsEnabled || fb->IsActive;
                 portInfo[MidiFlowOut][i].InterfaceId = umpDeviceInterfaceId;
-                portInfo[MidiFlowIn][i].Name = functionBlockName;
+                portInfo[MidiFlowOut][i].Name = functionBlockName;
             }
         }
     }


### PR DESCRIPTION
* CMidiPort: a macro was introduced to perform ticks calculation without truncation
* CMidiDeviceManager::GetFunctionBlockPortInfo: fixed a typo (maybe from copy/paste)
* static-enum-endpoints-cpp: convert functionBlock and groupTerminalBlock Numbers to int so that they can be printed correctly in std::cout (native type is uint8_t)