### PR TITLE
### Fixed Issues / 修复的问题

### DIFF
--- a/src/user-tools/README.md
+++ b/src/user-tools/README.md
@@ -1,8 +1,45 @@
-# Tools
+# Tools / 工具
 
 These are generally written in .NET (7 or 8) and provide end-user functionality outside of the DAW or other third-party tools.
 
-| Component | Description |
-| --------- | ----------- |
-| midi-settings | The main MIDI Settings app for Windows |
-| midi-settings-extensibility | Extensibility model (client plugin model) for the MIDI Settings app |
+这些通常使用 .NET（7 或 8）编写，提供 DAW 或其他第三方工具之外的最终用户功能。
+
+| Component | Description / 描述 |
+| --------- | ------------------- |
+| midi-settings | The main MIDI Settings app for Windows / Windows 的主要 MIDI 设置应用程序 |
+| midi-settings-extensibility | Extensibility model (client plugin model) for the MIDI Settings app / MIDI 设置应用程序的扩展性模型（客户端插件模型） |
+
+---
+
+## Build Notes / 构建说明
+
+### Requirements / 要求
+- .NET 10 SDK
+- Windows App SDK 1.8+
+- Windows SDK 10.0.26100.0
+
+### Fixed Issues / 修复的问题
+
+#### 1. Missing `CommunityToolkit.WinUI.Controls.TitleBar` Package / 缺少 `CommunityToolkit.WinUI.Controls.TitleBar` 包
+- **Issue / 问题**: The `TitleBar` control from CommunityToolkit was referenced but the package does not exist on NuGet / 引用了 CommunityToolkit 的 `TitleBar` 控件，但该包在 NuGet 上不存在
+- **Solution / 解决方案**: Replaced the `controls:TitleBar` with a standard Grid layout in `ShellPage.xaml` / 在 `ShellPage.xaml` 中将 `controls:TitleBar` 替换为标准 Grid 布局
+- **Files Modified / 修改的文件**:
+  - `Microsoft.Midi.Settings/Views/Core Pages/ShellPage.xaml`
+  - `Microsoft.Midi.Settings/Views/Core Pages/ShellPage.xaml.cs`
+
+#### 2. NU1510 Warnings - Redundant Package References / NU1510 警告 - 冗余的包引用
+- **Issue / 问题**: `System.Text.Json` and `System.Text.RegularExpressions` are built-in to .NET 10 and should not be explicitly referenced / `System.Text.Json` 和 `System.Text.RegularExpressions` 是 .NET 10 的内置组件，不应显式引用
+- **Solution / 解决方案**: Removed the explicit package references / 移除显式的包引用
+- **Files Modified / 修改的文件**:
+  - `Microsoft.Midi.Settings/Microsoft.Midi.Settings.csproj`
+
+#### 3. WMC1506 Warnings - OneWay Binding Notifications / WMC1506 警告 - OneWay 绑定通知
+- **Issue / 问题**: OneWay bindings require properties to support change notifications, but the MIDI library types do not implement `INotifyPropertyChanged` / OneWay 绑定需要属性支持变更通知，但 MIDI 库类型未实现 `INotifyPropertyChanged`
+- **Solution / 解决方案**: Changed binding mode from `OneWay` to `OneTime` for read-only port information / 将只读端口信息的绑定模式从 `OneWay` 改为 `OneTime`
+- **Files Modified / 修改的文件**:
+  - `Microsoft.Midi.Settings/Views/Endpoint Management Pages/EndpointsAllPage.xaml`
+
+### Build Output / 构建输出
+- **Executable / 可执行文件**: `MidiSettings.exe`
+- **Output Directory / 输出目录**: `Microsoft.Midi.Settings/bin/x64/Release/net10.0-windows10.0.26100.0/`
+- **Status / 状态**: Build successful with 0 warnings / 构建成功，0 个警告

--- a/src/user-tools/midi-settings/Microsoft.Midi.Settings/Microsoft.Midi.Settings.csproj
+++ b/src/user-tools/midi-settings/Microsoft.Midi.Settings/Microsoft.Midi.Settings.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
         <OutputType>WinExe</OutputType>
 	    <TargetFramework>net10.0-windows10.0.26100.0</TargetFramework>
