### PR TITLE
improved device removal handling, fix crashes and recovery after removal

### DIFF
--- a/src/api/Inc/MidiKS.h
+++ b/src/api/Inc/MidiKS.h
@@ -28,21 +28,38 @@ protected:
 
     virtual
     HRESULT Initialize(
-        _In_ LPCWSTR,
-        _In_opt_ HANDLE,
-        _In_ UINT,
-        _In_ MidiTransport,
-        _In_ ULONG&,
-        _In_ MessageOptionFlags);
+        _In_ LPCWSTR device,
+        _In_opt_ HANDLE filter,
+        _In_ UINT pinId,
+        _In_ MidiTransport transport,
+        _In_ ULONG& bufferSize,
+        _In_ DWORD* mmcssTaskId,
+        _In_ MessageOptionFlags optionFlags,
+        _In_ MidiFlow flow,
+        _In_ IMidiCallback *callback,
+        _In_ LONGLONG context
+        );
 
-    HRESULT OpenStream(_In_ ULONG&, _In_ MessageOptionFlags);
+    HRESULT OpenStream();
 
     HRESULT PinSetState(
         _In_ KSSTATE);
 
-    HRESULT ConfigureLoopedBuffer(_In_ ULONG&);
+    HRESULT ConfigureLoopedBuffer();
     HRESULT ConfigureLoopedRegisters();
     HRESULT ConfigureLoopedEvent();
+
+    // state and callbacks required to handle removal on a surprise removal
+    // or query remove, and restore on a query remove cancel.
+    wil::srwlock m_lock;
+    MidiFlow m_Flow{ MidiFlowOut };
+    bool m_DeviceRemoved {false};
+    IMidiCallback * m_Callback {nullptr};
+    LONGLONG m_Context {0};
+    ULONG m_BufferSize {0};
+    MessageOptionFlags m_OptionFlags {MessageOptionFlags_None};
+    void OnRemoveCallback();
+    void OnRestoreCallback();
 
     std::unique_ptr<KsHandleWrapper> m_FilterHandleWrapper;
     std::unique_ptr<KsHandleWrapper> m_PinHandleWrapper;

--- a/src/api/Inc/ThreadpoolWork.h
+++ b/src/api/Inc/ThreadpoolWork.h
@@ -1,0 +1,85 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License
+// ============================================================================
+// This is part of the Windows MIDI Services App API and should be used
+// in your Windows application via an official binary distribution.
+// Further information: https://aka.ms/midi
+// ============================================================================
+
+#pragma once
+
+#include <functional>
+#include <memory>
+#include <utility>
+
+class ThreadpoolWork
+{
+public:
+    ThreadpoolWork()
+    {
+        m_TpWork = CreateThreadpoolWork(&Callback, this, nullptr);
+    }
+
+    ~ThreadpoolWork()
+    {
+        PTP_WORK work = nullptr;
+
+        {
+            // prevent any additional work from being added
+            auto lock = m_Lock.lock();
+            work = m_TpWork;
+            m_TpWork = nullptr;
+        }
+
+        if (work)
+        {
+            WaitForThreadpoolWorkCallbacks(work, FALSE);
+            CloseThreadpoolWork(work);
+        }
+
+        // We're now single threaded, finish any outstanding
+        // callbacks
+        for (auto& f : m_CallbackLambdas)
+        {
+            if (f)
+            {
+                f();
+            }
+        }
+
+        m_CallbackLambdas.clear();
+    }
+
+    void Submit(std::function<void()> fn)
+    {
+        auto lock = m_Lock.lock();
+        if (m_TpWork)
+        {
+            m_CallbackLambdas.emplace_back(std::move(fn));
+            SubmitThreadpoolWork(m_TpWork);
+        }
+    }
+
+private:
+    static void CALLBACK Callback(PTP_CALLBACK_INSTANCE, void* ctx, PTP_WORK)\
+    {
+        auto This = static_cast<ThreadpoolWork*>(ctx);
+        std::vector<std::function<void()>> to_run;
+
+        // Atomically take all queued tasks
+        {
+            auto lock = This->m_Lock.lock();
+            to_run.swap(This->m_CallbackLambdas); // fn_ becomes empty while we run what's captured
+        }
+
+        // Run outside the lock
+        for (auto& f : to_run) {
+            if (f) f();
+        }
+    }
+
+    PTP_WORK m_TpWork {nullptr};
+    wil::critical_section m_Lock;
+    std::vector<std::function<void()>> m_CallbackLambdas;
+};
+

