### PR TITLE
Update MIDI docs for threading and conversion

### DIFF
--- a/docs/kb/moving-from-winmm-to-wms.md
+++ b/docs/kb/moving-from-winmm-to-wms.md
@@ -78,12 +78,20 @@ Custom drivers for things like loopbacks were more troublesome, because inside W
 
 WinMM is a simple API, but part of that simplicity is because it provides very limited information about ports, and lacks a lot of features customers and developers have requested over the past 30+ years. As a result of that and the integration of MIDI 2.0, the Windows MIDI Services API is somewhat more complex. Here's a mapping of concepts from WinMM to the Windows MIDI Services API.
 
+## A note on threading
+
+Many WinMM apps do all the MIDI work on the UI thread. Although this was never explicitly a forbidden approach, it was never a best practice. We're not judging here, though, just informing.
+
+In Windows MIDI Services, the service startup can take multiple seconds. For the SDK, we were explicitely asked by partner developers to **not** have Async calls, as those can be a pain when you are already managing your own threading. Therefore, **please ensure that your MIDI work, especially initialization and message sending, is not running on the UI thread** in your app. Otherwise, calls which take more than a five seconds can cause your app to "ghost" or "fade" and be reported as unresponsive.
+
+In modern apps, the UI thread should handle UI, and not MIDI. We recommend you initialize WinRT/COM in an MTA (Multi-threaded apartment)-enabled thread to ensure there are no blocking calls.
+
 ## Initialization
 
 There are three things you want to do before opening a connection to a MIDI Endpoint
 
 1. Initialize the WinRT (and COM) apartment. In C++/WinRT this is done using `winrt::init_apartment()`
-2. Ensure the MIDI Service has started. The MIDI Service will start when the first call is made to it to open any endpoint. However, you need to have those endpoints enumerated first, so it's best to call `MidiApi::EnsureServiceAvailable()` and check the return value. If the user has disabled the service, is using the MIDI Legacy Mode (no service) or the service cannot start for some reason, this will return false. When the service is demand-started in this way, enumeration of MIDI Endpoints begins as soon as it has started up. You can also check the currently set API mode in the `MidiApi` type, and bail (or fall back to older APIs) if it is set to legacy mode.
+2. Ensure the MIDI Service has started. The MIDI Service will start when the first call is made to it to open any endpoint. However, you need to have those endpoints enumerated first, so it's best to call `MidiApi::EnsureServiceAvailable()` and check the return value. If the user has disabled the service, is using the MIDI Legacy Mode (no service) or the service cannot start for some reason, this will return false. When the service is demand-started in this way, enumeration of MIDI Endpoints begins as soon as it has started up. You can also check the currently set API mode in the `MidiApi` type, and bail (or fall back to older APIs) if it is set to legacy mode. **NOTE: Service startup typically takes several seconds, more if there are many MIDI devices attached.** This is true even when using WinMM under the new MIDI stack.
 3. Create a `MidiSession`. An app can have multiple MIDI Sessions if there's logical separation between them (think different open projects). I recommend giving your session a meaningful name that the customer will recognize if they look at active sessions using any of the tools we make available.
 
 Once you have done those three things, you can start working with MIDI Endpoints