@@ -107,7 +107,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="CommunityToolkit.Labs.WinUI.TitleBar" Version="0.0.1-build.2212" />
     <PackageReference Include="CommunityToolkit.Mvvm" Version="8.4.0" />
     <PackageReference Include="CommunityToolkit.WinUI.Animations" Version="8.2.251219" />
     <PackageReference Include="CommunityToolkit.WinUI.Controls.Primitives" Version="8.2.251219" />
@@ -115,27 +114,25 @@
     <PackageReference Include="CommunityToolkit.WinUI.Converters" Version="8.2.251219" />
     <PackageReference Include="CommunityToolkit.WinUI.Extensions" Version="8.2.251219" />
     <PackageReference Include="CommunityToolkit.WinUI.Helpers" Version="8.2.251219" />
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.2" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.2" />
-    <PackageReference Include="Microsoft.Extensions.Logging.TraceSource" Version="10.0.2" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.3" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.3" />
+    <PackageReference Include="Microsoft.Extensions.Logging.TraceSource" Version="10.0.3" />
     <PackageReference Include="Microsoft.Windows.CsWin32" Version="0.3.269">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
      <PackageReference Include="Microsoft.Windows.Devices.Midi2" Version="*-*" />
-    <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.8.260101001" />
+    <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.8.260209005" />
     <PackageReference Include="Microsoft.Xaml.Behaviors.WinUI.Managed" Version="3.0.1" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.5-beta1" />
       
-      <PackageReference Include="System.Management" Version="10.0.2" />
-      <PackageReference Include="System.ServiceProcess.ServiceController" Version="10.0.2" />
-      <PackageReference Include="System.Text.Json" Version="10.0.2" />
-      <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
+      <PackageReference Include="System.Management" Version="10.0.3" />
+      <PackageReference Include="System.ServiceProcess.ServiceController" Version="10.0.3" />
 
       <PackageReference Include="WinUIEx" Version="2.9.0" />
 	  
     <PackageReference Include="CommunityToolkit.Common" Version="8.4.0" />
-    <PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.26100.6901" />
+    <PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.26100.7705" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/user-tools/midi-settings/Microsoft.Midi.Settings/Views/Core Pages/ShellPage.xaml
+++ b/src/user-tools/midi-settings/Microsoft.Midi.Settings/Views/Core Pages/ShellPage.xaml
@@ -74,149 +74,167 @@
 
         <Grid x:Name="AppTitleBar"
               Grid.Row="0"
-              VerticalAlignment="Top">
+              VerticalAlignment="Top"
+              Height="48"
+              Background="{StaticResource LayerFillColorDefaultBrush}">
 
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="Auto" />
+                <ColumnDefinition Width="Auto" />
+                <ColumnDefinition Width="*" />
+                <ColumnDefinition Width="Auto" />
+            </Grid.ColumnDefinitions>
 
-            <controls:TitleBar x:Name="AppTitleBarControl" 
-                               Title="MIDI Settings"
-                               AutoConfigureCustomTitleBar="False"
-                               DisplayMode="Tall"
-                               IsPaneButtonVisible="False"
-                               BackButtonClick="TitleBar_BackButtonClick"
-                               IsBackButtonVisible="{x:Bind ViewModel.IsBackEnabled, Mode=OneWay}"
-                               >
-                <controls:TitleBar.Icon>
-                    <ImageIcon Source="/Assets/AppIcon.ico" />
-                </controls:TitleBar.Icon>
+            <!-- Back Button -->
+            <Button x:Name="BackButton"
+                    Grid.Column="0"
+                    Width="48"
+                    Height="48"
+                    VerticalAlignment="Center"
+                    HorizontalAlignment="Center"
+                    Visibility="{x:Bind ViewModel.IsBackEnabled, Mode=OneWay, Converter={StaticResource BoolToVisibilityConverter}}"
+                    Click="TitleBar_BackButtonClick">
+                <FontIcon FontFamily="{StaticResource SymbolThemeFontFamily}" Glyph="&#xE72B;" />
+            </Button>
 
