### PR TITLE
Fix LNK4070 warning in winmmdrv.def

### DIFF
--- a/src/api/Client/WinMM/winmmdrv.def
+++ b/src/api/Client/WinMM/winmmdrv.def
@@ -1,6 +1,6 @@
 ; Copyright (c) Microsoft Corporation.  All rights reserved.
 
-LIBRARY WDMAUD2
+LIBRARY wdmaud2
 
 EXPORTS     
     modMessage


### PR DESCRIPTION
Change LIBRARY name from WDMAUD2 to wdmaud2 to match the actual output filename (wdmaud2.drv). This eliminates the linker warning: 'LNK4070: .EXP /OUT:WDMAUD2.dll directive does not match output filename'