### PR TITLE
Fix inverted logic in midifixreg_main.cpp for 32 bit registry updates

### DIFF
--- a/src/app-sdk/tools/midifixreg/midifixreg_main.cpp
+++ b/src/app-sdk/tools/midifixreg/midifixreg_main.cpp
@@ -517,7 +517,7 @@ int __cdecl main(int /*argc*/, char* /*argv[]*/)
                 WriteBlankLine();
             }
 
-            if (! midiWOWValueNeedsReplacing || midi1WOWValueNeedsReplacing || !valuesToDeleteWOW.empty())
+            if (midiWOWValueNeedsReplacing || midi1WOWValueNeedsReplacing || !valuesToDeleteWOW.empty())
             {
                 WriteImportant("Making required changes for 32 bit apps");
                 FixRegistryValues(drivers32WOWHklmKey, valuesToDeleteWOW, midiWOWValueNeedsReplacing, midi1WOWValueNeedsReplacing);


### PR DESCRIPTION
I found a logic error on line 520: the ! operator in !midiWOWValueNeedsReplacing causes the condition to be inverted. It currently tries to update the registry when it's not needed, instead of when it is. Removing the ! fixes this logic.