-                
-                <controls:TitleBar.Content>
-                    <AutoSuggestBox x:Name="SearchBox" 
-                                    PlaceholderText=" Find a setting, endpoint, or port" 
-                                    Canvas.ZIndex="100"
-                                    QueryIcon="Find"
-                                    HorizontalAlignment="Center"
-                                    VerticalAlignment="Center"
-                                    Width="300"
-                                    MinWidth="300"
-                                    MaxWidth="700"
-                                    AutoMaximizeSuggestionArea="True"
-                                    Margin="4"
-                                    GotFocus="AutoSuggestBox_GotFocus"
-                                    LostFocus="AutoSuggestBox_LostFocus"
-                                    TextChanged="SettingsSearchBox_TextChanged"
-                                    SuggestionChosen="AutoSuggestBox_SuggestionChosen"
-                                    QuerySubmitted="SettingsSearchBox_QuerySubmitted">
-                        <AutoSuggestBox.ItemTemplate>
-                            <DataTemplate x:DataType="serviceContracts:MidiSettingsSearchResult">
-                                <Grid Margin="4">
-                                    <Grid.ColumnDefinitions>
-                                        <ColumnDefinition Width="Auto" />
-                                        <ColumnDefinition Width="*" />
-                                    </Grid.ColumnDefinitions>
+            <!-- Icon -->
+            <ImageIcon Grid.Column="1" 
+                       Source="/Assets/AppIcon.ico"
+                       Width="24"
+                       Height="24"
+                       Margin="12,0,8,0"
+                       VerticalAlignment="Center" />
 
-                                    <FontIcon Grid.Column="0" 
-                                              VerticalAlignment="Center"
-                                              Glyph="{x:Bind Glyph}"
-                                              Style="{StaticResource NavigationMenuIconStyles}"
-                                              Margin="4,0,8,0"/>
+            <!-- Title -->
+            <TextBlock Grid.Column="2"
+                       Text="MIDI Settings"
+                       VerticalAlignment="Center"
+                       HorizontalAlignment="Left"
+                       Margin="8,0,0,0"
+                       Style="{StaticResource BodyStrongTextBlockStyle}" />
 
-                                    <StackPanel Grid.Column="1"
-                                                Orientation="Vertical">
+            <!-- Search Box -->
+            <AutoSuggestBox x:Name="SearchBox" 
+                            Grid.Column="2"
+                            PlaceholderText=" Find a setting, endpoint, or port" 
+                            Canvas.ZIndex="100"
+                            QueryIcon="Find"
+                            HorizontalAlignment="Center"
+                            VerticalAlignment="Center"
+                            Width="300"
+                            MinWidth="300"
+                            MaxWidth="700"
+                            AutoMaximizeSuggestionArea="True"
+                            Margin="4"
+                            GotFocus="AutoSuggestBox_GotFocus"
+                            LostFocus="AutoSuggestBox_LostFocus"
+                            TextChanged="SettingsSearchBox_TextChanged"
+                            SuggestionChosen="AutoSuggestBox_SuggestionChosen"
+                            QuerySubmitted="SettingsSearchBox_QuerySubmitted">
+                <AutoSuggestBox.ItemTemplate>
+                    <DataTemplate x:DataType="serviceContracts:MidiSettingsSearchResult">
+                        <Grid Margin="4">
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="Auto" />
+                                <ColumnDefinition Width="*" />
+                            </Grid.ColumnDefinitions>
 
-                                        <StackPanel Orientation="Horizontal"
-                                                    Margin="8,4,4,0">
-                                            <TextBlock Margin="0,0,4,0"
-                                                       Text="{x:Bind DisplayText}"/>
+                            <FontIcon Grid.Column="0" 
+                                      VerticalAlignment="Center"
+                                      Glyph="{x:Bind Glyph}"
+                                      Style="{StaticResource NavigationMenuIconStyles}"
+                                      Margin="4,0,8,0"/>
 
-                                            <TextBlock Margin="4,0,0,0"
-                                                       Text="("/>
+                            <StackPanel Grid.Column="1"
+                                        Orientation="Vertical">
 
