### PR TITLE
fixes for retrying sends, and service hang if client creation fails

### DIFF
--- a/src/api/Inc/MidiXProc.h
+++ b/src/api/Inc/MidiXProc.h
@@ -33,6 +33,7 @@ typedef struct MEMORY_MAPPED_REGISTERS
 typedef struct MEMORY_MAPPED_PIPE
 {
     MidiDataFormats DataFormat {MidiDataFormats_Invalid};
+    MessageOptionFlags MessageOptions {MessageOptionFlags_None};
 
     std::unique_ptr<MEMORY_MAPPED_BUFFER> DataBuffer;
     std::unique_ptr<MEMORY_MAPPED_BUFFER> RegistersBuffer;
@@ -112,6 +113,9 @@ private:
     // only 1 client may send a message at a time on the cross process
     // queue
     wil::critical_section m_MessageSendLock;
+    bool m_PipeStalled {false};
+    ULONGLONG m_SequentialDroppedBuffers {0};
+    ULONGLONG m_TotalDroppedBuffers {0};
 
     static BOOL m_useMMCSS;             // true if we are configured to use MMCSS
     static BOOL m_mmcssSettingRead;     // true if the MMCSS use value has been read from the registry

--- a/src/api/Libs/MidiKs/MidiKs.cpp
+++ b/src/api/Libs/MidiKs/MidiKs.cpp
@@ -221,7 +221,7 @@ KSMidiDevice::ConfigureLoopedBuffer(ULONG& bufferSize
             &buffer,
             sizeof(buffer),
             nullptr);
-}));
+    }));
 
     m_MidiPipe->Data.BufferAddress = (PBYTE) buffer.BufferAddress;
     bufferSize = m_MidiPipe->Data.BufferSize = buffer.ActualBufferSize;
@@ -254,7 +254,7 @@ KSMidiDevice::ConfigureLoopedRegisters()
             &registers,
             sizeof(registers),
             nullptr);
-}));
+    }));
 
     m_MidiPipe->Registers.ReadPosition = (PULONG) registers.ReadPosition;
     m_MidiPipe->Registers.WritePosition = (PULONG) registers.WritePosition;
@@ -290,7 +290,7 @@ KSMidiDevice::ConfigureLoopedEvent()
             &LoopedEvent,
             sizeof(LoopedEvent),
             nullptr);
-}));
+    }));
 
     return S_OK;
 }

--- a/src/api/Libs/MidiSrvTransportLib/MidiSrvTransport.cpp
+++ b/src/api/Libs/MidiSrvTransportLib/MidiSrvTransport.cpp
@@ -133,7 +133,10 @@ CMidi2MidiSrv::Initialize(
     clientCreationParams.BufferSize = PAGE_SIZE;  // original
     //clientCreationParams.BufferSize = 256;    // Set this for debugging see https://github.com/microsoft/MIDI/issues/182 for all the drama :)
     //clientCreationParams.BufferSize = PAGE_SIZE * 8;
-    clientCreationParams.MessageOptions = creationParams->MessageOptions;
+
+    // We request CallbackRetry on the service to client pipe to request that our messages are not dropped in the event that the device
+    // pipe becomes full.
+    clientCreationParams.MessageOptions = (MessageOptionFlags) (creationParams->MessageOptions | MessageOptionFlags_CallbackRetry);
 
     RETURN_IF_FAILED(GetMidiSrvBindingHandle(&bindingHandle));
 
@@ -158,6 +161,7 @@ CMidi2MidiSrv::Initialize(
         midiInPipe.reset(new (std::nothrow) MEMORY_MAPPED_PIPE);
         RETURN_IF_NULL_ALLOC(midiInPipe);
         midiInPipe->DataFormat = client->DataFormat;
+        midiInPipe->MessageOptions = clientCreationParams.MessageOptions;
         midiInPipe->DataBuffer.reset(new (std::nothrow) MEMORY_MAPPED_BUFFER);
         RETURN_IF_NULL_ALLOC(midiInPipe->DataBuffer);
         midiInPipe->RegistersBuffer.reset(new (std::nothrow) MEMORY_MAPPED_BUFFER);
@@ -180,6 +184,7 @@ CMidi2MidiSrv::Initialize(
         midiOutPipe.reset(new (std::nothrow) MEMORY_MAPPED_PIPE);
         RETURN_IF_NULL_ALLOC(midiOutPipe);
         midiOutPipe->DataFormat = client->DataFormat;
+        midiOutPipe->MessageOptions = clientCreationParams.MessageOptions;
         midiOutPipe->DataBuffer.reset(new (std::nothrow) MEMORY_MAPPED_BUFFER);
         RETURN_IF_NULL_ALLOC(midiOutPipe->DataBuffer);
         midiOutPipe->RegistersBuffer.reset(new (std::nothrow) MEMORY_MAPPED_BUFFER);

--- a/src/api/Service/Inc/MidiClientPipe.h
+++ b/src/api/Service/Inc/MidiClientPipe.h
@@ -82,6 +82,7 @@ private:
     BOOL m_GroupFiltered{FALSE};
     BYTE m_GroupIndex{0};
 
-    MessageOptionFlags m_MessageOptions { MessageOptionFlags_None };
+    MessageOptionFlags m_MidiInMessageOptions { MessageOptionFlags_None };
+    MessageOptionFlags m_MidiOutMessageOptions { MessageOptionFlags_None };
 };
 

--- a/src/api/Test/Midi2.Service.unittests/Midi2ServiceTests.h
+++ b/src/api/Test/Midi2.Service.unittests/Midi2ServiceTests.h
@@ -34,6 +34,7 @@ public:
     //Generic Tests
     TEST_METHOD(TestMidiServiceClientRPC);
     TEST_METHOD(TestMidiServiceInvalidCreationParams);
+    TEST_METHOD(TestMidiServiceFailedCreation);
 
     Midi2ServiceTests()
     {}

--- a/src/api/idl/WindowsMidiServices.idl
+++ b/src/api/idl/WindowsMidiServices.idl
@@ -54,8 +54,11 @@ typedef enum
 {
     MessageOptionFlags_None = 0,
     MessageOptionFlags_WaitForSendComplete = 1,
-    MessageOptionFlags_ContextContainsGroupIndex = 2
+    MessageOptionFlags_ContextContainsGroupIndex = 2,
+    MessageOptionFlags_CallbackRetry = 4
 } MessageOptionFlags;
+
+cpp_quote("#define MessageOptionFlags_Valid 0x00000007")
 
 // Structure used during transport initialization to communicate format information and other configuration
 typedef struct


### PR DESCRIPTION
If creation failed, it attempted to reenter the srw lock, which isn't permitted. Move cleanup on failure outside of the lock. Add a test case to cover this scenario.

If sending a message fails, set a flag on the xproc so that we don't wait for the failure over and over, future sends will confirm the pipe is still hung and fail fast. 

Going along with this, if the endpoint doesn't process any messages, let the messages backup in the pipe, and don't drop the messages, to ensure the client gets appropriate error messages.

The previous throttling change had an unintended side effect of the throttling being applied to the midi in side of the pipe, meaning that if a client requested throttling all midi in messages from that device would be throttled to all the clients. Split message options so we can have different options for midi in and midi out, and don't set throttling on midi in.