### PR TITLE
winmm perf improvements

### DIFF
--- a/src/api/Client/WinMM/MidiSrvPort.h
+++ b/src/api/Client/WinMM/MidiSrvPort.h
@@ -30,6 +30,20 @@ public:
     HRESULT ModMessage(_In_ UINT msg, _In_  DWORD_PTR param1, _In_ DWORD_PTR param2);
     bool IsFlow(_In_ MidiFlow flow);
 
+    void NotifyInterfaceRemoval(std::wstring interfaceId)
+    {
+        auto lock = m_Lock.lock();
+        if (m_InterfaceId == interfaceId)
+        {
+            m_Invalidated = true;
+        }
+    }
+    bool IsInvalidated()
+    {
+        auto lock = m_Lock.lock();
+        return m_Invalidated;
+    }
+
 private:
     HRESULT Reset();
     HRESULT AddBuffer(_In_ LPMIDIHDR buffer, _In_ DWORD_PTR bufferSize);
@@ -48,6 +62,8 @@ private:
     void WinmmClientCallback(_In_ UINT msg, _In_ DWORD_PTR param1, _In_ DWORD_PTR param2);
 
     wil::critical_section m_Lock;
+
+    bool m_Invalidated {false};
 
     MIDIOPENDESC m_OpenDesc {0};
     DWORD_PTR m_Flags {0};

--- a/src/api/Client/WinMM/MidiSrvPorts.cpp
+++ b/src/api/Client/WinMM/MidiSrvPorts.cpp
@@ -6,6 +6,7 @@
 #include <ks.h>
 
 #include "Feature_Servicing_MIDI2DevCaps2.h"
+#include "Feature_Servicing_MIDI2NumDevsPerf.h"
 
 using unique_hdevinfo = wil::unique_any_handle_invalid<decltype(&::SetupDiDestroyDeviceInfoList), ::SetupDiDestroyDeviceInfoList>;
 
@@ -13,6 +14,107 @@ using unique_hdevinfo = wil::unique_any_handle_invalid<decltype(&::SetupDiDestro
 EXTERN_C IMAGE_DOS_HEADER __ImageBase;
 #define HINST_WDMAUD2 ((HINSTANCE)&__ImageBase)
 
+DWORD CMEventCallback
+(
+    HCMNOTIFICATION,
+    PVOID Context,
+    CM_NOTIFY_ACTION  Action,
+    PCM_NOTIFY_EVENT_DATA EventData,
+    DWORD EventDataSize
+)
+{
+    // context must be valid, this must be for a midi in or midi out device interface,
+    // it must be an arrival or removal, and the notify event data must be valid.
+    if (Context != nullptr &&
+        EventData->FilterType == CM_NOTIFY_FILTER_TYPE_DEVICEINTERFACE &&
+        (EventData->u.DeviceInterface.ClassGuid == DEVINTERFACE_MIDI_OUTPUT || EventData->u.DeviceInterface.ClassGuid == DEVINTERFACE_MIDI_INPUT) &&
+        (Action == CM_NOTIFY_ACTION_DEVICEINTERFACEARRIVAL || Action == CM_NOTIFY_ACTION_DEVICEINTERFACEREMOVAL) &&
+        EventDataSize >= sizeof(CM_NOTIFY_EVENT_DATA))
+    {
+        CMidiPorts * pThis = (CMidiPorts *) Context;
+        MidiFlow flow = (EventData->u.DeviceInterface.ClassGuid == DEVINTERFACE_MIDI_OUTPUT)?MidiFlowOut:MidiFlowIn;
+        bool isArrival = (Action == CM_NOTIFY_ACTION_DEVICEINTERFACEARRIVAL);
+        pThis->MidiInterfaceChange(flow, isArrival, EventData->u.DeviceInterface.SymbolicLink);
+    }
+
+    return 0;
+}
+
+HRESULT
+CMidiPorts::RegisterNotifications()
+{
+    CONFIGRET cr;
+    CM_NOTIFY_FILTER notifyFilter = {};
+
+    auto lock = m_Lock.lock();
+
+    notifyFilter.cbSize = sizeof(notifyFilter);
+    notifyFilter.FilterType = CM_NOTIFY_FILTER_TYPE_DEVICEINTERFACE;
+    notifyFilter.u.DeviceInterface.ClassGuid = DEVINTERFACE_MIDI_OUTPUT;
+    cr = CM_Register_Notification(&notifyFilter, this, &CMEventCallback, &m_NotifyMidiOut);
+    if (cr != CR_SUCCESS)
+    {
+        RETURN_IF_FAILED(HRESULT_FROM_WIN32(CM_MapCrToWin32Err(cr, ERROR_INVALID_DATA)));
+    }
+    LOG_IF_FAILED(RefreshPortsForFlow(MidiFlowOut));
+
+    notifyFilter.cbSize = sizeof(notifyFilter);
+    notifyFilter.FilterType = CM_NOTIFY_FILTER_TYPE_DEVICEINTERFACE;
+    notifyFilter.u.DeviceInterface.ClassGuid = DEVINTERFACE_MIDI_INPUT;
+    cr = CM_Register_Notification(&notifyFilter, this, &CMEventCallback, &m_NotifyMidiIn);
+    if (cr != CR_SUCCESS)
+    {
+        RETURN_IF_FAILED(HRESULT_FROM_WIN32(CM_MapCrToWin32Err(cr, ERROR_INVALID_DATA)));
+    }
+    LOG_IF_FAILED(RefreshPortsForFlow(MidiFlowIn));
+
+    return S_OK;
+}
+
+HRESULT
+CMidiPorts::MidiInterfaceChange
+(
+    MidiFlow Flow,
+    bool IsArrival,
+    WCHAR *SymbolicLink
+)
+{
+    std::wstring notifiedInterface = WindowsMidiServicesInternal::ToLowerTrimmedWStringCopy(SymbolicLink);
+
+    auto lock = m_Lock.lock();
+
+    // search the flow for the interface id
+    for (auto const& [portNum, port] : m_MidiPortInfo[Flow])
+    {
+        if (port.InterfaceId == notifiedInterface)
+        {
+            // if found and is removal, refresh to remove,
+            // else it's already present so noop.
+            if (!IsArrival)
+            {
+                RETURN_IF_FAILED(RefreshPortsForFlow(Flow));
+
+                for (auto const& [portHandle, openPort] : m_OpenPorts)
+                {
+                    openPort->NotifyInterfaceRemoval(notifiedInterface);
+                }
+            }
+
+            // it was found, so we are finished (there will only ever be 1
+            // instance of an interface id in the map)
+            return S_OK;
+        }
+    }
+
+    // if not found and is arrival, refresh to add,
+    // else it's already removed so noop
+    if (IsArrival)
+    {
+        RETURN_IF_FAILED(RefreshPortsForFlow(Flow));
+    }
+
+    return S_OK;
+}
 
 CMidiPorts::CMidiPorts()
 {
@@ -72,6 +174,11 @@ CMidiPorts::RuntimeClassInitialize()
 
     RETURN_IF_FAILED(m_MidisrvTransport->AddClientSession(m_SessionId, m_SessionName.c_str()));
 
+    if (Feature_Servicing_MIDI2NumDevsPerf::IsEnabled())
+    {
+        RETURN_IF_FAILED(RegisterNotifications());
+    }
+
     return S_OK;        
 }
 
@@ -84,6 +191,13 @@ CMidiPorts::Shutdown()
         TraceLoggingString(__FUNCTION__, MIDI_TRACE_EVENT_LOCATION_FIELD),
         TraceLoggingLevel(WINEVENT_LEVEL_INFO),
         TraceLoggingPointer(this, "this"));
