### PR TITLE
use TimeDeltaMs for midi in from legacy ks drivers, not the stream position

### DIFF
--- a/src/api/.gitattributes
+++ b/src/api/.gitattributes
@@ -18,7 +18,6 @@ packages.config text eol=crlf
 *.idl text eol=crlf
 *.rgs text eol=crlf
 *.rc text eol=crlf
-*.inf text eol=crlf
 *.json text eol=crlf
 *.ps1 text eol=crlf
 *.cmd text eol=crlf

--- a/src/api/Drivers/MinMidi/Driver/MidiPin.cpp
+++ b/src/api/Drivers/MinMidi/Driver/MidiPin.cpp
@@ -16,6 +16,14 @@
 #define MAXIMUM_LOOPED_BUFFER_SIZE (PAGE_SIZE * 0x100)
 static_assert(    MAXIMUM_LOOPED_BUFFER_SIZE < ULONG_MAX/2, "The maximum looped buffer size may not exceed 1/2 MAX_ULONG");
 
+// Get the current time, in 100ns units
+ULONGLONG GetCurrentMIDITime( void )
+{
+    LARGE_INTEGER   liFrequency,liTime;
+    liTime = KeQueryPerformanceCounter(&liFrequency);
+    return (KSCONVERT_PERFORMANCE_TIME(liFrequency.QuadPart,liTime));
+}
+
 static const
 KSDATARANGE_MUSIC g_MidiStreamDataRangeUMP[] =
 {
@@ -605,7 +613,7 @@ MidiPin::Process(
                             {
                                 // copy the data in and add it to the list
                                 message->Size = musicHeader->ByteCount;
-                                message->Position = streamPtr->StreamHeader->PresentationTime.Time;
+                                message->Position = GetCurrentMIDITime();
                                 message->BufferIndex = (BYTE *) message->Buffer;
                                 RtlCopyMemory(message->Buffer, pData, musicHeader->ByteCount);
                                 InsertTailList(&This->m_Filter->m_FilterInstance->MidiInPin->m_LoopbackMessageQueue, &message->ListEntry);
@@ -677,6 +685,7 @@ MidiPin::Process(
                 ULONG numBytesToCopy = min(streamPtr->OffsetOut.Remaining - sizeof(KSMUSICFORMAT), message->Size);
                 ULONG copySize = sizeof(KSMUSICFORMAT) + numBytesToCopy;
                 ULONG copySizeAligned = (copySize + 3) & ~3;
+                LONGLONG position = message->Position;
 
                 // if we exceed the output buffer after aligning the buffer,
                 // remove the unaligned portion from the copy, do that in the next
@@ -688,8 +697,6 @@ MidiPin::Process(
                 }
 
                 RtlCopyMemory(midiMessage, message->BufferIndex, numBytesToCopy);
-
-                streamPtr->StreamHeader->PresentationTime.Time = message->Position;
 
                 if (numBytesToCopy < message->Size)
                 {
@@ -710,7 +717,8 @@ MidiPin::Process(
     
                 musicHeader->ByteCount = numBytesToCopy;
 
-                musicHeader->TimeDeltaMs = 0;
+                ASSERT(message->Position >= m_StartTime);
+                musicHeader->TimeDeltaMs = (ULONG)((position - This->m_StartTime) / 10000); // 100ns->Ms for delta MSec
 
                 KsStreamPointerAdvanceOffsetsAndUnlock(streamPtr, 0, copySizeAligned, TRUE);
 
@@ -1030,6 +1038,8 @@ MidiPin::SetDeviceState(
                         KeSetPriorityThread(This->m_WorkerThread, HIGH_PRIORITY);
                     }
                 }
+
+                This->m_StartTime = GetCurrentMIDITime();
             }
             break;
         default:

--- a/src/api/Drivers/MinMidi/Driver/MidiPin.h
+++ b/src/api/Drivers/MinMidi/Driver/MidiPin.h
@@ -198,6 +198,9 @@ private:
     MidiFilter * m_Filter {nullptr};
     KSSTATE m_DeviceState {KSSTATE_STOP};
 
+    // Time, in 100ns units, when the pin was started
+    ULONGLONG m_StartTime {0};
+
     // true for cyclic, false for standard
     BOOL m_IsLooped {FALSE};
 

--- a/src/api/Inc/Feature_Servicing_MIDI2LegacyTimestamp.h
+++ b/src/api/Inc/Feature_Servicing_MIDI2LegacyTimestamp.h
@@ -1,0 +1,18 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License
+// ============================================================================
+// This is part of the Windows MIDI Services App API and should be used
+// in your Windows application via an official binary distribution.
+// Further information: https://aka.ms/midi
+// ============================================================================
+
+#pragma once
+
+class Feature_Servicing_MIDI2LegacyTimestamp
+{
+public:
+    static bool IsEnabled()
+    {
+        return true;
+    }
+};

--- a/src/api/Inc/MidiKS.h
+++ b/src/api/Inc/MidiKS.h
@@ -163,4 +163,7 @@ private:
     BOOL m_Running{ TRUE };
 
     unique_mmcss_handle m_ThreadOwnedMmcssHandle;
+
+    LONGLONG m_StartTime{0};
+    LONGLONG m_qpcFrequency{0};
 };

--- a/src/api/Libs/MidiKs/MidiKs.cpp
+++ b/src/api/Libs/MidiKs/MidiKs.cpp
@@ -23,8 +23,12 @@
 #include "MidiKsCommon.h"
 #include "MidiXProc.h"
 #include "MidiKs.h"
+
+#include "midi_timestamp.h"
+
 #include "Feature_Servicing_MIDI2DeviceRemoval.h"
 #include "Feature_Servicing_MIDI2DriverHang.h"
+#include "Feature_Servicing_MIDI2LegacyTimestamp.h"
 
 KSMidiDevice::~KSMidiDevice()
 {
@@ -678,6 +682,14 @@ KSMidiOutDevice::WritePacketMidiData(
     LONGLONG position
 )
 {
+    if (Feature_Servicing_MIDI2LegacyTimestamp::IsEnabled())
+    {
+        // For legacy midi 1, the position is not provided to
+        // the driver via either the PresentationTime, or the
+        // TimeDetaMs
+        UNREFERENCED_PARAMETER(position);
+    }
+
     KSSTREAM_HEADER kssh {0};
     KSMUSICFORMAT *event = nullptr;
     UINT32 totalLength = 0;
@@ -708,8 +720,11 @@ KSMidiOutDevice::WritePacketMidiData(
     kssh.PresentationTime.Numerator = 1;
     kssh.PresentationTime.Denominator = 1;
 
-    // for legacy midi 1, if the position provided was 0, use 0
-    kssh.PresentationTime.Time = position;
+    if (!Feature_Servicing_MIDI2LegacyTimestamp::IsEnabled())
+    {
+        // for legacy midi 1, if the position provided was 0, use 0
+        kssh.PresentationTime.Time = position;
+    }
 
     // the length here is the allocated size of event, so 
     // header structure + data + padding
@@ -831,7 +846,18 @@ KSMidiInDevice::SendRequestToDriver()
             // is closed and the SyncIoctl returns, it may succeed, but have no data.
             if (m_MidiInCallback && payloadSize > 0)
             {
-                LOG_IF_FAILED(m_MidiInCallback->Callback(MessageOptionFlags_None, data, payloadSize, kssh.PresentationTime.Time, m_MidiInCallbackContext));
+                if (Feature_Servicing_MIDI2LegacyTimestamp::IsEnabled())
+                {
+                    // For MidiIn, PresentationTime from the KSSTREAM_HEADER is empty, and legacy drivers provide the TimeDeltaMs
+                    // in the ksmusicformat, which is the time elapsed from the start of the pin for the given buffer.
+                    // 
+                    // convert the delta to HNS time, and then add it to the start time to get the QPC that it would have arrived.
+                    LOG_IF_FAILED(m_MidiInCallback->Callback(MessageOptionFlags_None, data, payloadSize, m_StartTime + (event.ksMusicFormat.TimeDeltaMs * (m_qpcFrequency / MILLISECONDS_PER_SECOND)), m_MidiInCallbackContext));
+                }
+                else
+                {
+                    LOG_IF_FAILED(m_MidiInCallback->Callback(MessageOptionFlags_None, data, payloadSize, kssh.PresentationTime.Time, m_MidiInCallbackContext));
+                }
             }
         }
         else
@@ -897,6 +923,19 @@ KSMidiInDevice::Initialize(
     if (Feature_Servicing_MIDI2DeviceRemoval::IsEnabled())
     {
         RETURN_IF_FAILED(KSMidiDevice::Initialize(device, filter, pinId, transport, bufferSize, mmcssTaskId, optionFlags, MidiFlowIn, callback, context));
+
+        if (Feature_Servicing_MIDI2LegacyTimestamp::IsEnabled())
+        {
+            // Start time for the port, the timestamps returned in TimeDeltaMs by
+            // legacy drivers is relative to the start time
+            LARGE_INTEGER qpc{ 0 };
+
+            QueryPerformanceFrequency(&qpc);
+            m_qpcFrequency = qpc.QuadPart;
+
+            QueryPerformanceCounter(&qpc);
+            m_StartTime = qpc.QuadPart;
+        }
 
         // Spin up the worker thread if using IOCTL_KS_READ_STREAM
         if (m_Transport == MidiTransport_StandardByteStream)

--- a/src/api/Test/Libs/MidiTestCommon/MidiTestCommon.cpp
+++ b/src/api/Test/Libs/MidiTestCommon/MidiTestCommon.cpp
@@ -34,6 +34,7 @@
 #include "Feature_Servicing_MIDI2WinmmAddBufferSizeCheck.h"
 #include "Feature_Servicing_MIDI2ContainerIds.h"
 #include "Feature_Servicing_MIDI2DriverHang.h"
+#include "Feature_Servicing_MIDI2LegacyTimestamp.h"
 
 using unique_hdevinfo = wil::unique_any_handle_invalid<decltype(&::SetupDiDestroyDeviceInfoList), ::SetupDiDestroyDeviceInfoList>;
 
@@ -122,6 +123,9 @@ void PrintStagingStates()
     LOG_FEATURE_STATE(Feature_Servicing_MIDI2WinmmAddBufferSizeCheck);
     LOG_FEATURE_STATE(Feature_Servicing_MIDI2ContainerIds);
     LOG_FEATURE_STATE(Feature_Servicing_MIDI2DriverHang);
+
+    // 2605
+    LOG_FEATURE_STATE(Feature_Servicing_MIDI2LegacyTimestamp);
 }
 
 HRESULT StartMIDIService()


### PR DESCRIPTION
Legacy ks drivers have a stream position and a TimeDeltaMs, the TimeDeltaMs correlates to the usb packet transferred, so that messages from the same usb packet contain the same TimeDeltaMs. Use that instead of the stream position.