### PR TITLE
Minor fix to caching

### DIFF
--- a/build/staging/version/BundleInfo.wxi
+++ b/build/staging/version/BundleInfo.wxi
@@ -1,5 +1,5 @@
 <Include>
   <?define SetupVersionName="Preview 13 Arm64" ?>
-  <?define SetupVersionNumber="1.0.13-preview.13.154" ?>
-  <?define MidiSdkAndToolsVersion="1.0.13-preview.13.154" ?>
+  <?define SetupVersionNumber="1.0.13-preview.13.156" ?>
+  <?define MidiSdkAndToolsVersion="1.0.13-preview.13.156" ?>
 </Include>

--- a/build/staging/version/WindowsMidiServicesVersion.cs
+++ b/build/staging/version/WindowsMidiServicesVersion.cs
@@ -11,14 +11,14 @@ namespace Microsoft.Windows.Devices.Midi2.Common
 		public const string Source = "GitHub Preview";
 		public const string BuildDate = "2025-08-28";
 		public const string Name = "Preview 13";
-		public const string BuildFullVersion = "1.0.13-preview.13.154";
+		public const string BuildFullVersion = "1.0.13-preview.13.156";
 		public const ushort VersionMajor = 1;
 		public const ushort VersionMinor = 0;
 		public const ushort VersionPatch = 13;
-		public const ushort VersionBuildNumber = 154;
-		public const string Preview = "preview.13.154";
-		public const string AssemblyFullVersion = "1.0.13.154";
-		public const string FileFullVersion = "1.0.13.154";
+		public const ushort VersionBuildNumber = 156;
+		public const string Preview = "preview.13.156";
+		public const string AssemblyFullVersion = "1.0.13.156";
+		public const string FileFullVersion = "1.0.13.156";
 	}
 }
 

--- a/build/staging/version/WindowsMidiServicesVersion.h
+++ b/build/staging/version/WindowsMidiServicesVersion.h
@@ -9,13 +9,13 @@
 #define WINDOWS_MIDI_SERVICES_NUGET_BUILD_SOURCE                             L"GitHub Preview"
 #define WINDOWS_MIDI_SERVICES_NUGET_BUILD_DATE                               L"2025-08-28"
 #define WINDOWS_MIDI_SERVICES_NUGET_BUILD_VERSION_NAME                       L"Preview 13"
-#define WINDOWS_MIDI_SERVICES_NUGET_BUILD_VERSION_FULL                       L"1.0.13-preview.13.154"
+#define WINDOWS_MIDI_SERVICES_NUGET_BUILD_VERSION_FULL                       L"1.0.13-preview.13.156"
 #define WINDOWS_MIDI_SERVICES_NUGET_BUILD_VERSION_MAJOR                      1
 #define WINDOWS_MIDI_SERVICES_NUGET_BUILD_VERSION_MINOR                      0
 #define WINDOWS_MIDI_SERVICES_NUGET_BUILD_VERSION_PATCH                      13
-#define WINDOWS_MIDI_SERVICES_NUGET_BUILD_VERSION_BUILD_NUMBER               154
-#define WINDOWS_MIDI_SERVICES_NUGET_BUILD_PREVIEW                            L"preview.13.154"
-#define WINDOWS_MIDI_SERVICES_NUGET_BUILD_VERSION_FILE                       L"1.0.13.154"
+#define WINDOWS_MIDI_SERVICES_NUGET_BUILD_VERSION_BUILD_NUMBER               156
+#define WINDOWS_MIDI_SERVICES_NUGET_BUILD_PREVIEW                            L"preview.13.156"
+#define WINDOWS_MIDI_SERVICES_NUGET_BUILD_VERSION_FILE                       L"1.0.13.156"
 
 #endif
 

--- a/samples/cpp-winrt/basics/client-basics-cpp.vcxproj
+++ b/samples/cpp-winrt/basics/client-basics-cpp.vcxproj
@@ -2,7 +2,7 @@
 <Project DefaultTargets="Build" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\packages\Microsoft.Windows.CppWinRT.2.0.240405.15\build\native\Microsoft.Windows.CppWinRT.props" Condition="Exists('..\packages\Microsoft.Windows.CppWinRT.2.0.240405.15\build\native\Microsoft.Windows.CppWinRT.props')" />
   <PropertyGroup Label="Globals">
-    <WindowsMidiServicesSdkPackage>Microsoft.Windows.Devices.Midi2.1.0.13-preview.13.154</WindowsMidiServicesSdkPackage>
+    <WindowsMidiServicesSdkPackage>Microsoft.Windows.Devices.Midi2.1.0.13-preview.13.156</WindowsMidiServicesSdkPackage>
     <CppWinRTOptimized>true</CppWinRTOptimized>
     <CppWinRTRootNamespaceAutoMerge>true</CppWinRTRootNamespaceAutoMerge>
     <CppWinRTGenerateWindowsMetadata>false</CppWinRTGenerateWindowsMetadata>