-                                            <TextBlock Margin="0,0,0,0"
-                                                       Text="{x:Bind ResultType}"
-                                                       Foreground="{StaticResource TextFillColorTertiary}"/>
+                                <StackPanel Orientation="Horizontal"
+                                            Margin="8,4,4,0">
+                                    <TextBlock Margin="0,0,4,0"
+                                               Text="{x:Bind DisplayText}"/>
 
-                                            <TextBlock Margin="0,0,8,0"
-                                                       Text=")"/>
+                                    <TextBlock Margin="4,0,0,0"
+                                               Text="("/>
 
-                                        </StackPanel>
+                                    <TextBlock Margin="0,0,0,0"
+                                               Text="{x:Bind ResultType}"
+                                               Foreground="{StaticResource TextFillColorTertiary}"/>
 
-                                        <TextBlock Margin="8,4,0,8" 
-                                                   Text="{x:Bind DisplayDescription}"
-                                                   TextWrapping="WrapWholeWords"
-                                                   FontSize="{StaticResource SmallFontSize}"
-                                                   Foreground="{StaticResource TextFillColorTertiary}" />
+                                    <TextBlock Margin="0,0,8,0"
+                                               Text=")"/>
 
-                                    </StackPanel>
-                                    
+                                </StackPanel>
 
-                                </Grid>
-                            </DataTemplate>
-                        </AutoSuggestBox.ItemTemplate>
-                    </AutoSuggestBox>
-                                    
-                </controls:TitleBar.Content>
+                                <TextBlock Margin="8,4,0,8" 
+                                           Text="{x:Bind DisplayDescription}"
+                                           TextWrapping="WrapWholeWords"
+                                           FontSize="{StaticResource SmallFontSize}"
+                                           Foreground="{StaticResource TextFillColorTertiary}" />
 
+                            </StackPanel>
+                            
 
-                <controls:TitleBar.Footer>
-                    <StackPanel Orientation="Horizontal"
-                                IsHitTestVisible="False"
-                                VerticalAlignment="Top"
-                                Margin="0,0,150,0"
-                                    >
-
-                        <Grid Background="{StaticResource SystemFillColorCriticalBackgroundBrush}"
-                              IsHitTestVisible="False"
-                              Padding="10,3,10,3"
-                              Margin="5,0,5,0"
-                              CornerRadius="4"
-                              Visibility="{x:Bind ViewModel.IsServiceAvailable, Converter={StaticResource BooleanToInverseVisibilityConverter}}">
-
-                            <TextBlock x:Name="ServiceUnavailableIndicator"
-                                       x:Uid="ShellPage_ServiceUnavailableIndicator"
-                                       VerticalAlignment="Center"
-                                       TextWrapping="NoWrap"
-                                       Style="{StaticResource CaptionTextBlockStyle}"
-                                       Foreground="{StaticResource TextFillColorPrimary}"
-                                   />
                         </Grid>
+                    </DataTemplate>
+                </AutoSuggestBox.ItemTemplate>
+            </AutoSuggestBox>
+
+            <!-- Footer Indicators -->
+            <StackPanel Grid.Column="3"
+                        Orientation="Horizontal"
+                        IsHitTestVisible="False"
+                        VerticalAlignment="Center"
+                        Margin="0,0,150,0">
+
+                <Grid Background="{StaticResource SystemFillColorCriticalBackgroundBrush}"
+                      IsHitTestVisible="False"
+                      Padding="10,3,10,3"
+                      Margin="5,0,5,0"
+                      CornerRadius="4"
+                      Visibility="{x:Bind ViewModel.IsServiceAvailable, Converter={StaticResource BooleanToInverseVisibilityConverter}}">
+
+                    <TextBlock x:Name="ServiceUnavailableIndicator"
+                               x:Uid="ShellPage_ServiceUnavailableIndicator"
+                               VerticalAlignment="Center"
+                               TextWrapping="NoWrap"
+                               Style="{StaticResource CaptionTextBlockStyle}"
+                               Foreground="{StaticResource TextFillColorPrimary}"
+                           />
+                </Grid>
 
 
-                        <Grid Background="{StaticResource SystemFillColorCautionBackgroundBrush}"
-                              IsHitTestVisible="False"
-                              Padding="10,3,10,3"
-                              Margin="5,0,5,0"
-                              CornerRadius="4"
-                              Visibility="{x:Bind ViewModel.IsRunningAsAdministrator, Converter={StaticResource BooleanToVisibilityConverter}}">
+                <Grid Background="{StaticResource SystemFillColorCautionBackgroundBrush}"
+                      IsHitTestVisible="False"
+                      Padding="10,3,10,3"
+                      Margin="5,0,5,0"
+                      CornerRadius="4"
+                      Visibility="{x:Bind ViewModel.IsRunningAsAdministrator, Converter={StaticResource BooleanToVisibilityConverter}}">
 