@@ -108,7 +116,7 @@ Windows MIDI Services provides specializations of the WinRT `DeviceWatcher` whic
 
 You can find samples of both types of watcher at [https://aka.ms/midisamples](https://aka.ms/midisamples)
 
-### Don't store names
+### Best Practice: Don't store names
 
 In WinMM, the only persistent identifier we gave you was the port name. That meant users could never rename them, which was the second-most requested feature after multi-client support. In Windows MIDI Services, customers are free to rename ports using either the legacy names (WinMM-style), new-style names (uses iJack when available), or completely custom names.
 
@@ -180,6 +188,12 @@ Similarly, Windows MIDI Services receives all messages through the `MidiEndpoint
 
 > The COM callbacks are the only way to receive multiple messages together. The event support is for a single message at a time.
 
+### Best practice: Receive and handle messages quickly for best performance
+
+When you receive an event callback or a COM Extensions callback indicating new message data is available, handle it quickly. You want to keep MIDI flowing and responsive, and the buffer between the service and your app drained, so that means you will want to copy the message data you need into your own processing queue, and then return from the event. If you have time-consuming processing to do, or additional messages to send in response, that should be handled separately outside the event or callback handler.
+
+Although there were no cross-process queues involved, the same advice was true in WinMM before Windows MIDI Services so many professional apps already handle the data in this way.
+
 ## Outgoing timestamps
 
 To send a message immediately, as you would in WinMM, pass the `MidiClock::TimestampConstantSendImmediately()` value. You can also use `MidiClock::Now()` but the constant bypasses an additional check in the service and so is ever so slightly more efficient.
@@ -191,3 +205,5 @@ Although the timestamps are currently based on `QueryPerformanceCounter` Always 
 ## Incoming timestamps
 
 In WinMM and WinRT MIDI 1.0, incoming message timestamps are an offset from when the port was opened. In Windows MIDI Services, outgoing and incoming timestamps are offsets from when the PC was booted up. They are 64 bit values, currently in 100ns units, and so will not wrap around in our lifetimes, even if the PC is left on every single day. You do not need to handle any sort of wrapping of these numbers.
+
+

--- a/docs/sdk-reference/MidiEndpointConnection.md
+++ b/docs/sdk-reference/MidiEndpointConnection.md
@@ -104,10 +104,7 @@ This function sends each packet one at a time, because each packet has its own t
 | -------- | ----------- |
 | `MessageReceived (source, args)` | From `IMidiMessageReceivedEventSource`. This is the event for receiving MIDI Messages, one at a time. |
 
-When processing the `MessageReceived` event, do so quickly. This event is synchronous. If you need to do long-running processing of incoming messages, add them to your own incoming queue structure and have them processed by another application thread.
-
-> # Threading: 
-> In a multi-threaded apartment, the thread the `MessageReceived` callback comes in on is not the same thread which created the connection to begin with. Windows MIDI Services uses a high-priority thread in the background, one per connection. For this reason, it's best to use the event only to receive the message and store it, not to do any additional processing on the message. The TAEF test `MidiEndpointCreationThreadTests` in the `Midi2.Client.unittests` project demonstrates how this works.
+**Performance Tip:** When processing the `MessageReceived` event, do so quickly. This event is synchronous. If you need to do long-running processing of incoming messages, add them to your own incoming queue and have them processed by another application thread.
 
 > # Note: 
 > Wire up event handlers and add message processing plugins prior to calling `Open()`. 
@@ -116,72 +113,4 @@ When processing the `MessageReceived` event, do so quickly. This event is synchr
 
 Here's an excerpt from the full "API client basics" sample. It shows sending and receiving messages using the two built-in loopback endpoints. For more information on the loopback endpoints, see [diagnostics endpoints](../../endpoints/diagnostic-endpoints.md).
 
-```cs
-using (var session = MidiSession.CreateSession("API Sample Session"))
-{
-    // get the endpoint Ids. Normally, you'd use enumeration functions to get this
-    // for non-diagnostics endpoints.
-    var endpointAId = MidiDiagnostics.DiagnosticsLoopbackAEndpointId;
-    var endpointBId = MidiDiagnostics.DiagnosticsLoopbackBEndpointId;
-
-    Console.WriteLine("Connecting to Sender UMP Endpoint: " + endpointAId);
-    Console.WriteLine("Connecting to Receiver UMP Endpoint: " + endpointBId);
-
-    var sendEndpoint = session.CreateEndpointConnection(endpointAId);
-    var receiveEndpoint = session.CreateEndpointConnection(endpointBId);
-
-    void MessageReceivedHandler(object sender, MidiMessageReceivedEventArgs args)
-    {
-        var ump = args.GetMessagePacket();
-
-        Console.WriteLine();
-        Console.WriteLine("Received UMP");
-        Console.WriteLine("- Current Timestamp: " + MidiClock.Now);
-        Console.WriteLine("- UMP Timestamp:     " + ump.Timestamp);
-        Console.WriteLine("- UMP Msg Type:      " + ump.MessageType);
-        Console.WriteLine("- UMP Packet Type:   " + ump.PacketType);
-        Console.WriteLine("- Message:           " + MidiMessageHelper.GetMessageFriendlyNameFromFirstWord(args.PeekFirstWord()));
-
-        if (ump is MidiMessage32)
-        {
-            var ump32 = ump as MidiMessage32;
-
-            if (ump32 != null)
-                Console.WriteLine("- Word 0:            0x{0:X}", ump32.Word0);
-        }
-    };
-
-    // wire up the event handler before opening the endpoint
-    receiveEndpoint.MessageReceived += MessageReceivedHandler;
-
-    Console.WriteLine("Opening endpoint connection");
-
-    receiveEndpoint.Open();
-    sendEndpoint.Open();
-
-    Console.WriteLine("Creating MIDI 1.0 Channel Voice 32-bit UMP...");
-
-    var ump32 = MidiMessageBuilder.BuildMidi1ChannelVoiceMessage(
-        MidiClock.Now, // use current timestamp
-        5,      // group 4
-        Midi1ChannelVoiceMessageStatus.NoteOn,  // 9
-        3,      // channel 2
-        120,    // note 120 - hex 0x78
-        100);   // velocity 100 hex 0x64
-
-    sendEndpoint.SendSingleMessagePacket((IMidiUniversalPacket)ump32);  // could also use the SendWords methods, etc.
-
-    Console.WriteLine(" ** Wait for the message to arrive, and then press enter to cleanup. ** ");
-    Console.ReadLine();
-
-    // you should unregister the event handler as well
-    receiveEndpoint.MessageReceived -= MessageReceivedHandler;
-
-    // not strictly necessary if the session is going out of scope or is in a using block
-    session.DisconnectEndpointConnection(sendEndpoint.ConnectionId);
-    session.DisconnectEndpointConnection(receiveEndpoint.ConnectionId);
-}
-
-```
-
-More complete examples [available on Github](https://aka.ms/midirepo)
+Complete examples [available on Github](https://aka.ms/midirepo)

--- a/docs/sdk-reference/MidiEndpointConnection_COM-Extensions.md
+++ b/docs/sdk-reference/MidiEndpointConnection_COM-Extensions.md
@@ -115,6 +115,8 @@ interface IMidiEndpointConnectionMessagesReceivedCallback : IUnknown
 | -------- | ----------- |
 | `MessagesReceived` | Called when one or more messages have been received from the endpoint. How many messages are included in a single call depends largely upon how the endpoint receives and passes them along, and what additional processing is done on the data in the service. 
 
+**Performance Tip:** When processing the `MessagesReceived` callback, do so quickly. This callback is synchronous. If you need to do long-running processing of incoming messages, add them to your own incoming queue and have them processed by another application thread.
+
 The session id and connection id are provided for convenience when using a centralized message handler. 
 
 The messages data pointer is valid only for the duration of the call, as it is a pointer into the cross-process memory-mapped buffer shared with the service. Therefore, all data must be copied and not referenced. 

--- a/docs/sdk-reference/Utilities/Messages/MidiBytestreamToUmpMessageConverterState.md
+++ b/docs/sdk-reference/Utilities/Messages/MidiBytestreamToUmpMessageConverterState.md
@@ -1,0 +1,23 @@
+---
+layout: sdk_reference_page
+title: MidiBytestreamToUmpMessageConverterState
+namespace: Windows.Devices.Midi2.Utilities.Messages
+type: runtimeclass
+description: Holds conversion state used when converting a stream of MIDI 1.0 bytes into UMP words
+---
+
+This class holds the state required when converting a continuous stream of MIDI 1.0 bytestream data into Universal MIDI Packet (UMP) words across multiple calls. Because MIDI 1.0 bytestream data can span message boundaries, and can use features like running status, the converter needs a place to keep track of what it has seen so far.
+
+Create an instance of this class and pass it to the `MidiMessageConverter.ConvertMidi1CompleteMessageBytesToUmpWords` overload which accepts a converter state. Reuse the same state instance across calls for a given stream so that partial messages and running status are handled correctly.
+
+## Constructors
+
+| Constructor | Description |
+| --------------- | ----------- |
+| `MidiBytestreamToUmpMessageConverterState ()` | Creates a new, empty converter state instance. |
+
+## Properties
+
+| Property | Description |
+| --------------- | ----------- |
+| `Tag` | An optional application-defined string you may use to identify or annotate this state instance (for example, the source endpoint or group it is tracking). |

--- a/docs/sdk-reference/Utilities/Messages/MidiMessageConverter.md
+++ b/docs/sdk-reference/Utilities/Messages/MidiMessageConverter.md
@@ -48,5 +48,6 @@ This class provides support for representing MIDI 1.0 messages in the Universal 
 | ------------- | ----------- |
 | `ConvertMidi1MessageToUmpWords(group, originalMessage)` | Converts a WinRT `IMidiMessage` to a list of UMP words for the given group. |
 | `ConvertMidi1CompleteMessageBytesToUmpWords(group, midi1Bytes, allowRunningStatus)` | Converts a sequence of raw MIDI 1.0 bytes to UMP words. Set `allowRunningStatus` to `true` to handle running status encoding. |
+| `ConvertMidi1CompleteMessageBytesToUmpWords(group, midi1Bytes, allowRunningStatus, converterState)` | Converts a sequence of raw MIDI 1.0 bytes to UMP words, using the supplied [`MidiBytestreamToUmpMessageConverterState`](MidiBytestreamToUmpMessageConverterState.md) to preserve conversion state (partial messages, running status) across calls for a continuous stream. |
 | `ConvertSingleGroupCompleteMessageUmpWordsToMidi1Bytes(umpWords)` | Converts a sequence of UMP words (all from one group) back to MIDI 1.0 bytes. |
 | `ConvertHexByteStringToByteArray(hexByteString)` | Converts a space-separated or plain hex byte string (e.g., `"F0 41 10 F7"`) to a byte array. Useful for parsing SysEx strings from user input. |


### PR DESCRIPTION
Improve guidance across WinMM migration and endpoint connection docs with explicit threading/performance tips (avoid UI-thread MIDI work, process callbacks quickly, and queue long-running work). 

Add SDK reference documentation for `MidiBytestreamToUmpMessageConverterState` and document the new `MidiMessageConverter` overload that preserves bytestream conversion state across calls. 

Also streamline `MidiEndpointConnection` by removing the large inline sample and linking to full examples.