--- a/samples/cpp-winrt/basics/packages.config
+++ b/samples/cpp-winrt/basics/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Microsoft.Windows.CppWinRT" version="2.0.240405.15" targetFramework="native" />
-  <package id="Microsoft.Windows.Devices.Midi2" version="1.0.13-preview.13.154" targetFramework="native" />
+  <package id="Microsoft.Windows.Devices.Midi2" version="1.0.13-preview.13.156" targetFramework="native" />
 </packages>

--- a/samples/cpp-winrt/endpoint-listeners/endpoint-listeners-cpp.vcxproj
+++ b/samples/cpp-winrt/endpoint-listeners/endpoint-listeners-cpp.vcxproj
@@ -2,7 +2,7 @@
 <Project DefaultTargets="Build" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\packages\Microsoft.Windows.CppWinRT.2.0.240405.15\build\native\Microsoft.Windows.CppWinRT.props" Condition="Exists('..\packages\Microsoft.Windows.CppWinRT.2.0.240405.15\build\native\Microsoft.Windows.CppWinRT.props')" />
   <PropertyGroup Label="Globals">
-    <WindowsMidiServicesSdkPackage>Microsoft.Windows.Devices.Midi2.1.0.13-preview.13.154</WindowsMidiServicesSdkPackage>
+    <WindowsMidiServicesSdkPackage>Microsoft.Windows.Devices.Midi2.1.0.13-preview.13.156</WindowsMidiServicesSdkPackage>
     <CppWinRTOptimized>true</CppWinRTOptimized>
     <CppWinRTRootNamespaceAutoMerge>true</CppWinRTRootNamespaceAutoMerge>
     <CppWinRTGenerateWindowsMetadata>false</CppWinRTGenerateWindowsMetadata>

--- a/samples/cpp-winrt/endpoint-listeners/packages.config
+++ b/samples/cpp-winrt/endpoint-listeners/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Microsoft.Windows.CppWinRT" version="2.0.240405.15" targetFramework="native" />
-  <package id="Microsoft.Windows.Devices.Midi2" version="1.0.13-preview.13.154" targetFramework="native" />
+  <package id="Microsoft.Windows.Devices.Midi2" version="1.0.13-preview.13.156" targetFramework="native" />
 </packages>

--- a/samples/cpp-winrt/full-init/full-init-cpp.vcxproj
+++ b/samples/cpp-winrt/full-init/full-init-cpp.vcxproj
@@ -2,7 +2,7 @@
 <Project DefaultTargets="Build" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\packages\Microsoft.Windows.CppWinRT.2.0.240405.15\build\native\Microsoft.Windows.CppWinRT.props" Condition="Exists('..\packages\Microsoft.Windows.CppWinRT.2.0.240405.15\build\native\Microsoft.Windows.CppWinRT.props')" />
   <PropertyGroup Label="Globals">
-    <WindowsMidiServicesSdkPackage>Microsoft.Windows.Devices.Midi2.1.0.13-preview.13.154</WindowsMidiServicesSdkPackage>
+    <WindowsMidiServicesSdkPackage>Microsoft.Windows.Devices.Midi2.1.0.13-preview.13.156</WindowsMidiServicesSdkPackage>
     <CppWinRTOptimized>true</CppWinRTOptimized>
     <CppWinRTRootNamespaceAutoMerge>true</CppWinRTRootNamespaceAutoMerge>
     <CppWinRTGenerateWindowsMetadata>false</CppWinRTGenerateWindowsMetadata>

--- a/samples/cpp-winrt/full-init/packages.config
+++ b/samples/cpp-winrt/full-init/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Microsoft.Windows.CppWinRT" version="2.0.240405.15" targetFramework="native" />
-  <package id="Microsoft.Windows.Devices.Midi2" version="1.0.13-preview.13.154" targetFramework="native" />
+  <package id="Microsoft.Windows.Devices.Midi2" version="1.0.13-preview.13.156" targetFramework="native" />
 </packages>

--- a/samples/cpp-winrt/loopback-endpoints/loopback-endpoints-cpp.vcxproj
+++ b/samples/cpp-winrt/loopback-endpoints/loopback-endpoints-cpp.vcxproj
@@ -2,7 +2,7 @@
 <Project DefaultTargets="Build" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\packages\Microsoft.Windows.CppWinRT.2.0.240405.15\build\native\Microsoft.Windows.CppWinRT.props" Condition="Exists('..\packages\Microsoft.Windows.CppWinRT.2.0.240405.15\build\native\Microsoft.Windows.CppWinRT.props')" />
   <PropertyGroup Label="Globals">
-    <WindowsMidiServicesSdkPackage>Microsoft.Windows.Devices.Midi2.1.0.13-preview.13.154</WindowsMidiServicesSdkPackage>
+    <WindowsMidiServicesSdkPackage>Microsoft.Windows.Devices.Midi2.1.0.13-preview.13.156</WindowsMidiServicesSdkPackage>
     <CppWinRTOptimized>true</CppWinRTOptimized>
     <CppWinRTRootNamespaceAutoMerge>true</CppWinRTRootNamespaceAutoMerge>
     <CppWinRTGenerateWindowsMetadata>true</CppWinRTGenerateWindowsMetadata>