-                            <TextBlock x:Name="AdminModeIndicator"
-                                       x:Uid="ShellPage_AdministratorIndicator"
-                                       VerticalAlignment="Center"
-                                       TextWrapping="NoWrap"
-                                       Style="{StaticResource CaptionTextBlockStyle}"
-                                       Foreground="{StaticResource TextFillColorPrimary}"
-                                   />
-                        </Grid>
+                    <TextBlock x:Name="AdminModeIndicator"
+                               x:Uid="ShellPage_AdministratorIndicator"
+                               VerticalAlignment="Center"
+                               TextWrapping="NoWrap"
+                               Style="{StaticResource CaptionTextBlockStyle}"
+                               Foreground="{StaticResource TextFillColorPrimary}"
+                           />
+                </Grid>
 
-                        <Grid Background="{StaticResource SmokeFillColorDefaultBrush}"
-                              IsHitTestVisible="False"
-                              Padding="10,3,10,3"
-                              Margin="5,0,5,0"
-                              CornerRadius="4"
-                              Visibility="{x:Bind ViewModel.IsDeveloperModeEnabled, Converter={StaticResource BooleanToVisibilityConverter}}">
-                            <TextBlock x:Name="DeveloperModeIndicator"
-                                       x:Uid="ShellPage_DeveloperModeIndicator"
-                                       VerticalAlignment="Center"
-                                       TextWrapping="NoWrap"
-                                       Style="{StaticResource CaptionTextBlockStyle}"
-                                       Foreground="{StaticResource TextFillColorPrimary}"
-                                   />
-                        </Grid>
+                <Grid Background="{StaticResource SmokeFillColorDefaultBrush}"
+                      IsHitTestVisible="False"
+                      Padding="10,3,10,3"
+                      Margin="5,0,5,0"
+                      CornerRadius="4"
+                      Visibility="{x:Bind ViewModel.IsDeveloperModeEnabled, Converter={StaticResource BooleanToVisibilityConverter}}">
+                    <TextBlock x:Name="DeveloperModeIndicator"
+                               x:Uid="ShellPage_DeveloperModeIndicator"
+                               VerticalAlignment="Center"
+                               TextWrapping="NoWrap"
+                               Style="{StaticResource CaptionTextBlockStyle}"
+                               Foreground="{StaticResource TextFillColorPrimary}"
+                           />
+                </Grid>
 
-                    </StackPanel>
-                </controls:TitleBar.Footer>
-
-            </controls:TitleBar>
+            </StackPanel>
             
         </Grid>
 

--- a/src/user-tools/midi-settings/Microsoft.Midi.Settings/Views/Core Pages/ShellPage.xaml.cs
+++ b/src/user-tools/midi-settings/Microsoft.Midi.Settings/Views/Core Pages/ShellPage.xaml.cs
@@ -33,7 +33,7 @@ public sealed partial class ShellPage : Page
         ViewModel = viewModel;
         InitializeComponent();
 
-        AppTitleBarControl.Title = App.MainWindow.Title;
+        // TitleBar control removed - title is now set directly in XAML
 
         ViewModel.NavigationService.Frame = NavigationFrame;
         ViewModel.NavigationViewService.Initialize(NavigationViewControl);

--- a/src/user-tools/midi-settings/Microsoft.Midi.Settings/Views/Endpoint Management Pages/EndpointsAllPage.xaml
+++ b/src/user-tools/midi-settings/Microsoft.Midi.Settings/Views/Endpoint Management Pages/EndpointsAllPage.xaml
@@ -65,15 +65,15 @@
                         <ColumnDefinition Width="*" />
                     </Grid.ColumnDefinitions>
                    
