### PR TITLE
Improve semantics in the `README`.

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,36 +2,37 @@
 
 This project is the next-generation MIDI API for Windows, including MIDI 1.0 and MIDI 2.0 (MIDI CI, and MIDI 2.0 UMP). It includes enhancements, a new USB class driver, new transports, and essential tools. The project adds many enhancements and bug fixes to our MIDI 1.0 support, and importantly adds support for the latest revisions to MIDI 2.0 as approved by The MIDI Association.
 
-> The open source USB MIDI 2.0 driver has been generously donated by [AMEI](https://www.amei.or.jp/), the **Association of Musical Electronics Industry**, and developed by [AmeNote :tm:](https://www.AmeNote.com/) in partnership with Microsoft. Please see the file headers for any additional copyright notices. A huge thank you to AMEI and its member companies for making this happen: AlphaTheta Corporation, INTERNET Co., Ltd., Kawai Musical Instruments Manufacturing Co., Ltd., CRYPTON FUTURE MEDIA, INC., CRIMSON TECHNOLOGY, Inc., KORG INC., Educational Corporation Shobi Gakuen, SyncPower Corporation, ZOOM CORPORATION, SUZUKI MUSICAL INST.MFG.CO.,LTD., TEAC CORPORATION, Yamaha Corporation, Yamaha Music Entertainment Holdings, Inc., Roland Corporation, Analog Devices, K.K.
+> The open source USB MIDI 2.0 driver has been generously donated by [AMEI](https://www.amei.or.jp/), the **Association of Musical Electronics Industry**, and developed by [AmeNote™](https://www.AmeNote.com/) in partnership with Microsoft. Please see the file headers for any additional copyright notices. A huge thank you to AMEI and its member companies for making this happen: AlphaTheta Corporation, INTERNET Co., Ltd., Kawai Musical Instruments Manufacturing Co., Ltd., CRYPTON FUTURE MEDIA, INC., CRIMSON TECHNOLOGY, Inc., KORG INC., Educational Corporation Shobi Gakuen, SyncPower Corporation, ZOOM CORPORATION, SUZUKI MUSICAL INST.MFG.CO.,LTD., TEAC CORPORATION, Yamaha Corporation, Yamaha Music Entertainment Holdings, Inc., Roland Corporation, Analog Devices, K.K.
 
 **This is an official Microsoft project**. Although Microsoft is an active member of the MIDI Association, and Pete is the chair of the MIDI Association Executive Board, and other contributors are on standards boards, this project is not affiliated with the MIDI Association other than as a consumer of and contributor to the standards. Affiliation with AMEI is disclosed above.
 
 ## Documentation
 
-All documentation has been moved to our documentation pages [https://aka.ms/midi](https://aka.ms/midi)
+All documentation has been moved to our documentation pages, at [`aka.ms/midi`](https://aka.ms/midi):
 
 > **Join the Discussion!**
 >
-> Our official community server for this project is on Discord here: https://aka.ms/MidiDiscord
+> Our official community server for this project is on Discord at [`aka.ms/MidiDiscord`](https://aka.ms/MidiDiscord).
 >
 > Please keep bug and feature requests in the issues here, but other discussion, live streams, Q&A, and more can happen on Discord. Additionally, we know that not everyone who uses MIDI has access to GitHub, so we welcome additional suggestions, reports, etc. there for those members of the community.
 
 ## Releases
 
-Please see the [releases page](https://aka.ms/midireleases)
+Please see the [releases page](https://aka.ms/midireleases).
 
 ## License
 
-* See [LICENSE](LICENSE)
-* For a statement of intent and some other FAQs about forking and more, see [FAQ-License-and-Intent.md](FAQ-License-and-Intent.md)
+* See [`LICENSE`](LICENSE).
+
+* For a statement of intent and some other FAQs about forking and more, see [`FAQ-License-and-Intent.md`](FAQ-License-and-Intent.md).
 
 ## Contributing
 
-See [CONTRIBUTING.md](get-started/midi-developers/contributors/)
+See [`CONTRIBUTING.md`](get-started/midi-developers/contributors/).
 
 ## Security
 
-See [SECURITY.md](SECURITY.md)
+See [`SECURITY.md`](SECURITY.md).
 
 ## Trademarks
 
@@ -55,6 +56,9 @@ Older videos:
 [![Mike Kent on MIDI 2.0 Protocol Messages and UMP](https://img.youtube.com/vi/Kky1nlwz8-8/mqdefault.jpg)](https://www.youtube.com/watch?v=Kky1nlwz8-8)
 
 * [Windows MIDI and Music Dev Blog](https://devblogs.microsoft.com/windows-music-dev/)
+
 * [MIDI is about collaboration, not competition](https://midi.org/midi-articles/midi-is-about-collaboration-not-competition)
+
 * [MIDI @ 40 and the new Windows MIDI Services](https://devblogs.microsoft.com/windows-music-dev/midi-40-and-the-new-windows-midi-services/)
+
 * [Join the MIDI Association](https://aka.ms/midiorgjoin/)


### PR DESCRIPTION
Adherence to WCAG AA requires that this conforms to GHFM, which is a superset of CommonMark, which conforms to the WHATWG HTML5 LS.

Consequently, I've wrapped code in hyperlink labels with `code`s, expanded each `li` to be prepended with a `/n`, so that multi-line and single-line `li`s do not utilise different `line-height`s, and have removed the Variation Selector-16 from `U+2122` (™️ → ™).