--- a/samples/cpp-winrt/loopback-endpoints/packages.config
+++ b/samples/cpp-winrt/loopback-endpoints/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Microsoft.Windows.CppWinRT" version="2.0.240405.15" targetFramework="native" />
-  <package id="Microsoft.Windows.Devices.Midi2" version="1.0.13-preview.13.154" targetFramework="native" />
+  <package id="Microsoft.Windows.Devices.Midi2" version="1.0.13-preview.13.156" targetFramework="native" />
 </packages>

--- a/samples/cpp-winrt/send-speed/packages.config
+++ b/samples/cpp-winrt/send-speed/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Microsoft.Windows.CppWinRT" version="2.0.240405.15" targetFramework="native" />
-  <package id="Microsoft.Windows.Devices.Midi2" version="1.0.13-preview.13.154" targetFramework="native" />
+  <package id="Microsoft.Windows.Devices.Midi2" version="1.0.13-preview.13.156" targetFramework="native" />
 </packages>

--- a/samples/cpp-winrt/send-speed/send-speed-cpp.vcxproj
+++ b/samples/cpp-winrt/send-speed/send-speed-cpp.vcxproj
@@ -2,7 +2,7 @@
 <Project DefaultTargets="Build" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\packages\Microsoft.Windows.CppWinRT.2.0.240405.15\build\native\Microsoft.Windows.CppWinRT.props" Condition="Exists('..\packages\Microsoft.Windows.CppWinRT.2.0.240405.15\build\native\Microsoft.Windows.CppWinRT.props')" />
   <PropertyGroup Label="Globals">
-    <WindowsMidiServicesSdkPackage>Microsoft.Windows.Devices.Midi2.1.0.13-preview.13.154</WindowsMidiServicesSdkPackage>
+    <WindowsMidiServicesSdkPackage>Microsoft.Windows.Devices.Midi2.1.0.13-preview.13.156</WindowsMidiServicesSdkPackage>
     <CppWinRTOptimized>true</CppWinRTOptimized>
     <CppWinRTRootNamespaceAutoMerge>true</CppWinRTRootNamespaceAutoMerge>
     <CppWinRTGenerateWindowsMetadata>true</CppWinRTGenerateWindowsMetadata>

--- a/samples/cpp-winrt/simple-app-to-app-midi/packages.config
+++ b/samples/cpp-winrt/simple-app-to-app-midi/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Microsoft.Windows.CppWinRT" version="2.0.240405.15" targetFramework="native" />
-  <package id="Microsoft.Windows.Devices.Midi2" version="1.0.13-preview.13.154" targetFramework="native" />
+  <package id="Microsoft.Windows.Devices.Midi2" version="1.0.13-preview.13.156" targetFramework="native" />
 </packages>

--- a/samples/cpp-winrt/simple-app-to-app-midi/simple-app-to-app-cpp.vcxproj
+++ b/samples/cpp-winrt/simple-app-to-app-midi/simple-app-to-app-cpp.vcxproj
@@ -2,7 +2,7 @@
 <Project DefaultTargets="Build" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\packages\Microsoft.Windows.CppWinRT.2.0.240405.15\build\native\Microsoft.Windows.CppWinRT.props" Condition="Exists('..\packages\Microsoft.Windows.CppWinRT.2.0.240405.15\build\native\Microsoft.Windows.CppWinRT.props')" />
   <PropertyGroup Label="Globals">
-    <WindowsMidiServicesSdkPackage>Microsoft.Windows.Devices.Midi2.1.0.13-preview.13.154</WindowsMidiServicesSdkPackage>
+    <WindowsMidiServicesSdkPackage>Microsoft.Windows.Devices.Midi2.1.0.13-preview.13.156</WindowsMidiServicesSdkPackage>
     <CppWinRTOptimized>true</CppWinRTOptimized>
     <CppWinRTRootNamespaceAutoMerge>true</CppWinRTRootNamespaceAutoMerge>
     <CppWinRTGenerateWindowsMetadata>true</CppWinRTGenerateWindowsMetadata>

--- a/samples/cpp-winrt/static-enum-endpoints/packages.config
+++ b/samples/cpp-winrt/static-enum-endpoints/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Microsoft.Windows.CppWinRT" version="2.0.240405.15" targetFramework="native" />
-  <package id="Microsoft.Windows.Devices.Midi2" version="1.0.13-preview.13.154" targetFramework="native" />
+  <package id="Microsoft.Windows.Devices.Midi2" version="1.0.13-preview.13.156" targetFramework="native" />
 </packages>

