### PR TITLE
Issue 362, 695 and 599

### DIFF
--- a/src/api/Drivers/USBMIDI2/Driver/StreamEngine.h
+++ b/src/api/Drivers/USBMIDI2/Driver/StreamEngine.h
@@ -42,6 +42,9 @@ Environment:
 
 class StreamEngine;
 
+#define READ_BUFFER_MAX_THRESHOLD   384 * sizeof(UMPDATAFORMAT)
+#define READ_BUFFER_MIN_THRESHOLD   256 * sizeof(UMPDATAFORMAT)
+
 typedef struct _SINGLE_BUFFER_MAPPING
 {
     // address of the memory alloation
@@ -137,6 +140,12 @@ public:
         _In_reads_(bufferSize)      PUINT8              pBuffer,
         _In_                        size_t              bufferSize
     );
+
+    _Must_inspect_result_
+    __drv_maxIRQL(PASSIVE_LEVEL)
+    NONPAGED_CODE_SEG
+    ULONG
+    BufferInUse();
 
 private:
 


### PR DESCRIPTION
Issue 362, Issue 695 and Feature 599
Driver updated to include:
- Continuous Reader max and min thresholds to stop and start continuous reader at governed level of input cross process buffer, not overloading it.
- a read monitor thread that responds to read events on buffer for continuous reader but also ability to exit worker thread if requested
- Governor on read inputs which completes Feature 599 from a driver point of view

Issue 695 is complete from a driver point of view, although testing shows likey good through whole IO stack.