### PR TITLE
Fix TextTemplating targets import for VS 2022 compatibility

### DIFF
--- a/src/build-gen-version-includes/GenVersionIncludes.csproj
+++ b/src/build-gen-version-includes/GenVersionIncludes.csproj
@@ -129,8 +129,11 @@
     <Service Include="{508349b6-6b84-4df5-91f0-309beebad82d}" />
   </ItemGroup>
 
-  <Import Project="$(MSBuildExtensionsPath)\Microsoft\VisualStudio\v18.0\TextTemplating\Microsoft.TextTemplating.targets" />
-
-
-
+  <!-- Try v17.0 first (VS 2022) -->
+  <Import Project="$(MSBuildExtensionsPath)\Microsoft\VisualStudio\v17.0\TextTemplating\Microsoft.TextTemplating.targets" 
+          Condition="Exists('$(MSBuildExtensionsPath)\Microsoft\VisualStudio\v17.0\TextTemplating\Microsoft.TextTemplating.targets')" />
+  <!-- Fallback to v18.0 (VS 2022 18.x) -->
+  <Import Project="$(MSBuildExtensionsPath)\Microsoft\VisualStudio\v18.0\TextTemplating\Microsoft.TextTemplating.targets" 
+          Condition="!Exists('$(MSBuildExtensionsPath)\Microsoft\VisualStudio\v17.0\TextTemplating\Microsoft.TextTemplating.targets') And Exists('$(MSBuildExtensionsPath)\Microsoft\VisualStudio\v18.0\TextTemplating\Microsoft.TextTemplating.targets')" />
+          
 </Project>


### PR DESCRIPTION
Add conditional import logic to support both VS 2022 17.x and 18.x versions:
- Try v17.0 TextTemplating targets first (VS 2022)
- Fallback to v18.0 if v17.0 not found (VS 2026 18.x)

This ensures the project can build across different Visual Studio 2022 versions without requiring manual path adjustments.