### PR TITLE
Issue 798 - Driver Verifier errors with continuous reader

### DIFF
--- a/src/api/Drivers/USBMIDI2/Driver/Device.cpp
+++ b/src/api/Drivers/USBMIDI2/Driver/Device.cpp
@@ -474,7 +474,6 @@ EvtDeviceD0Entry(
 )
 {
     UNREFERENCED_PARAMETER(PreviousState);
-    UNREFERENCED_PARAMETER(Device);
 
     TraceEvents(TRACE_LEVEL_INFORMATION, TRACE_DRIVER, "%!FUNC! Entry");
 

--- a/src/api/Drivers/USBMIDI2/Driver/Device.cpp
+++ b/src/api/Drivers/USBMIDI2/Driver/Device.cpp
@@ -474,11 +474,12 @@ EvtDeviceD0Entry(
 )
 {
     UNREFERENCED_PARAMETER(PreviousState);
+    UNREFERENCED_PARAMETER(Device);
 
     TraceEvents(TRACE_LEVEL_INFORMATION, TRACE_DRIVER, "%!FUNC! Entry");
 
     PAGED_CODE();
-    USBMIDI2DriverIoContinuousReader(Device, true, true);
+    //USBMIDI2DriverIoContinuousReader(Device, true, true);
 
     TraceEvents(TRACE_LEVEL_INFORMATION, TRACE_DRIVER, "%!FUNC! Exit");
 
@@ -499,8 +500,6 @@ EvtDeviceD0Exit(
     TraceEvents(TRACE_LEVEL_INFORMATION, TRACE_DRIVER, "%!FUNC! Entry");
 
     PAGED_CODE();
-    USBMIDI2DriverIoContinuousReader(Device, false, true);
-
     powerAction = WdfDeviceGetSystemPowerAction(Device);
 
     // 
@@ -514,6 +513,8 @@ EvtDeviceD0Exit(
 
         devCtx = GetDeviceContext(Device);
         ASSERT(devCtx != nullptr);
+
+        USBMIDI2DriverIoContinuousReader(Device, false, false);
 
         //
         // Get the current exit latency.
@@ -2120,6 +2121,7 @@ Return Value:
     NTSTATUS            status;
     KIRQL               oldLevel;
 
+    TraceEvents(TRACE_LEVEL_INFORMATION, TRACE_DRIVER, "%!FUNC! Entry");
 
     pDeviceContext = GetDeviceContext(Device);
     
@@ -2157,6 +2159,7 @@ Return Value:
         }
         KeReleaseSpinLock(&pDeviceContext->ContRdrLock, oldLevel);
     }
+    TraceEvents(TRACE_LEVEL_INFORMATION, TRACE_DRIVER, "%!FUNC! Exit");
 }
 
 _Use_decl_annotations_

--- a/src/api/Drivers/USBMIDI2/Driver/Device.h
+++ b/src/api/Drivers/USBMIDI2/Driver/Device.h
@@ -278,7 +278,8 @@ NONPAGED_CODE_SEG
 VOID
 USBMIDI2DriverIoContinuousReader(
     _In_ WDFDEVICE  Device,
-    _In_ BOOLEAN    runContinuousReader
+    _In_ BOOLEAN    runContinuousReader,
+    _In_ BOOLEAN    setActive
 );
 
 //

--- a/src/api/Drivers/USBMIDI2/Driver/StreamEngine.cpp
+++ b/src/api/Drivers/USBMIDI2/Driver/StreamEngine.cpp
@@ -576,6 +576,9 @@ StreamEngine::Pause()
     }
     else if (AcxPinGetId(m_Pin) == MidiPinTypeMidiIn)
     {
+        // Stop Continous Reader
+        USBMIDI2DriverIoContinuousReader(AcxCircuitGetWdfDevice(AcxPinGetCircuit(m_Pin)), false, false);
+
         // Make sure we are not trying to change state while processing
         auto lock = m_MidiInLock.acquire();
 
@@ -584,9 +587,6 @@ StreamEngine::Pause()
         m_TotalDroppedBuffers = 0;
         m_ContiguousDroppedBuffers = 0;
         m_TotalBuffersProcessed = 0;
-
-        // Stop Continous Reader
-        USBMIDI2DriverIoContinuousReader(AcxCircuitGetWdfDevice(AcxPinGetCircuit(m_Pin)), false, false);
 
         // shut down and clean up the worker thread.
         m_ThreadExitEvent.set();

--- a/src/api/Drivers/USBMIDI2/Driver/StreamEngine.cpp
+++ b/src/api/Drivers/USBMIDI2/Driver/StreamEngine.cpp
@@ -585,6 +585,9 @@ StreamEngine::Pause()
         m_ContiguousDroppedBuffers = 0;
         m_TotalBuffersProcessed = 0;
 
+        // Stop Continous Reader
+        USBMIDI2DriverIoContinuousReader(AcxCircuitGetWdfDevice(AcxPinGetCircuit(m_Pin)), false, false);
+
         // shut down and clean up the worker thread.
         m_ThreadExitEvent.set();
         m_ThreadExitedEvent.wait();


### PR DESCRIPTION
Driver verified notified issue with interrupt access levels during calls to start and top continuous reader. Ensured there was no spin locks in play when continuous reader started or stopped. This resolved any Driver Verifier issues. 
