### PR TITLE
Update match criteria to remove current failing approaches with USB s…

### DIFF
--- a/src/api/Inc/Feature_Servicing_MIDI2USBDeviceMatch.h
+++ b/src/api/Inc/Feature_Servicing_MIDI2USBDeviceMatch.h
@@ -1,0 +1,18 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License
+// ============================================================================
+// This is part of the Windows MIDI Services App API and should be used
+// in your Windows application via an official binary distribution.
+// Further information: https://aka.ms/midi
+// ============================================================================
+
+#pragma once
+
+class Feature_Servicing_MIDI2USBDeviceMatch
+{
+public:
+    static bool IsEnabled()
+    {
+        return true;
+    }
+};

--- a/src/api/Libs/MidiPluginConfigurationLib/MidiEndpointMatchCriteria.cpp
+++ b/src/api/Libs/MidiPluginConfigurationLib/MidiEndpointMatchCriteria.cpp
@@ -32,6 +32,8 @@
 #include <winrt/Windows.Foundation.h>
 #include <winrt/Windows.Foundation.Collections.h>
 
+#include "Feature_Servicing_MIDI2USBDeviceMatch.h"
+
 #define MIDI_CONFIG_JSON_ENDPOINT_COMMON_MATCH_OBJECT_KEY L"match"
 
 namespace json = ::winrt::Windows::Data::Json;
@@ -282,23 +284,31 @@ bool MidiEndpointMatchCriteria::Matches(MidiEndpointMatchCriteria& matchValues)
     // Most of the rest of these are absolute. If specified and they do not match, then it's not a match
     // because they are properties of the actual device, not something assigned by Windows
 
-    // VID/PID/Serial
-    if (matchValues.UsbVendorId > 0 &&
-        matchValues.UsbProductId > 0 && 
-        matchValues.UsbVendorId == UsbVendorId &&
-        matchValues.UsbProductId == UsbProductId)
+    // we no longer allow matches on vid/pid/serial because
+    // it was causing tons of problems with multiple devices
+    // and also devices with same bogus serial number
+    // This was a good idea, but failed in practice.
+    if (!Feature_Servicing_MIDI2USBDeviceMatch::IsEnabled())
     {
-        if (matchValues.UsbSerialNumber.empty() && UsbSerialNumber.empty())
+        // VID/PID/Serial
+        if (matchValues.UsbVendorId > 0 &&
+            matchValues.UsbProductId > 0 && 
+            matchValues.UsbVendorId == UsbVendorId &&
+            matchValues.UsbProductId == UsbProductId)
         {
-            // we're not matching on serial, and VID/PID match, so we're good
-            return true;
-        }
-        else
-        {
-            // we return either way here, because if the info doesn't match, we shouldn't continue
-            return matchValues.UsbSerialNumber == UsbSerialNumber;
+            if (matchValues.UsbSerialNumber.empty() && UsbSerialNumber.empty())
+            {
+                // we're not matching on serial, and VID/PID match, so we're good
+                return true;
+            }
+            else
+            {
+                // we return either way here, because if the info doesn't match, we shouldn't continue
+                return matchValues.UsbSerialNumber == UsbSerialNumber;
+            }
         }
     }
+
 
     // Manufacturer and product instance id
     if (!matchValues.DeviceManufacturerName.empty() && 
@@ -329,14 +339,17 @@ bool MidiEndpointMatchCriteria::Matches(MidiEndpointMatchCriteria& matchValues)
         return matchValues.TransportSuppliedEndpointName == TransportSuppliedEndpointName;
     }
 
-    // Parent device name. This is going to restrict us to a single UMP endpoint per device
-    // so it may need to be removed, or combined with other criteria in the future
-    if (!matchValues.ParentDeviceName.empty() &&
-        !ParentDeviceName.empty())
+    // matching on parent device name also didn't work out in the real world
+    if (!Feature_Servicing_MIDI2USBDeviceMatch::IsEnabled())
     {
-        return matchValues.ParentDeviceName == ParentDeviceName;
+        // Parent device name. This is going to restrict us to a single UMP endpoint per device
+        // so it may need to be removed, or combined with other criteria in the future
+        if (!matchValues.ParentDeviceName.empty() &&
+            !ParentDeviceName.empty())
+        {
+            return matchValues.ParentDeviceName == ParentDeviceName;
+        }
     }
-
 
     return false;
 }


### PR DESCRIPTION
Matching on USB VID/PID/Serial was not working due to bogus duplicate serial numbers. And matching just on VID/PID was never a good idea when folks have multiples of the same device.

Additionally, matching on parent device info wasn't working.

The whole fuzzy match idea was to work around devices without serial numbers, but turned out to be more trouble than it's worth. for USB.

This PR removes those.

Related Issues
- #887 
- #891 