### PR TITLE
chore: fix typos and grammar issues in multiple places

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -50,7 +50,7 @@ For code, one place to start is by looking at the open issues here in Github, or
 
 > All contributions must be compatible with the MIT license we use. 
 
-## Specific Consideratiopns
+## Specific Considerations
 
 ### External OSS Library Dependencies
 

--- a/docs/_docs/2019-01-16-change-password.md
+++ b/docs/_docs/2019-01-16-change-password.md
@@ -1,6 +1,6 @@
 ---
 layout: doc
-title: Chnage Password
+title: Change Password
 date: 2019-09-08 8:14:30 +0600
 post_image: assets/images/service-icon3.png
 tags: [Account Settings]

--- a/docs/_includes/topics_area.html
+++ b/docs/_includes/topics_area.html
@@ -16,7 +16,7 @@
 			
 					<article class="post topics-service bg-color3 wow fadeIn" data-wow-duration="3s">
 						<header class="topics-title">
-						 <h4 class="heading-4 text-capitalize">{{ tag }} </h4>  </h4>
+						 <h4 class="heading-4 text-capitalize">{{ tag }} </h4>
 						</header>
                   <ul class="topics-list list-inline">
                      {% for doc_post in site.docs %}

--- a/docs/kb/what-is-sdk-initialization-doing.md
+++ b/docs/kb/what-is-sdk-initialization-doing.md
@@ -124,7 +124,7 @@ This is not related to the SDK itself, but to the in-box Windows service.
 
 To ship the service and its transport/transform plugins in Windows, we had to set it to demand-start. That is, it only starts when applications need to use its features. This helps Windows start up quickly -- something particularly important given that the set of users who use MIDI is relatively small compared to the audience as a whole.
 
-When the first call is made into the service, the service is started up. During startup, we enumerate devices, initialize the transports, create the Windows MIDI Services endpoints, peform discovery and protocol negotiation with MIDI 2 devices, and create compatible WinMM ports. If you have many MIDI devices attached, this can take a noticeable number of seconds to complete.
+When the first call is made into the service, the service is started up. During startup, we enumerate devices, initialize the transports, create the Windows MIDI Services endpoints, perform discovery and protocol negotiation with MIDI 2 devices, and create compatible WinMM ports. If you have many MIDI devices attached, this can take a noticeable number of seconds to complete.
 
 > Customers are free to change the service to automatic start. In fact, we recommend that for anyone who uses MIDI regularly -- especially musicians. That will avoid the delay when making that first call into the service.
 

--- a/src/api/Test/Midi2.Driver.unittests/stdafx.h
+++ b/src/api/Test/Midi2.Driver.unittests/stdafx.h
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 #pragma once
 
-// this is a hack, but because this is a test project, and know we're not
+// this is a hack, but because this is a test project, and we know we're not
 // using coroutines in our tests, we'll risk it. 
 #define _ALLOW_COROUTINE_ABI_MISMATCH
 


### PR DESCRIPTION
This PR corrects several typos and small grammar issues across docs and tests:

- CONTRIBUTING.md: “Consideratiopns” -> “Considerations”.
- Change password doc: fixed “Chnage” typo.
- topics\_area.html: removed extra `</h4>`.
- MIDI service KB: corrected “peform” -> “perform”.
- stdafx.h: fixed comment wording (`and know` ->`and we know`).

> No functional changes. Only docs/comments cleanup.