--- a/samples/cpp-winrt/static-enum-endpoints/static-enum-endpoints-cpp.vcxproj
+++ b/samples/cpp-winrt/static-enum-endpoints/static-enum-endpoints-cpp.vcxproj
@@ -2,7 +2,7 @@
 <Project DefaultTargets="Build" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\packages\Microsoft.Windows.CppWinRT.2.0.240405.15\build\native\Microsoft.Windows.CppWinRT.props" Condition="Exists('..\packages\Microsoft.Windows.CppWinRT.2.0.240405.15\build\native\Microsoft.Windows.CppWinRT.props')" />
   <PropertyGroup Label="Globals">
-    <WindowsMidiServicesSdkPackage>Microsoft.Windows.Devices.Midi2.1.0.13-preview.13.154</WindowsMidiServicesSdkPackage>
+    <WindowsMidiServicesSdkPackage>Microsoft.Windows.Devices.Midi2.1.0.13-preview.13.156</WindowsMidiServicesSdkPackage>
     <CppWinRTOptimized>true</CppWinRTOptimized>
     <CppWinRTRootNamespaceAutoMerge>true</CppWinRTRootNamespaceAutoMerge>
     <CppWinRTGenerateWindowsMetadata>true</CppWinRTGenerateWindowsMetadata>

--- a/samples/cpp-winrt/watch-endpoints/packages.config
+++ b/samples/cpp-winrt/watch-endpoints/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Microsoft.Windows.CppWinRT" version="2.0.240405.15" targetFramework="native" />
-  <package id="Microsoft.Windows.Devices.Midi2" version="1.0.13-preview.13.154" targetFramework="native" />
+  <package id="Microsoft.Windows.Devices.Midi2" version="1.0.13-preview.13.156" targetFramework="native" />
 </packages>

--- a/samples/cpp-winrt/watch-endpoints/watch-endpoints-cpp.vcxproj
+++ b/samples/cpp-winrt/watch-endpoints/watch-endpoints-cpp.vcxproj
@@ -2,7 +2,7 @@
 <Project DefaultTargets="Build" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\packages\Microsoft.Windows.CppWinRT.2.0.240405.15\build\native\Microsoft.Windows.CppWinRT.props" Condition="Exists('..\packages\Microsoft.Windows.CppWinRT.2.0.240405.15\build\native\Microsoft.Windows.CppWinRT.props')" />
   <PropertyGroup Label="Globals">
-    <WindowsMidiServicesSdkPackage>Microsoft.Windows.Devices.Midi2.1.0.13-preview.13.154</WindowsMidiServicesSdkPackage>
+    <WindowsMidiServicesSdkPackage>Microsoft.Windows.Devices.Midi2.1.0.13-preview.13.156</WindowsMidiServicesSdkPackage>
     <CppWinRTOptimized>true</CppWinRTOptimized>
     <CppWinRTRootNamespaceAutoMerge>true</CppWinRTRootNamespaceAutoMerge>
     <CppWinRTGenerateWindowsMetadata>true</CppWinRTGenerateWindowsMetadata>

--- a/src/api/Inc/MidiEndpointCustomPropertiesCache.h
+++ b/src/api/Inc/MidiEndpointCustomPropertiesCache.h
@@ -31,12 +31,12 @@ namespace WindowsMidiServicesPluginConfigurationLib
         //std::shared_ptr<MidiEndpointCustomProperties> GetProperties(_In_ std::map<winrt::hstring, winrt::hstring> knownEndpointProperties);
         std::shared_ptr<MidiEndpointCustomProperties> GetProperties(_In_ MidiEndpointMatchCriteria& knownEndpointProperties);
 
-        void Add(_In_ std::shared_ptr<MidiEndpointMatchCriteria> match, _In_ std::shared_ptr<MidiEndpointCustomProperties> properties);
+        bool Add(_In_ std::shared_ptr<MidiEndpointMatchCriteria> match, _In_ std::shared_ptr<MidiEndpointCustomProperties> properties);
 
         // TODO: Do we need a "remove" in here?
 
     private:
-        std::vector<MidiEndpointCustomPropertiesCacheEntry> m_entries;
+        std::vector<std::shared_ptr<MidiEndpointCustomPropertiesCacheEntry>> m_entries;
 
     };
 

--- a/src/api/Libs/MidiPluginConfigurationLib/MidiEndpointCustomProperties.cpp
+++ b/src/api/Libs/MidiPluginConfigurationLib/MidiEndpointCustomProperties.cpp
@@ -415,7 +415,7 @@ bool MidiEndpointCustomProperties::WriteNonCommonProperties(_In_ std::vector<DEV
 
     // naming approach
     destination.push_back({ { PKEY_MIDI_Midi1PortNamingSelection, DEVPROP_STORE_SYSTEM, nullptr },
-        DEVPROP_TYPE_UINT32, (ULONG)sizeof(WindowsMidiServicesNamingLib::Midi1PortNameSelection), (PVOID)&Midi1NamingApproach });
+        DEVPROP_TYPE_UINT32, (ULONG)sizeof(uint32_t), (PVOID)&Midi1NamingApproach });
 
 
     return true;