--- a/src/api/Service/Exe/MidiClientManager.cpp
+++ b/src/api/Service/Exe/MidiClientManager.cpp
@@ -551,7 +551,8 @@ CMidiClientManager::GetMidiProtocolDownscalerTransform(
     auto transforms = m_TransformPipes.equal_range(devicePipe->MidiDevice());
     for (auto& transform = transforms.first; transform != transforms.second; ++transform)
     {
-        if (flow == transform->second->Flow() && 
+        if (transform->second->IsDevicePipe(devicePipe) &&
+            flow == transform->second->Flow() && 
             transform->second->TransformGuid() == transformGuid)
         {
             RETURN_HR_IF(E_UNEXPECTED, transformPipe);
@@ -578,7 +579,7 @@ CMidiClientManager::GetMidiProtocolDownscalerTransform(
         wil::com_ptr_nothrow<IMidiDeviceManager> midiDeviceManager = m_DeviceManager.get();
         RETURN_IF_FAILED(Microsoft::WRL::MakeAndInitialize<CMidiTransformPipe>(&transform));
 
-        RETURN_IF_FAILED(transform->Initialize(devicePipe->MidiDevice().c_str(), &creationParams, &m_MmcssTaskId, midiDeviceManager.get()));
+        RETURN_IF_FAILED(transform->Initialize(devicePipe->MidiDevice().c_str(), devicePipe, &creationParams, &m_MmcssTaskId, midiDeviceManager.get()));
         transformPipe = transform.get();
 
         // connect the transform to the device
@@ -704,7 +705,8 @@ CMidiClientManager::GetMidiTransform(
         auto transforms = m_TransformPipes.equal_range(devicePipe->MidiDevice());
         for (auto& transform = transforms.first; transform != transforms.second; ++transform)
         {
-            if (flow == transform->second->Flow() &&
+            if (transform->second->IsDevicePipe(devicePipe) &&
+                flow == transform->second->Flow() &&
                 dataFormatFrom == transform->second->DataFormatIn() &&
                 dataFormatTo == transform->second->DataFormatOut())
             {
@@ -783,7 +785,7 @@ CMidiClientManager::GetMidiTransform(
         wil::com_ptr_nothrow<IMidiDeviceManager> midiDeviceManager = m_DeviceManager.get();
         RETURN_IF_FAILED(Microsoft::WRL::MakeAndInitialize<CMidiTransformPipe>(&transform));
 
-        RETURN_IF_FAILED(transform->Initialize(devicePipe->MidiDevice().c_str(), &creationParams, &m_MmcssTaskId, midiDeviceManager.get()));
+        RETURN_IF_FAILED(transform->Initialize(devicePipe->MidiDevice().c_str(), devicePipe, &creationParams, &m_MmcssTaskId, midiDeviceManager.get()));
         transformPipe = transform.get();
 
         // connect the transform to the device
@@ -861,7 +863,8 @@ CMidiClientManager::GetMidiScheduler(
     {
         //wil::com_ptr_nothrow<CMidiTransformPipe> pipe = transform->second.get();
 
-        if (transform->second->TransformGuid() == __uuidof(Midi2SchedulerTransform))
+        if (transform->second->IsDevicePipe(devicePipe) && 
+            transform->second->TransformGuid() == __uuidof(Midi2SchedulerTransform))
         {
             transformPipe = transform->second;
             break;
@@ -894,7 +897,7 @@ CMidiClientManager::GetMidiScheduler(
         wil::com_ptr_nothrow<IMidiDeviceManager> midiDeviceManager = m_DeviceManager.get();
         RETURN_IF_FAILED(Microsoft::WRL::MakeAndInitialize<CMidiTransformPipe>(&transform));
 
-        RETURN_IF_FAILED(transform->Initialize(devicePipe->MidiDevice().c_str(), &creationParams, &m_MmcssTaskId, midiDeviceManager.get()));
+        RETURN_IF_FAILED(transform->Initialize(devicePipe->MidiDevice().c_str(), devicePipe, &creationParams, &m_MmcssTaskId, midiDeviceManager.get()));
 
         transformPipe = transform.get();
 

--- a/src/api/Service/Exe/MidiDeviceManager.cpp
+++ b/src/api/Service/Exe/MidiDeviceManager.cpp
@@ -1770,6 +1770,8 @@ CMidiDeviceManager::DeactivateEndpoint
 
     do
     {
+        auto lock = m_midiPortsLock.lock();
+
         // locate the MIDIPORT that identifies the swd
         // NOTE: This uses instanceId, not the Device Interface Id
         auto item = std::find_if(m_midiPorts.begin(), m_midiPorts.end(), [&](const std::unique_ptr<MIDIPORT>& Port)
@@ -2659,6 +2661,8 @@ CMidiDeviceManager::RebuildMidi1PortsForEndpoint(
 )
 {
     std::wstring cleanEndpointId { internal::NormalizeEndpointInterfaceIdWStringCopy(endpointDeviceInterfaceId) };
+
+    auto lock = m_midiPortsLock.lock();
 
     for (auto& port : m_midiPorts)
     {

--- a/src/api/Service/Exe/MidiEndpointProtocolWorker.h
+++ b/src/api/Service/Exe/MidiEndpointProtocolWorker.h
@@ -46,6 +46,8 @@ public:
     void EndProcessing() { if (m_endProcessing.is_valid() && !m_endProcessing.is_signaled()) m_endProcessing.SetEvent(); }
 
 private:
+    wil::critical_section m_lock;
+
     std::wstring m_endpointDeviceInterfaceId;
     //std::wstring m_deviceInstanceId;
     GUID m_sessionId{};

--- a/src/api/Service/Exe/MidiTransformPipe.cpp
+++ b/src/api/Service/Exe/MidiTransformPipe.cpp
@@ -12,6 +12,7 @@ _Use_decl_annotations_
 HRESULT
 CMidiTransformPipe::Initialize(
     LPCWSTR device,
+    wil::com_ptr_nothrow<CMidiPipe>& devicePipe,
     PMIDISRV_TRANSFORMCREATION_PARAMS pipeCreationParams,
     DWORD* mmcssTaskId,
     IMidiDeviceManager* midiDeviceManager
@@ -32,6 +33,8 @@ CMidiTransformPipe::Initialize(
     TRANSFORMCREATIONPARAMS creationParams {};
 
     m_TransformGuid = pipeCreationParams->TransformGuid;
+
+    m_DevicePipe = devicePipe;
 
     // Confirm that this component is either signed, or we are in developer mode.
     // Else, do not use it.

--- a/src/api/Service/Inc/MidiTransformPipe.h
+++ b/src/api/Service/Inc/MidiTransformPipe.h
@@ -24,6 +24,7 @@ class CMidiTransformPipe : public CMidiPipe
 public:
     
     HRESULT Initialize(_In_ LPCWSTR, // device it's associated to
+                            _In_ wil::com_ptr_nothrow<CMidiPipe>& devicePipe,
                             _In_ PMIDISRV_TRANSFORMCREATION_PARAMS, // what transform to create
                             _In_ DWORD *, // mmcss
                             _In_ IMidiDeviceManager* // MidiDeviceManager to provide to transforms that need to update device properties
@@ -34,7 +35,13 @@ public:
 
     GUID TransformGuid();
 
+    BOOL IsDevicePipe(_In_ wil::com_ptr_nothrow<CMidiPipe>& devicePipe)
+    {
+        return (BOOL) (m_DevicePipe == devicePipe);
+    }
+
 private:
+    wil::com_ptr_nothrow<CMidiPipe> m_DevicePipe;
     wil::com_ptr_nothrow<IMidiDataTransform> m_MidiDataTransform;
     winrt::guid m_TransformGuid{};
 };


### PR DESCRIPTION
improved device removal handling, fix crashes and recovery after removal.

Xproc wasn't being invalidated when the driver handles were closed, resulting in a crash on attempts to write data after the removal.

On query remove cancel, restore the pin state and xproc to a running state.

Transforms were only looked up by device id, resulting in a transform connected to an invalidated device pipe being used in place of a new instance connected to the new device pipe, resulting in send and receive failures on the new clients using the new device pipe.

Upon removal, reattach, removal, potential for crash in protocol worker if shutdown happens during initialization.

Previous notification client handle must be unregistered on a worker thread, as unregistering from within the callback causes deadlock.

