### PR TITLE
Update Microsoft.Windows.Devices.Midi2.Initialization.hpp

### DIFF
--- a/src/app-sdk/client-initialization-redist/Microsoft.Windows.Devices.Midi2.Initialization.hpp
+++ b/src/app-sdk/client-initialization-redist/Microsoft.Windows.Devices.Midi2.Initialization.hpp
@@ -236,7 +236,9 @@ namespace Microsoft::Windows::Devices::Midi2::Initialization
                 )))
                 {
                     if (minRequiredVersionMajor > installedVersionMajor) return false;
+                    if (minRequiredVersionMajor < installedVersionMajor) return true;
                     if (minRequiredVersionMinor > installedVersionMinor) return false;
+                    if (minRequiredVersionMinor < installedVersionMinor) return true;
                     if (minRequiredVersionPatch > installedVersionPatch) return false;
 
                     return true;


### PR DESCRIPTION
Fixes #930 updating CheckMinimumRequiredSdkVersion() to compare Major and Minor values correctly.