+
+    if (Feature_Servicing_MIDI2NumDevsPerf::IsEnabled())
+    {
+        // first, shut down notifications, as it may hold the lock
+        m_NotifyMidiOut.reset();
+        m_NotifyMidiIn.reset();
+    }
 
     auto lock = m_Lock.lock();
 
@@ -126,11 +240,20 @@ CMidiPorts::MidMessage(UINT deviceID, UINT msg, DWORD_PTR user, DWORD_PTR param1
     {
         case MIDM_GETNUMDEVS:
             {
-                UINT32 deviceCount{ };
-                hr = GetMidiDeviceCount(MidiFlowIn, deviceCount);
-                if (SUCCEEDED(hr))
+                if (Feature_Servicing_MIDI2NumDevsPerf::IsEnabled())
                 {
+                    auto lock = m_Lock.lock();
+                    UINT32 deviceCount = m_MidiPortCount[MidiFlowIn];
                     return (MAKELONG(deviceCount, MMSYSERR_NOERROR));
+                }
+                else
+                {
+                    UINT32 deviceCount{ };
+                    hr = GetMidiDeviceCount(MidiFlowIn, deviceCount);
+                    if (SUCCEEDED(hr))
+                    {
+                        return (MAKELONG(deviceCount, MMSYSERR_NOERROR));
+                    }
                 }
             }
             break;
@@ -180,11 +303,20 @@ CMidiPorts::ModMessage(UINT deviceID, UINT msg, DWORD_PTR user, DWORD_PTR param1
     {
         case MODM_GETNUMDEVS:
             {
-                UINT32 deviceCount{ };
-                hr = GetMidiDeviceCount(MidiFlowOut, deviceCount);
-                if (SUCCEEDED(hr))
+                if (Feature_Servicing_MIDI2NumDevsPerf::IsEnabled())
                 {
+                    auto lock = m_Lock.lock();
+                    UINT32 deviceCount = m_MidiPortCount[MidiFlowOut];
                     return (MAKELONG(deviceCount, MMSYSERR_NOERROR));
+                }
+                else
+                {
+                    UINT32 deviceCount{ };
+                    hr = GetMidiDeviceCount(MidiFlowOut, deviceCount);
+                    if (SUCCEEDED(hr))
+                    {
+                        return (MAKELONG(deviceCount, MMSYSERR_NOERROR));
+                    }
                 }
             }
             break;
@@ -213,6 +345,7 @@ CMidiPorts::ModMessage(UINT deviceID, UINT msg, DWORD_PTR user, DWORD_PTR param1
     return MMRESULT_FROM_HRESULT(hr);
 }
 
+// Start remove with Feature_Servicing_MIDI2NumDevsPerf
 _Use_decl_annotations_
 HRESULT
 CMidiPorts::GetMidiDeviceCount(MidiFlow flow, UINT32& count)
@@ -519,6 +652,310 @@ CMidiPorts::GetMidiDeviceCount(MidiFlow flow, UINT32& count)
 
     return S_OK;
 }
+// End remove with Feature_Servicing_MIDI2NumDevsPerf
+
+_Use_decl_annotations_
+HRESULT
+CMidiPorts::RefreshPortsForFlow(MidiFlow flow)
+{
+    TraceLoggingWrite(WdmAud2TelemetryProvider::Provider(),
+        MIDI_TRACE_EVENT_INFO,
+        TraceLoggingString(__FUNCTION__, MIDI_TRACE_EVENT_LOCATION_FIELD),
+        TraceLoggingLevel(WINEVENT_LEVEL_INFO),
+        TraceLoggingPointer(this, "this"),
+        TraceLoggingValue((int)flow, "MidiFlow"));
+
+    RETURN_HR_IF(E_INVALIDARG, flow != MidiFlowIn && flow != MidiFlowOut);
+
+    // We return the largest valid port number here, the client
+    // is then responsible to retrieve the dev caps for these ports
+    // to determine which ports are present at runtime.
+    UINT highestPortNumber {0};
+
+    // throw away old structure for this flow
+    // build up new structure of all active devices for the requested flow, return
+    // maximum port number, our port numbers are from 1->, max port number is 0->
+    // (because port 0 is reserved for the synth, which will eventually be in midisrv)           
+    m_MidiPortInfo[flow].clear();
+    m_MidiPortCount[flow] = 0;
+
+    SP_DEVINFO_DATA device = { sizeof(SP_DEVINFO_DATA) };
+    const GUID* interfaceCategory = (flow == MidiFlowOut) ? &DEVINTERFACE_MIDI_OUTPUT : &DEVINTERFACE_MIDI_INPUT;
+    auto devInfo = unique_hdevinfo{ SetupDiGetClassDevs(interfaceCategory, nullptr, nullptr, DIGCF_DEVICEINTERFACE | DIGCF_PRESENT) };
+    RETURN_HR_IF(HRESULT_FROM_WIN32(GetLastError()), !devInfo);
+
+    for (DWORD deviceIndex = 0; SetupDiEnumDeviceInfo(devInfo.get(), deviceIndex, &device); deviceIndex++)
+    {
+        SP_DEVICE_INTERFACE_DATA deviceInterfaceData = { sizeof(SP_DEVICE_INTERFACE_DATA) };
+        for (DWORD deviceInterfaceIndex = 0; SetupDiEnumDeviceInterfaces(devInfo.get(), &device, interfaceCategory, deviceInterfaceIndex, &deviceInterfaceData); deviceInterfaceIndex++ )
+        {
+            DEVPROPTYPE propType = DEVPROP_TYPE_NULL;
+            WCHAR deviceName[MAXPNAMELEN] = {0};
+            DWORD servicePortNum {0};
+            DWORD requiredSize {0};
+            WCHAR deviceDriverInterfaceId[MAX_PATH] = {0};
+            std::unique_ptr<SP_DEVICE_INTERFACE_DETAIL_DATA> interfaceDetailData;
+            KSCOMPONENTID ksComponentId {0};
+            DWORD ksComponentIdSize {0};
+
+            // retrieve the device interface id string
+            if (!SetupDiGetDeviceInterfaceDetail(
+                devInfo.get(),
+                &deviceInterfaceData,
+                nullptr,
+                0,
+                &requiredSize,
+                nullptr))
+            {
+                if (ERROR_INSUFFICIENT_BUFFER == GetLastError())
+                {
+                    interfaceDetailData.reset((PSP_DEVICE_INTERFACE_DETAIL_DATA)(new (std::nothrow) BYTE[requiredSize]));
+                    RETURN_IF_NULL_ALLOC(interfaceDetailData);
+                    memset(interfaceDetailData.get(), 0, requiredSize);
+                    interfaceDetailData->cbSize = sizeof(SP_DEVICE_INTERFACE_DETAIL_DATA);
+                    SetupDiGetDeviceInterfaceDetail(
+                                    devInfo.get(),
+                                    &deviceInterfaceData,
+                                    interfaceDetailData.get(),
+                                    requiredSize,
+                                    nullptr,
+                                    nullptr);
+                }
+            }
+            if (nullptr == interfaceDetailData)
+            {
+                continue;
+            }
+
+            // retrieve the assigned port number for this interface
+            // if not present, then this may be the synth, which currently
+            // doesn't go through midisrv.
+            if (!SetupDiGetDeviceInterfaceProperty(
+                devInfo.get(),
+                &deviceInterfaceData,
+                &PKEY_MIDI_ServiceAssignedPortNumber,
+                &propType,
+                (PBYTE) &servicePortNum,
+                sizeof(DWORD),
+                nullptr,
+                0))
+            {
+                continue;
+            }
+            if (propType != DEVPROP_TYPE_UINT32)
+            {
+                continue;
+            }
+
+            // retrieve the friendly name for the port
+            if (!SetupDiGetDeviceInterfaceProperty(
+                devInfo.get(),
+                &deviceInterfaceData,
+                &DEVPKEY_DeviceInterface_FriendlyName,
+                &propType,
+                (PBYTE) &deviceName,
+                sizeof(deviceName),
+                &requiredSize,
+                0))
+            {
+                continue;
+            }
+            if (propType != DEVPROP_TYPE_STRING ||
+                requiredSize < sizeof(WCHAR))
+            {
+                continue;
+            }
+
+            // to support DRV_QUERYDEVICEINTERFACE
+            if (!SetupDiGetDeviceInterfaceProperty(
+                devInfo.get(),
+                &deviceInterfaceData,
+                &PKEY_MIDI_DriverDeviceInterface,
+                &propType,
+                (PBYTE)&deviceDriverInterfaceId,
+                sizeof(deviceDriverInterfaceId),
+                &requiredSize,
+                0))
+            {
+                continue;
+            }
+            if (propType != DEVPROP_TYPE_STRING ||
+                requiredSize < sizeof(WCHAR))
+            {
+                continue;
+            }
+
+            if (Feature_Servicing_MIDI2DevCaps2::IsEnabled())
+            {
+                // Retrieve the KS component id information, if available,
+                // from the SWD.
+                if (SetupDiGetDeviceInterfaceProperty(
+                    devInfo.get(),
+                    &deviceInterfaceData,
+                    &PKEY_MIDI_KsComponentId,
+                    &propType,
+                    (PBYTE) &ksComponentId,
+                    sizeof(KSCOMPONENTID),
+                    &ksComponentIdSize,
+                    0))
+                {
+                    if (propType != DEVPROP_TYPE_BINARY ||
+                        ksComponentIdSize != sizeof(KSCOMPONENTID))
+                    {
+                        continue;
+                    }
+                }
+            }
+
+            // our port numbers start with 1 because they're the "global" port numbers
+            // that the user should see and port 0 is reserved for the synth.
+            // So, a service port number of 1 indicates that we have 1 port, and so on.
+            // This means that the port number count is simply the largest port number
+            // we are aware of.
+            if (servicePortNum > highestPortNumber)
+            {
+                highestPortNumber = servicePortNum;
+            }
+
+            // save the port information to the array.
+            m_MidiPortInfo[flow][servicePortNum].PortNumber = servicePortNum;
+            m_MidiPortInfo[flow][servicePortNum].Name = deviceName;
+            m_MidiPortInfo[flow][servicePortNum].InterfaceId = WindowsMidiServicesInternal::ToLowerTrimmedWStringCopy(interfaceDetailData->DevicePath);
+            m_MidiPortInfo[flow][servicePortNum].DriverDeviceInterfaceId = WindowsMidiServicesInternal::ToLowerTrimmedWStringCopy(deviceDriverInterfaceId);
+
+            if (Feature_Servicing_MIDI2DevCaps2::IsEnabled())
+            {
+                WORD wMid {MM_MICROSOFT};
+                WORD wPid = (flow == MidiFlowOut)?MM_MSFT_GENERIC_MIDIOUT:MM_MSFT_GENERIC_MIDIIN;
+                MMVERSION vDriverVersion {0x0100};
+                GUID manufacturerGuid {0};
+                GUID productGuid {0};
+                GUID nameGuid {0};
+
+                INIT_MMREG_MID( &manufacturerGuid, wMid );
+                INIT_MMREG_PID( &productGuid, wPid );
+
+                if (ksComponentIdSize > 0)
+                {
+                    // Legacy kscomponentid information is available, default to wdmaudio midi in/out
+                    // pid, in the event the pid provided by the driver is not compatible,
+                    // and the legacy driver versioning, in the even the provided version isn't
+                    // compatible.
+                    //
+                    // This is to as closely as possible match what wdmaud returned for these
+                    // drivers, which apps have come to depend upon.
+                    wPid = (flow == MidiFlowOut)?MM_MSFT_WDMAUDIO_MIDIOUT:MM_MSFT_WDMAUDIO_MIDIIN;
+                    vDriverVersion = MAKEWORD(VER_PRODUCTMINORVERSION, VER_PRODUCTMAJORVERSION);
+
+                    manufacturerGuid = ksComponentId.Manufacturer;
+                    productGuid = ksComponentId.Product;
+                    nameGuid = ksComponentId.Name;
+                
+                    if (IS_COMPATIBLE_MMREG_MID(&ksComponentId.Manufacturer))
+                    {
+                        wMid = EXTRACT_MMREG_MID(&ksComponentId.Manufacturer);
+                    }
+                    
+                    if (IS_COMPATIBLE_MMREG_PID(&ksComponentId.Product))
+                    {
+                        wPid = EXTRACT_MMREG_PID(&ksComponentId.Product);
+                    }
+                
+                    if ((ksComponentId.Version < 256) && (ksComponentId.Revision < 256))
+                    {
+                        vDriverVersion = MAKEWORD(ksComponentId.Revision, ksComponentId.Version);
+                    }
+                }
+
+                // Fill in the midiCaps for this port
+                if (flow == MidiFlowOut)
+                {
+                    MIDIOUTCAPS2W *caps = &(m_MidiPortInfo[flow][servicePortNum].MidiOutCaps);
+                
+                    caps->wMid = wMid;
+                    caps->wPid = wPid;
+                    caps->vDriverVersion = vDriverVersion;
+                    caps->ManufacturerGuid = manufacturerGuid;
+                    caps->ProductGuid = productGuid;
+                    caps->NameGuid = nameGuid;
+                
+                    wcsncpy_s(caps->szPname, MAXPNAMELEN, m_MidiPortInfo[flow][servicePortNum].Name.c_str(), _TRUNCATE);
+                    caps->szPname[MAXPNAMELEN - 1] = NULL;
+                
+                    caps->wTechnology = MOD_MIDIPORT;
+                    caps->wVoices = 0;
+                    caps->wNotes = 0;
+                    caps->wChannelMask = 0xFFFF;
+                    caps->dwSupport = 0;
+                }
+                else
+                {
+                    MIDIINCAPS2W *caps = &(m_MidiPortInfo[flow][servicePortNum].MidiInCaps);
+                
+                    caps->wMid = wMid;
+                    caps->wPid = wPid;
+                    caps->vDriverVersion = vDriverVersion;
+                    caps->ManufacturerGuid = manufacturerGuid;
+                    caps->ProductGuid = productGuid;
+                    caps->NameGuid = nameGuid;
+
+                    wcsncpy_s(caps->szPname, MAXPNAMELEN, m_MidiPortInfo[flow][servicePortNum].Name.c_str(), _TRUNCATE);
+                    caps->szPname[MAXPNAMELEN - 1] = NULL;
+                
+                    caps->dwSupport = 0;
+                }
+            }
+            else
+            {
+                // Fill in the midiCaps for this port
+                if (flow == MidiFlowOut)
+                {
+                    MIDIOUTCAPSW *caps = (MIDIOUTCAPSW*) &(m_MidiPortInfo[flow][servicePortNum].MidiOutCaps);
+                
+                    caps->wMid = MM_MICROSOFT;
+                    caps->wPid = MM_MSFT_GENERIC_MIDIOUT;
+                    caps->vDriverVersion = 0x0100;
+                
+                    wcsncpy_s(caps->szPname, MAXPNAMELEN, m_MidiPortInfo[flow][servicePortNum].Name.c_str(), _TRUNCATE);
+                    caps->szPname[MAXPNAMELEN - 1] = NULL;
+                
+                    caps->wTechnology = MOD_MIDIPORT;
+                    caps->wVoices = 0;
+                    caps->wNotes = 0;
+                    caps->wChannelMask = 0xFFFF;
+                    caps->dwSupport = 0;
+                }
+                else
+                {
+                    MIDIINCAPSW *caps = (MIDIINCAPSW*) &(m_MidiPortInfo[flow][servicePortNum].MidiInCaps);
+                
+                    caps->wMid = MM_MICROSOFT;
+                    caps->wPid = MM_MSFT_GENERIC_MIDIIN;
+                    caps->vDriverVersion = 0x0100;
+
+                    //wcsncpy_s(caps->szPname, m_MidiPortInfo[flow][servicePortNum].Name.c_str(), MAXPNAMELEN);
+                    wcsncpy_s(caps->szPname, MAXPNAMELEN, m_MidiPortInfo[flow][servicePortNum].Name.c_str(), _TRUNCATE);
+                    caps->szPname[MAXPNAMELEN - 1] = NULL;
+                
+                    caps->dwSupport = 0;
+                }
+            }
+        }
+    }
+
+    // save and return the highest port number
+    m_MidiPortCount[flow] = highestPortNumber;
+
+    TraceLoggingWrite(WdmAud2TelemetryProvider::Provider(),
+        MIDI_TRACE_EVENT_INFO,
+        TraceLoggingString(__FUNCTION__, MIDI_TRACE_EVENT_LOCATION_FIELD),
+        TraceLoggingLevel(WINEVENT_LEVEL_INFO),
+        TraceLoggingPointer(this, "this"),
+        TraceLoggingValue((int)flow, "MidiFlow"));
+
+    return S_OK;
+}
+
 
 _Use_decl_annotations_
 HRESULT
@@ -667,7 +1104,14 @@ CMidiPorts::Open(MidiFlow flow, UINT portNumber, const MIDIOPENDESC* midiOpenDes
     // to the port number provided by winmm.
     UINT localPortNumber = portNumber + 1;
 
-    RETURN_HR_IF(HRESULT_FROM_MMRESULT(MMSYSERR_BADDEVICEID), localPortNumber > m_MidiPortCount[flow]);
+    if (Feature_Servicing_MIDI2NumDevsPerf::IsEnabled())
+    {
+        RETURN_HR_IF(HRESULT_FROM_MMRESULT(MMSYSERR_NODRIVER), localPortNumber > m_MidiPortCount[flow]);
+    }
+    else
+    {
+        RETURN_HR_IF(HRESULT_FROM_MMRESULT(MMSYSERR_BADDEVICEID), localPortNumber > m_MidiPortCount[flow]);
+    }
 
     auto portInfo = m_MidiPortInfo[flow].find(localPortNumber);
 
@@ -784,6 +1228,19 @@ CMidiPorts::ForwardMidMessage(UINT msg, MidiPortHandle portHandle, DWORD_PTR par
     wil::com_ptr_nothrow<CMidiPort> port;
 
     RETURN_IF_FAILED(GetOpenedPort(MidiFlowIn, portHandle, port));
+
+    if (Feature_Servicing_MIDI2NumDevsPerf::IsEnabled())
+    {
+        // If this is a close message, we still want to forward
+        // the message to the port so that it has the opportunity
+        // to close, even if it has been invalidated.
+        if (MIDM_CLOSE != msg && port->IsInvalidated())
+        {
+            // If the device has been removed, return no driver
+            return HRESULT_FROM_MMRESULT(MMSYSERR_NODRIVER);
+        }
+    }
+
     RETURN_IF_FAILED(port->MidMessage(msg, param1, param2));
     return S_OK;
 }
@@ -805,6 +1262,19 @@ CMidiPorts::ForwardModMessage(UINT msg, MidiPortHandle portHandle, DWORD_PTR par
     wil::com_ptr_nothrow<CMidiPort> port;
 
     RETURN_IF_FAILED(GetOpenedPort(MidiFlowOut, portHandle, port));
+
+    if (Feature_Servicing_MIDI2NumDevsPerf::IsEnabled())
+    {
+        // If this is a close message, we still want to forward
+        // the message to the port so that it has the opportunity
+        // to close, even if it has been invalidated.
+        if (MODM_CLOSE != msg && port->IsInvalidated())
+        {
+            // If the device has been removed, return no driver
+            return E_HANDLE;
+        }
+    }
+
     RETURN_IF_FAILED(port->ModMessage(msg, param1, param2));
     return S_OK;
 }

--- a/src/api/Client/WinMM/MidiSrvPorts.h
+++ b/src/api/Client/WinMM/MidiSrvPorts.h
@@ -1,9 +1,11 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 
 #include "MidiSrvPort.h"
+#include <cfgmgr32.h>
 
 #pragma once
 
+using unique_cm_notification = wil::unique_any<HCMNOTIFICATION, decltype(&::CM_Unregister_Notification), ::CM_Unregister_Notification>;
 typedef ULONGLONG MidiPortHandle;
 
 typedef struct _PORT_INFO
@@ -35,9 +37,15 @@ public:
     HRESULT Shutdown();
     DWORD APIENTRY MidMessage(_In_ UINT deviceID, _In_ UINT msg, _In_ DWORD_PTR user, _In_ DWORD_PTR param1, _In_ DWORD_PTR param2);
     DWORD APIENTRY ModMessage(_In_ UINT deviceID, _In_ UINT msg, _In_ DWORD_PTR user, _In_ DWORD_PTR param1, _In_ DWORD_PTR param2);
+    HRESULT MidiInterfaceChange(MidiFlow Flow, bool IsArrival, WCHAR *SymbolicLink);
 
 private:
+    HRESULT RegisterNotifications();
+    // Start remove with Feature_Servicing_MIDI2NumDevsPerf
     HRESULT GetMidiDeviceCount(_In_ MidiFlow flow, _In_ UINT32& count);
+    // End remove with Feature_Servicing_MIDI2NumDevsPerf
+    HRESULT RefreshPortsForFlow(_In_ MidiFlow flow);
+    HRESULT GetDevCaps(_In_ MidiFlow flow, _In_ UINT portNumber, _In_ DWORD_PTR midiCaps);
     HRESULT GetDevCaps(_In_ MidiFlow flow, _In_ UINT portNumber, _In_ DWORD_PTR midiCaps, _In_ DWORD_PTR midiCapsSize);
     HRESULT Open(_In_ MidiFlow flow, _In_ UINT portNumber, _In_ const MIDIOPENDESC* midiOpenDesc, _In_ DWORD_PTR flags, _In_ MidiPortHandle* openedPort);
     HRESULT Close(_In_ MidiFlow flow, _In_ MidiPortHandle portHandle);
@@ -66,5 +74,8 @@ private:
     // map of the open midi clients ordered by the port handle, which is just the
     // address of the CMidiPort object for that client. 
     std::map<MidiPortHandle, wil::com_ptr_nothrow<CMidiPort>> m_OpenPorts;
+
+    unique_cm_notification m_NotifyMidiOut;
+    unique_cm_notification m_NotifyMidiIn;
 };
 

--- a/src/api/Inc/Feature_Servicing_MIDI2NumDevsPerf.h
+++ b/src/api/Inc/Feature_Servicing_MIDI2NumDevsPerf.h
@@ -1,0 +1,18 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License
+// ============================================================================
+// This is part of the Windows MIDI Services App API and should be used
+// in your Windows application via an official binary distribution.
+// Further information: https://aka.ms/midi
+// ============================================================================
+
+#pragma once
+
+class Feature_Servicing_MIDI2NumDevsPerf
+{
+public:
+    static bool IsEnabled()
+    {
+        return true;
+    }
+};

--- a/src/api/Service/Exe/MidiDeviceManager.cpp
+++ b/src/api/Service/Exe/MidiDeviceManager.cpp
@@ -19,6 +19,7 @@
 #include "Feature_Servicing_MIDI2DeviceRemoval.h"
 #include "Feature_Servicing_MIDI2ContainerIds.h"
 #include "Feature_Servicing_MIDI2DevCaps2.h"
+#include "Feature_Servicing_MIDI2NumDevsPerf.h"
 
 using namespace winrt::Windows::Devices::Enumeration;
 
@@ -479,14 +480,28 @@ SwMidiPortCreateCallback(__in HSWDEVICE swDevice, __in HRESULT creationResult, _
 
     if (SUCCEEDED(creationContext->MidiPort->hr))
     {
-        creationContext->MidiPort->hr = SwDeviceInterfaceRegister(
-            swDevice,
-            creationContext->MidiPort->InterfaceCategory,
-            nullptr,
-            creationContext->IntPropertyCount,
-            creationContext->InterfaceDevProperties,
-            TRUE,
-            wil::out_param(creationContext->MidiPort->DeviceInterfaceId));
+        if (Feature_Servicing_MIDI2NumDevsPerf::IsEnabled())
+        {
+            creationContext->MidiPort->hr = SwDeviceInterfaceRegister(
+                swDevice,
+                creationContext->MidiPort->InterfaceCategory,
+                nullptr,
+                creationContext->IntPropertyCount,
+                creationContext->InterfaceDevProperties,
+                FALSE, // must register as "disabled" so that we have the opportunity to assign a port number prior to it going active
+                wil::out_param(creationContext->MidiPort->DeviceInterfaceId));
+        }
+        else
+        {
+            creationContext->MidiPort->hr = SwDeviceInterfaceRegister(
+                swDevice,
+                creationContext->MidiPort->InterfaceCategory,
+                nullptr,
+                creationContext->IntPropertyCount,
+                creationContext->InterfaceDevProperties,
+                TRUE,
+                wil::out_param(creationContext->MidiPort->DeviceInterfaceId));
+        }
     }
 
     if (SUCCEEDED(creationContext->MidiPort->hr))
@@ -3190,8 +3205,11 @@ CMidiDeviceManager::SyncMidi1Ports(
                     nullptr,
                     &createdMidiPort));
 
-                // Assign the new port number.
-                RETURN_IF_FAILED(AssignPortNumber(createdMidiPort->SwDevice.get(), createdMidiPort->DeviceInterfaceId.get(), createdMidiPort->Flow));
+                if (!Feature_Servicing_MIDI2NumDevsPerf::IsEnabled())
+                {
+                    // Assign the new port number.
+                    RETURN_IF_FAILED(AssignPortNumber(createdMidiPort->SwDevice.get(), createdMidiPort->DeviceInterfaceId.get(), createdMidiPort->Flow));
+                }
 
                 // We want to reuse interfaceProperties for the next creation,
                 // so pop the endpoint specific properties off in preparation.

--- a/src/api/Test/Midi2.Transport.unittests/Midi2SrvTransportTests.cpp
+++ b/src/api/Test/Midi2.Transport.unittests/Midi2SrvTransportTests.cpp
@@ -1376,6 +1376,195 @@ MidiSrvTransportTests::TestKSAPortEnumeration()
     }
 }
 
+void
+MidiSrvTransportTests::GetWinmmMinMidiEndpoints
+(
+    std::vector<std::unique_ptr<MIDIU_DEVICE>> &midiInDevices,
+    std::vector<std::unique_ptr<MIDIU_DEVICE>> &midiOutDevices,
+    UINT &numInDevices,
+    UINT &numOutDevices
+)
+{
+    #define MINMIDI_STRING L"MINMIDI"
+
+    for (UINT i = 0; i < midiInGetNumDevs(); i++)
+    {
+        MIDIINCAPS inCaps {0};
+        if (MMSYSERR_NOERROR == midiInGetDevCaps(i, &inCaps, sizeof(MIDIINCAPS)))
+        {
+            if (0 == _wcsnicmp(inCaps.szPname, MINMIDI_STRING, wcslen(MINMIDI_STRING)))
+            {
+                numInDevices++;
+            }
+        }
+    }
+
+    VERIFY_SUCCEEDED(MidiSWDeviceEnum::EnumerateDevices(midiInDevices, [&](PMIDIU_DEVICE device)
+    {
+        if (device->Flow == MidiFlowIn &&
+            std::wstring::npos != device->ParentDeviceInstanceId.find(MINMIDI_STRING) &&
+            TRUE == device->MidiOne)
+        {
+            return true;
+        }
+        else
+        {
+            return false;
+        }
+    }));
+
+    for (UINT i = 0; i < midiOutGetNumDevs(); i++)
+    {
+        MIDIOUTCAPS outCaps {0};
+        if (MMSYSERR_NOERROR == midiOutGetDevCaps(i, &outCaps, sizeof(MIDIOUTCAPS)))
+        {
+            if (0 == _wcsnicmp(outCaps.szPname, MINMIDI_STRING, wcslen(MINMIDI_STRING)))
+            {
+                numOutDevices++;
+            }
+        }
+    }
+
+    VERIFY_SUCCEEDED(MidiSWDeviceEnum::EnumerateDevices(midiOutDevices, [&](PMIDIU_DEVICE device)
+    {
+        if (device->Flow == MidiFlowOut &&
+            std::wstring::npos != device->ParentDeviceInstanceId.find(MINMIDI_STRING) &&
+            TRUE == device->MidiOne)
+        {
+            return true;
+        }
+        else
+        {
+            return false;
+        }
+    }));
+}
+
+#define WINMM_PORT_TIMEOUT 120000
+#define WINMM_PORT_QUERY_DELAY 500
+
+HRESULT
+MidiSrvTransportTests::WaitForWinmmDeviceCount
+(
+    std::vector<std::unique_ptr<MIDIU_DEVICE>> &midiInDevices,
+    std::vector<std::unique_ptr<MIDIU_DEVICE>> &midiOutDevices,
+    UINT &numInDevices,
+    UINT &numOutDevices,
+    UINT expectedInCount,
+    UINT expectedOutCount
+)
+{
+    UINT64 startTime = GetTickCount64();
+
+    while ((midiInDevices.size() != expectedInCount || numInDevices != expectedInCount || 
+            midiOutDevices.size() != expectedOutCount || numOutDevices != expectedOutCount) && 
+            (GetTickCount64() - startTime < WINMM_PORT_TIMEOUT))
+    {
+        midiInDevices.clear();
+        numInDevices = 0;
+        midiOutDevices.clear();
+        numOutDevices = 0;
+        Sleep(WINMM_PORT_QUERY_DELAY);
+        GetWinmmMinMidiEndpoints(midiInDevices, midiOutDevices, numInDevices, numOutDevices);
+    };
+
+    if (midiInDevices.size() != expectedInCount || numInDevices != expectedInCount ||
+        numOutDevices != expectedOutCount || midiOutDevices.size() != expectedOutCount)
+    {
+        LOG_OUTPUT(L"Expect %d in ports and %d out ports", expectedInCount, expectedOutCount);
+        LOG_OUTPUT(L"Actually %d in ports and %d out ports and %d winmm in ports and %d winmm out ports", midiInDevices.size(), midiOutDevices.size(), numInDevices, numOutDevices);
+    }
+
+    RETURN_HR_IF(E_FAIL, midiInDevices.size() != expectedInCount || midiOutDevices.size() != expectedOutCount);
+    RETURN_HR_IF(E_FAIL, numInDevices != expectedInCount || numOutDevices != expectedOutCount);
+
+    return S_OK;
+}
+
+void
+MidiSrvTransportTests::TestWinmmPortEnumeration()
+{
+    if (Feature_Servicing_MIDI2VirtualPortDriversFix::IsEnabled())
+    {
+        WEX::TestExecution::SetVerifyOutput verifySettings(WEX::TestExecution::VerifyOutputSettings::LogOnlyFailures);
+
+        std::vector<std::unique_ptr<MIDIU_DEVICE>> midiInDevices;
+        std::vector<std::unique_ptr<MIDIU_DEVICE>> midiOutDevices;
+        UINT numInDevices {0};
+        UINT numOutDevices {0};
+        std::wstring minmidiInstanceId;
+
+        GetWinmmMinMidiEndpoints(midiInDevices, midiOutDevices, numInDevices, numOutDevices);
+
+        if (midiInDevices.size() == 0 || midiOutDevices.size() == 0)
+        {
+            WEX::Logging::Log::Result(WEX::Logging::TestResults::Skipped, L"Test requires MinMidi.");
+            return;
+        }
+
+        VERIFY_ARE_EQUAL(midiInDevices.size(), numInDevices);
+        VERIFY_ARE_EQUAL(midiOutDevices.size(), numOutDevices);
+
+        minmidiInstanceId = midiInDevices[0]->ParentDeviceInstanceId;
+        LOG_OUTPUT(L"Testing %s", minmidiInstanceId.c_str());
+
+        auto cleanup = wil::scope_exit([&]()
+        {
+            // Simulate a surprise removal to restore the driver back to the baseline state in the event this
+            // test fails.
+            SendDriverCommand(KSPROPERTY_MINMIDICONTROL_SURPRISEREMOVESIMULATION, 1);
+            SetDeviceEnabled(minmidiInstanceId.c_str(), false);
+            SetDeviceEnabled(minmidiInstanceId.c_str(), true);
+        });
+
+        // remove all of the endpoints.
+        LOG_OUTPUT(L"Removing all minmidi ports");
+        while (SUCCEEDED(SendDriverCommand(KSPROPERTY_MINMIDICONTROL_REMOVEPORT, (DWORD) MidiDataFormats_ByteStream)));
+        while (SUCCEEDED(SendDriverCommand(KSPROPERTY_MINMIDICONTROL_REMOVEPORT, (DWORD) MidiDataFormats_UMP)));
+
+        // There should be 0
+        LOG_OUTPUT(L"Confirming removed");
+        VERIFY_SUCCEEDED(WaitForWinmmDeviceCount(midiInDevices, midiOutDevices, numInDevices, numOutDevices, 0, 0));
+
+        // now enable all available bytestream interfaces on the driver and confirm the ports show up w/ both the SWD,
+        // and winmm
+        UINT expectedPortcount = 0;
+        while (SUCCEEDED(SendDriverCommand(KSPROPERTY_MINMIDICONTROL_ADDPORT, (DWORD) MidiDataFormats_ByteStream)))
+        {
+            expectedPortcount++;
+            LOG_OUTPUT(L"Enabling bytestream port %d", expectedPortcount);
+            VERIFY_SUCCEEDED(WaitForWinmmDeviceCount(midiInDevices, midiOutDevices, numInDevices, numOutDevices, expectedPortcount, expectedPortcount));
+        }
+
+        // now enable all available UMP interfaces on the driver and confirm those ports show up w/ both the SWD,
+        // and winmm.
+        while (SUCCEEDED(SendDriverCommand(KSPROPERTY_MINMIDICONTROL_ADDPORT, (DWORD) MidiDataFormats_UMP)))
+        {
+            expectedPortcount++;
+            LOG_OUTPUT(L"Enabling UMP port %d", expectedPortcount);
+            VERIFY_SUCCEEDED(WaitForWinmmDeviceCount(midiInDevices, midiOutDevices, numInDevices, numOutDevices, expectedPortcount, expectedPortcount));
+        }
+
+        // And disable all the ports and make sure they all go away.
+        while (SUCCEEDED(SendDriverCommand(KSPROPERTY_MINMIDICONTROL_REMOVEPORT, (DWORD) MidiDataFormats_ByteStream)))
+        {
+            expectedPortcount--;
+            LOG_OUTPUT(L"Disabling bytestream port %d", expectedPortcount);
+            VERIFY_SUCCEEDED(WaitForWinmmDeviceCount(midiInDevices, midiOutDevices, numInDevices, numOutDevices, expectedPortcount, expectedPortcount));
+        }
+        while (SUCCEEDED(SendDriverCommand(KSPROPERTY_MINMIDICONTROL_REMOVEPORT, (DWORD) MidiDataFormats_UMP)))
+        {
+            expectedPortcount--;
+            LOG_OUTPUT(L"Disabling UMP port %d", expectedPortcount);
+            VERIFY_SUCCEEDED(WaitForWinmmDeviceCount(midiInDevices, midiOutDevices, numInDevices, numOutDevices, expectedPortcount, expectedPortcount));
+        }
+
+        // There again should be be 0
+        LOG_OUTPUT(L"Confirming all gone");
+        VERIFY_SUCCEEDED(WaitForWinmmDeviceCount(midiInDevices, midiOutDevices, numInDevices, numOutDevices, 0, 0));
+    }
+}
+
 bool MidiSrvTransportTests::TestSetup()
 {
     m_MidiInCallback = nullptr;

--- a/src/api/Test/Midi2.Transport.unittests/Midi2SrvTransportTests.h
+++ b/src/api/Test/Midi2.Transport.unittests/Midi2SrvTransportTests.h
@@ -79,12 +79,17 @@ public:
 
     TEST_METHOD(TestKSAPortEnumeration);
 
+    TEST_METHOD(TestWinmmPortEnumeration);
+
 private:
     void TestMidiSrvMultiClient(_In_ MidiDataFormats, _In_ MidiDataFormats, _In_ BOOL);
     void TestMidiSrvMultiClientBidi(_In_ MidiDataFormats, _In_ MidiDataFormats);
 
     void GetKSAMinMidiEndpoints    (std::vector<std::unique_ptr<MIDIU_DEVICE>> &midiInDevices,   std::vector<std::unique_ptr<MIDIU_DEVICE>> &midiOutDevices);
     HRESULT WaitForDeviceCount(std::vector<std::unique_ptr<MIDIU_DEVICE>> &midiInDevices, std::vector<std::unique_ptr<MIDIU_DEVICE>> &midiOutDevices, UINT expectedInCount, UINT expectedOutCount);
+
+    void GetWinmmMinMidiEndpoints    (std::vector<std::unique_ptr<MIDIU_DEVICE>> &midiInDevices,    std::vector<std::unique_ptr<MIDIU_DEVICE>> &midiOutDevices, UINT& numInDevices, UINT& numOutDevices);
+    HRESULT WaitForWinmmDeviceCount(std::vector<std::unique_ptr<MIDIU_DEVICE>> &midiInDevices, std::vector<std::unique_ptr<MIDIU_DEVICE>> &midiOutDevices, UINT& numInDevices, UINT& numOutDevices, UINT expectedInCount, UINT expectedOutCount);
 };
 
 


### PR DESCRIPTION
move port enumeration into a worker thread so the getnumdevs call is just returning the current value.

when the worker sees an endpoint go away, mark the ports as invalidated so calls can fail with the correct error code

add tests for getnumdevs perf and arrival and removal validation.