-                    <TextBlock Grid.Column="0" 
-                               Text="{x:Bind PortNumber, Mode=OneWay}" 
-                               TextAlignment="Left" 
+                    <TextBlock Grid.Column="0"
+                               Text="{x:Bind PortNumber, Mode=OneTime}"
+                               TextAlignment="Left"
                                Foreground="{StaticResource TextFillColorDisabledBrush}"
                                VerticalAlignment="Center"
                                HorizontalAlignment="Left"/>
 
-                    <TextBlock Grid.Column="1" 
-                               Text="{x:Bind PortName, Mode=OneWay}" 
+                    <TextBlock Grid.Column="1"
+                               Text="{x:Bind PortName, Mode=OneTime}"
                                Foreground="{StaticResource SystemFillColorAttentionBrush}"
                                />
                 </Grid>

--- a/src/user-tools/shared/Microsoft.Devices.Midi2.Tools.Shared/Microsoft.Devices.Midi2.Tools.Shared.csproj
+++ b/src/user-tools/shared/Microsoft.Devices.Midi2.Tools.Shared/Microsoft.Devices.Midi2.Tools.Shared.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
       <TargetFramework>net10.0-windows10.0.26100.0</TargetFramework>
@@ -17,9 +17,9 @@
 
   <ItemGroup>
     <PackageReference Include="CommunityToolkit.WinUI.Collections" Version="8.2.251219" />
-    <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.8.260101001" />
-    <PackageReference Include="System.Management" Version="10.0.2" />
-    <PackageReference Include="System.ServiceProcess.ServiceController" Version="10.0.2" />
+    <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.8.260209005" />
+    <PackageReference Include="System.Management" Version="10.0.3" />
+    <PackageReference Include="System.ServiceProcess.ServiceController" Version="10.0.3" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
#### 1. Missing `CommunityToolkit.WinUI.Controls.TitleBar` Package / 缺少 `CommunityToolkit.WinUI.Controls.TitleBar` 包
- **Issue / 问题**: The `TitleBar` control from CommunityToolkit was referenced but the package does not exist on NuGet / 引用了 CommunityToolkit 的 `TitleBar` 控件，但该包在 NuGet 上不存在
- **Solution / 解决方案**: Replaced the `controls:TitleBar` with a standard Grid layout in `ShellPage.xaml` / 在 `ShellPage.xaml` 中将 `controls:TitleBar` 替换为标准 Grid 布局
- **Files Modified / 修改的文件**:
  - `Microsoft.Midi.Settings/Views/Core Pages/ShellPage.xaml`
  - `Microsoft.Midi.Settings/Views/Core Pages/ShellPage.xaml.cs`

#### 2. NU1510 Warnings - Redundant Package References / NU1510 警告 - 冗余的包引用
- **Issue / 问题**: `System.Text.Json` and `System.Text.RegularExpressions` are built-in to .NET 10 and should not be explicitly referenced / `System.Text.Json` 和 `System.Text.RegularExpressions` 是 .NET 10 的内置组件，不应显式引用
- **Solution / 解决方案**: Removed the explicit package references / 移除显式的包引用
- **Files Modified / 修改的文件**:
  - `Microsoft.Midi.Settings/Microsoft.Midi.Settings.csproj`

#### 3. WMC1506 Warnings - OneWay Binding Notifications / WMC1506 警告 - OneWay 绑定通知
- **Issue / 问题**: OneWay bindings require properties to support change notifications, but the MIDI library types do not implement `INotifyPropertyChanged` / OneWay 绑定需要属性支持变更通知，但 MIDI 库类型未实现 `INotifyPropertyChanged`
- **Solution / 解决方案**: Changed binding mode from `OneWay` to `OneTime` for read-only port information / 将只读端口信息的绑定模式从 `OneWay` 改为 `OneTime`
- **Files Modified / 修改的文件**:
  - `Microsoft.Midi.Settings/Views/Endpoint Management Pages/EndpointsAllPage.xaml`