--- a/src/api/Libs/MidiPluginConfigurationLib/MidiEndpointCustomPropertiesCache.cpp
+++ b/src/api/Libs/MidiPluginConfigurationLib/MidiEndpointCustomPropertiesCache.cpp
@@ -47,9 +47,9 @@ std::shared_ptr<MidiEndpointCustomProperties> MidiEndpointCustomPropertiesCache:
 {
     for (auto const& entry : m_entries)
     {
-        if (entry.Match->Matches(knownEndpointProperties))
+        if (entry->Match->Matches(knownEndpointProperties))
         {
-            return entry.Properties;
+            return entry->Properties;
         }
     }
 
@@ -60,14 +60,38 @@ std::shared_ptr<MidiEndpointCustomProperties> MidiEndpointCustomPropertiesCache:
 
 
 _Use_decl_annotations_
-void MidiEndpointCustomPropertiesCache::Add(
+bool MidiEndpointCustomPropertiesCache::Add(
     std::shared_ptr<MidiEndpointMatchCriteria> match, std::shared_ptr<MidiEndpointCustomProperties> properties)
 {
-    MidiEndpointCustomPropertiesCacheEntry entry{};
-    entry.Match = match;
-    entry.Properties = properties;
+
+    // Need to make sure we don't already have custom properties for this endpoint. If so, remove them.
+    // we only remove one, because if we do this correctly each time, there will never be more than one
+    // other match in here.
+
+    std::vector<std::shared_ptr<MidiEndpointCustomPropertiesCacheEntry>>::iterator it;
+
+    for (it = m_entries.begin(); it != m_entries.end(); it++)
+    {
+        if ((*it)->Match->Matches(*match))
+        {
+            m_entries.erase(it);
+            break;
+        }
+    }
+
+    auto entry = std::make_shared<MidiEndpointCustomPropertiesCacheEntry>();
+
+    if (entry == nullptr)
+    {
+        return false;
+    }
+
+    entry->Match = match;
+    entry->Properties = properties;
 
     m_entries.push_back(entry);
+
+    return true;
 }
 
 

--- a/src/api/Transport/KSAggregateTransport/Midi2.KSAggregateMidiConfigurationManager.cpp
+++ b/src/api/Transport/KSAggregateTransport/Midi2.KSAggregateMidiConfigurationManager.cpp
@@ -105,7 +105,8 @@ CMidi2KSAggregateMidiConfigurationManager::ProcessCustomProperties(
         if (customProperties != nullptr)
         {
             // cache this set of properties in case of surprise removal or the device is added later
-            m_customPropertiesCache->Add(matchCriteria, customProperties);
+            auto cached = m_customPropertiesCache->Add(matchCriteria, customProperties);
+            LOG_HR_IF(E_FAIL, !cached);
 
             // we only write dev properties if we have a resolved endpoint device id
             // otherwise, caching is the best we can do

--- a/src/api/Transport/KSAggregateTransport/Midi2.KSAggregateMidiEndpointManager.cpp
+++ b/src/api/Transport/KSAggregateTransport/Midi2.KSAggregateMidiEndpointManager.cpp
@@ -493,7 +493,7 @@ CMidi2KSAggregateMidiEndpointManager::CreateMidiUmpEndpoint(
         );
 
         // return new device interface id
-        masterEndpointDefinition.EndpointDeviceId = std::wstring{ newDeviceInterfaceId.get() };
+        masterEndpointDefinition.EndpointDeviceId = internal::NormalizeEndpointInterfaceIdWStringCopy(std::wstring{ newDeviceInterfaceId.get() });
 
         auto lock = m_availableEndpointDefinitionsLock.lock();
 

--- a/src/api/Transport/KSTransport/Midi2.KSMidiConfigurationManager.cpp
+++ b/src/api/Transport/KSTransport/Midi2.KSMidiConfigurationManager.cpp
@@ -102,7 +102,8 @@ CMidi2KSMidiConfigurationManager::ProcessCustomProperties(
         if (customProperties != nullptr)
         {
             // cache this set of properties in case of surprise removal or the device is added later
-            m_customPropertiesCache->Add(matchCriteria, customProperties);
+            auto cached = m_customPropertiesCache->Add(matchCriteria, customProperties);
+            LOG_HR_IF(E_FAIL,!cached);
 
             if (customProperties->WriteAllProperties(endpointDevProperties))
             {

--- a/src/api/Transport/KSTransport/Midi2.KSMidiEndpointManager.cpp
+++ b/src/api/Transport/KSTransport/Midi2.KSMidiEndpointManager.cpp
@@ -492,8 +492,6 @@ CMidi2KSMidiEndpointManager::OnDeviceAdded(
         std::vector<DEVPROPERTY> interfaceDevProperties;
 
 
-        // TODO: Need to fold in cached custom properties ---------------------------------------------------------------------------
-
         MIDIENDPOINTCOMMONPROPERTIES commonProperties {};
         commonProperties.TransportId = KsTransportLayerGUID;
         commonProperties.EndpointDeviceType = MidiEndpointDeviceType_Normal;

--- a/src/app-sdk/tests/Benchmarks/Benchmarks.vcxproj
+++ b/src/app-sdk/tests/Benchmarks/Benchmarks.vcxproj
@@ -20,7 +20,7 @@
     </ProjectConfiguration>
   </ItemGroup>
   <PropertyGroup Label="Globals">
-    <WindowsMidiServicesSdkPackage>Microsoft.Windows.Devices.Midi2.1.0.13-preview.13.154</WindowsMidiServicesSdkPackage>
+    <WindowsMidiServicesSdkPackage>Microsoft.Windows.Devices.Midi2.1.0.13-preview.13.156</WindowsMidiServicesSdkPackage>
     <VCProjectVersion>17.0</VCProjectVersion>
     <ProjectGuid>{4DABE157-7DD5-422A-8C77-B83EAC9987D0}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>

--- a/src/app-sdk/tests/Benchmarks/packages.config
+++ b/src/app-sdk/tests/Benchmarks/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Microsoft.Windows.CppWinRT" version="2.0.250303.1" targetFramework="native" />
-  <package id="Microsoft.Windows.Devices.Midi2" version="1.0.13-preview.13.154" targetFramework="native" />
+  <package id="Microsoft.Windows.Devices.Midi2" version="1.0.13-preview.13.156" targetFramework="native" />
   <package id="Microsoft.Windows.ImplementationLibrary" version="1.0.250325.1" targetFramework="native" />
 </packages>

--- a/src/app-sdk/tests/InitializationExe/packages.config
+++ b/src/app-sdk/tests/InitializationExe/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Microsoft.Windows.CppWinRT" version="2.0.250303.1" targetFramework="native" />
-  <package id="Microsoft.Windows.Devices.Midi2" version="1.0.13-preview.13.154" targetFramework="native" />
+  <package id="Microsoft.Windows.Devices.Midi2" version="1.0.13-preview.13.156" targetFramework="native" />
   <package id="Microsoft.Windows.ImplementationLibrary" version="1.0.250325.1" targetFramework="native" />
 </packages>

--- a/src/app-sdk/tests/InitializationExe/sdkinittest.vcxproj
+++ b/src/app-sdk/tests/InitializationExe/sdkinittest.vcxproj
@@ -2,7 +2,7 @@
 <Project DefaultTargets="Build" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\..\packages\Microsoft.Windows.CppWinRT.2.0.250303.1\build\native\Microsoft.Windows.CppWinRT.props" Condition="Exists('..\..\packages\Microsoft.Windows.CppWinRT.2.0.250303.1\build\native\Microsoft.Windows.CppWinRT.props')" />
   <PropertyGroup Label="Globals">
-    <WindowsMidiServicesSdkPackage>Microsoft.Windows.Devices.Midi2.1.0.13-preview.13.154</WindowsMidiServicesSdkPackage>
+    <WindowsMidiServicesSdkPackage>Microsoft.Windows.Devices.Midi2.1.0.13-preview.13.156</WindowsMidiServicesSdkPackage>
     <CppWinRTOptimized>true</CppWinRTOptimized>
     <CppWinRTRootNamespaceAutoMerge>true</CppWinRTRootNamespaceAutoMerge>
     <CppWinRTGenerateWindowsMetadata>true</CppWinRTGenerateWindowsMetadata>

--- a/src/app-sdk/tests/Offline.unittests/Offline.unittests.vcxproj
+++ b/src/app-sdk/tests/Offline.unittests/Offline.unittests.vcxproj
@@ -20,7 +20,7 @@
     </ProjectConfiguration>
   </ItemGroup>
   <PropertyGroup Label="Globals">
-    <WindowsMidiServicesSdkPackage>Microsoft.Windows.Devices.Midi2.1.0.13-preview.13.154</WindowsMidiServicesSdkPackage>
+    <WindowsMidiServicesSdkPackage>Microsoft.Windows.Devices.Midi2.1.0.13-preview.13.156</WindowsMidiServicesSdkPackage>
     <VCProjectVersion>17.0</VCProjectVersion>
     <ProjectGuid>{BCAE6353-5F32-4AE8-9949-039A2BC2C8C6}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>

--- a/src/app-sdk/tests/Offline.unittests/packages.config
+++ b/src/app-sdk/tests/Offline.unittests/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Microsoft.Windows.CppWinRT" version="2.0.250303.1" targetFramework="native" />
-  <package id="Microsoft.Windows.Devices.Midi2" version="1.0.13-preview.13.154" targetFramework="native" />
+  <package id="Microsoft.Windows.Devices.Midi2" version="1.0.13-preview.13.156" targetFramework="native" />
   <package id="Microsoft.Windows.ImplementationLibrary" version="1.0.250325.1" targetFramework="native" />
 </packages>

--- a/src/app-sdk/tests/SdkInitialization.unittests/SdkInitialization.unittests.vcxproj
+++ b/src/app-sdk/tests/SdkInitialization.unittests/SdkInitialization.unittests.vcxproj
@@ -20,7 +20,7 @@
     </ProjectConfiguration>
   </ItemGroup>
   <PropertyGroup Label="Globals">
-    <WindowsMidiServicesSdkPackage>Microsoft.Windows.Devices.Midi2.1.0.13-preview.13.154</WindowsMidiServicesSdkPackage>
+    <WindowsMidiServicesSdkPackage>Microsoft.Windows.Devices.Midi2.1.0.13-preview.13.156</WindowsMidiServicesSdkPackage>
     <VCProjectVersion>17.0</VCProjectVersion>
     <ProjectGuid>{9803D8E6-5CA5-420C-A02B-5E3327355041}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>

--- a/src/app-sdk/tests/SdkInitialization.unittests/packages.config
+++ b/src/app-sdk/tests/SdkInitialization.unittests/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Microsoft.Windows.CppWinRT" version="2.0.250303.1" targetFramework="native" />
-  <package id="Microsoft.Windows.Devices.Midi2" version="1.0.13-preview.13.154" targetFramework="native" />
+  <package id="Microsoft.Windows.Devices.Midi2" version="1.0.13-preview.13.156" targetFramework="native" />
   <package id="Microsoft.Windows.ImplementationLibrary" version="1.0.250325.1" targetFramework="native" />
 </packages>

--- a/src/app-sdk/tests/Service.integrationtests/Service.integrationtests.vcxproj
+++ b/src/app-sdk/tests/Service.integrationtests/Service.integrationtests.vcxproj
@@ -20,7 +20,7 @@
     </ProjectConfiguration>
   </ItemGroup>
   <PropertyGroup Label="Globals">
-    <WindowsMidiServicesSdkPackage>Microsoft.Windows.Devices.Midi2.1.0.13-preview.13.154</WindowsMidiServicesSdkPackage>
+    <WindowsMidiServicesSdkPackage>Microsoft.Windows.Devices.Midi2.1.0.13-preview.13.156</WindowsMidiServicesSdkPackage>
     <VCProjectVersion>17.0</VCProjectVersion>
     <ProjectGuid>{63FDB29C-5638-427B-86BF-05B318480571}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>

--- a/src/app-sdk/tests/Service.integrationtests/packages.config
+++ b/src/app-sdk/tests/Service.integrationtests/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Microsoft.Windows.CppWinRT" version="2.0.250303.1" targetFramework="native" />
-  <package id="Microsoft.Windows.Devices.Midi2" version="1.0.13-preview.13.154" targetFramework="native" />
+  <package id="Microsoft.Windows.Devices.Midi2" version="1.0.13-preview.13.156" targetFramework="native" />
   <package id="Microsoft.Windows.ImplementationLibrary" version="1.0.250325.1" targetFramework="native" />
 </packages>

--- a/src/app-sdk/tools/mididiag/mididiag.vcxproj
+++ b/src/app-sdk/tools/mididiag/mididiag.vcxproj
@@ -3,7 +3,7 @@
   <Import Project="..\..\packages\Microsoft.Windows.CppWinRT.2.0.250303.1\build\native\Microsoft.Windows.CppWinRT.props" Condition="Exists('..\..\packages\Microsoft.Windows.CppWinRT.2.0.250303.1\build\native\Microsoft.Windows.CppWinRT.props')" />
   <Import Project="$(SolutionDir)packages\Microsoft.Windows.CppWinRT.2.0.240405.15\build\native\Microsoft.Windows.CppWinRT.props" Condition="Exists('$(SolutionDir)packages\Microsoft.Windows.CppWinRT.2.0.240405.15\build\native\Microsoft.Windows.CppWinRT.props')" />
   <PropertyGroup Label="Globals">
-    <WindowsMidiServicesSdkPackage>Microsoft.Windows.Devices.Midi2.1.0.13-preview.13.154</WindowsMidiServicesSdkPackage>
+    <WindowsMidiServicesSdkPackage>Microsoft.Windows.Devices.Midi2.1.0.13-preview.13.156</WindowsMidiServicesSdkPackage>
     <CppWinRTOptimized>true</CppWinRTOptimized>
     <CppWinRTRootNamespaceAutoMerge>true</CppWinRTRootNamespaceAutoMerge>
     <CppWinRTGenerateWindowsMetadata>true</CppWinRTGenerateWindowsMetadata>

--- a/src/app-sdk/tools/mididiag/packages.config
+++ b/src/app-sdk/tools/mididiag/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Microsoft.Windows.CppWinRT" version="2.0.250303.1" targetFramework="native" />
-  <package id="Microsoft.Windows.Devices.Midi2" version="1.0.13-preview.13.154" targetFramework="native" />
+  <package id="Microsoft.Windows.Devices.Midi2" version="1.0.13-preview.13.156" targetFramework="native" />
   <package id="Microsoft.Windows.ImplementationLibrary" version="1.0.250325.1" targetFramework="native" />
 </packages>

--- a/src/app-sdk/tools/midimdnsinfo/midimdnsinfo.vcxproj
+++ b/src/app-sdk/tools/midimdnsinfo/midimdnsinfo.vcxproj
@@ -2,7 +2,7 @@
 <Project DefaultTargets="Build" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\..\packages\Microsoft.Windows.CppWinRT.2.0.250303.1\build\native\Microsoft.Windows.CppWinRT.props" Condition="Exists('..\..\packages\Microsoft.Windows.CppWinRT.2.0.250303.1\build\native\Microsoft.Windows.CppWinRT.props')" />
   <PropertyGroup Label="Globals">
-    <WindowsMidiServicesSdkPackage>Microsoft.Windows.Devices.Midi2.1.0.13-preview.13.154</WindowsMidiServicesSdkPackage>
+    <WindowsMidiServicesSdkPackage>Microsoft.Windows.Devices.Midi2.1.0.13-preview.13.156</WindowsMidiServicesSdkPackage>
     <CppWinRTOptimized>true</CppWinRTOptimized>
     <CppWinRTRootNamespaceAutoMerge>true</CppWinRTRootNamespaceAutoMerge>
     <CppWinRTGenerateWindowsMetadata>true</CppWinRTGenerateWindowsMetadata>

--- a/src/app-sdk/tools/midimdnsinfo/packages.config
+++ b/src/app-sdk/tools/midimdnsinfo/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Microsoft.Windows.CppWinRT" version="2.0.250303.1" targetFramework="native" />
-  <package id="Microsoft.Windows.Devices.Midi2" version="1.0.13-preview.13.154" targetFramework="native" />
+  <package id="Microsoft.Windows.Devices.Midi2" version="1.0.13-preview.13.156" targetFramework="native" />
   <package id="Microsoft.Windows.ImplementationLibrary" version="1.0.250325.1" targetFramework="native" />
 </packages>

--- a/src/app-sdk/tools/midiusbinfo/midiusbinfo.vcxproj
+++ b/src/app-sdk/tools/midiusbinfo/midiusbinfo.vcxproj
@@ -2,7 +2,7 @@
 <Project DefaultTargets="Build" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\..\packages\Microsoft.Windows.CppWinRT.2.0.250303.1\build\native\Microsoft.Windows.CppWinRT.props" Condition="Exists('..\..\packages\Microsoft.Windows.CppWinRT.2.0.250303.1\build\native\Microsoft.Windows.CppWinRT.props')" />
   <PropertyGroup Label="Globals">
-    <WindowsMidiServicesSdkPackage>Microsoft.Windows.Devices.Midi2.1.0.13-preview.13.154</WindowsMidiServicesSdkPackage>
+    <WindowsMidiServicesSdkPackage>Microsoft.Windows.Devices.Midi2.1.0.13-preview.13.156</WindowsMidiServicesSdkPackage>
     <CppWinRTOptimized>true</CppWinRTOptimized>
     <CppWinRTRootNamespaceAutoMerge>true</CppWinRTRootNamespaceAutoMerge>
     <CppWinRTGenerateWindowsMetadata>true</CppWinRTGenerateWindowsMetadata>

--- a/src/app-sdk/tools/midiusbinfo/packages.config
+++ b/src/app-sdk/tools/midiusbinfo/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Microsoft.Windows.CppWinRT" version="2.0.250303.1" targetFramework="native" />
-  <package id="Microsoft.Windows.Devices.Midi2" version="1.0.13-preview.13.154" targetFramework="native" />
+  <package id="Microsoft.Windows.Devices.Midi2" version="1.0.13-preview.13.156" targetFramework="native" />
   <package id="Microsoft.Windows.ImplementationLibrary" version="1.0.250325.1" targetFramework="native" />
 </packages>

--- a/src/user-tools/midi-settings/Microsoft.Midi.Settings/Views/ShellPage.xaml
+++ b/src/user-tools/midi-settings/Microsoft.Midi.Settings/Views/ShellPage.xaml
@@ -70,12 +70,11 @@
             <RowDefinition Height="Auto" />
             <RowDefinition Height="*" />
         </Grid.RowDefinitions>
-        
-       
+
+
         <Grid x:Name="AppTitleBar"
               Grid.Row="0"
-              VerticalAlignment="Top"
-              >
+              VerticalAlignment="Top">
 
 
             <controls:TitleBar x:Name="AppTitleBarControl" 


### PR DESCRIPTION
See MidiEndpointPropertiesCache.Add for the change. Doesn't fix the Iridium's name/description corruption, but given that it's randomly with this one MIDI 2.0 device, and no MIDI 1 devices regardless of driver, and sometimes the problems shows in the name and other times in the description, it may be related to the driver GTB memory issue. I'll need to continue testing.