### PR TITLE
Fix Montage connection issue, further improve midisrv startup/enumeration performance, fix some KSA bugs

### DIFF
--- a/diagnostics/trace-logging/MidiServices.wprp
+++ b/diagnostics/trace-logging/MidiServices.wprp
@@ -1,8 +1,27 @@
 <?xml version="1.0" encoding="utf-8"?>
 <WindowsPerformanceRecorder Version="1.0" Author="Microsoft Corporation" Copyright="Microsoft Corporation" Company="Microsoft Corporation">
   <Profiles>
+  <!--
+    <SystemCollector Id="SystemCollector" Name="System Collector">
+      <BufferSize Value="256" />
+      <Buffers Value="3" PercentageOfTotalMemory="true" MaximumBufferSpace="256" />
+    </SystemCollector>
+
+    <SystemProvider Id="SystemProvider">
+      <Keywords>
+        <Keyword Value="Drivers" />
+        <Keyword Value="Registry" />
+      </Keywords>
+    </SystemProvider>
+    -->
 
     <EventCollector Id="EventCollector_MidiSrvSimple" Name="Windows MIDI Services Events">
+      <BufferSize Value="256" />
+      <Buffers Value="64" />
+    </EventCollector>
+
+    <!-- Kernel-mode providers cannot log into paged-memory buffers, so they get their own session. -->
+    <EventCollector Id="EventCollector_MidiSrvKernel" Name="Windows MIDI Services Kernel Events">
       <BufferSize Value="256" />
       <Buffers Value="64" />
     </EventCollector>
@@ -23,8 +42,7 @@
     <EventProvider Id="EventProvider_BasicLoopbackMidiTransport" Name="*Microsoft.Windows.Midi2.BasicLoopbackMidiTransport"/>
     <EventProvider Id="EventProvider_WdmAud2" Name="*Microsoft.Windows.Midi2.WdmAud2" />
     <EventProvider Id="EventProvider_SDK" Name="*Microsoft.Windows.Midi2.Sdk"/>
-    <EventProvider Id="EventProvider_SDKInitialization" Name="*Microsoft.Windows.Midi2.MidiClientInitializer"/>
-
+    
     <EventProvider Id="EventProvider_BS2UMPTransform" Name="*Microsoft.Windows.Midi2.BS2UMPTransform"/>
     <EventProvider Id="EventProvider_EndpointMetadataListenerTransform" Name="*Microsoft.Windows.Midi2.EndpointMetadataListenerTransform"/>
     <EventProvider Id="EventProvider_JitterReductionGeneratorTransform" Name="*Microsoft.Windows.Midi2.JitterReductionGeneratorTransform"/>
@@ -35,9 +53,38 @@
     <EventProvider Id="EventProvider_SettingsApp" Name="*Microsoft.Midi.Settings"/>
     <EventProvider Id="EventProvider_ConsoleApp" Name="*Microsoft.Midi.Console"/>
 
+    <!-- Microsoft-Windows-Kernel-PnP -->
+    <EventProvider Id="EventProvider_KernelPnP" Name="9C205A39-1250-487D-ABD7-E831C6290539" NonPagedMemory="true" Level="5" />
+
+    <!-- Microsoft-Windows-Kernel-PnP-Rundown. Only emits during a capture state (rundown). -->
+    <EventProvider Id="EventProvider_KernelPnPRundown" Name="B3A0C2C8-83BB-4DDF-9F8D-4B22D3C38AD7" NonPagedMemory="true" Level="5" CaptureStateOnly="true">
+      <CaptureStateOnStart>
+        <Keyword Value="0xFFFFFFFFFFFFFFFF" />
+      </CaptureStateOnStart>
+      <CaptureStateOnSave>
+        <Keyword Value="0xFFFFFFFFFFFFFFFF" />
+      </CaptureStateOnSave>
+    </EventProvider>
+
+    <!-- Microsoft-Windows-UserPnp -->
+    <EventProvider Id="EventProvider_UserPnP" Name="96F4A050-7E31-453C-88BE-9634F4E02139" Level="5" />
+
+    <!-- Microsoft-Windows-DriverFrameworks-UserMode -->
+    <EventProvider Id="EventProvider_UmdfDriverFrameworks" Name="2E35AAEB-857F-4BEB-A418-2E6C0E54D988" Level="5" />
+
+    <!-- USB stack. Kernel-mode, so these belong in the non-paged collector. -->
+    <EventProvider Id="EventProvider_UsbHub3" Name="AC52AD17-CC01-4F85-8DF5-4DCE4333C99B" NonPagedMemory="true" Level="5" />
+    <EventProvider Id="EventProvider_UsbUcx" Name="36DA592D-E43A-4E28-AF6F-4BC57C5A11E8" NonPagedMemory="true" Level="5" />
+    <EventProvider Id="EventProvider_UsbXhci" Name="30E1D284-5D88-459C-83FD-6345B39B19EC" NonPagedMemory="true" Level="5" />
+
      <Profile Id="MidiSrv.Verbose.File" Name="MidiSrv" DetailLevel="Verbose" Description="Windows MIDI Services trace profile" LoggingMode="File">
       <Collectors>
-    
+      <!--
+        <SystemCollectorId Value="SystemCollector">
+          <SystemProviderId Value="SystemProvider" />
+        </SystemCollectorId>   
+      -->
+
         <EventCollectorId Value="EventCollector_MidiSrvSimple">
           <EventProviders>
             <EventProviderId Value="EventProvider_MidiSrv"/>
@@ -56,8 +103,7 @@
             <EventProviderId Value="EventProvider_WdmAud2"/>
 
             <EventProviderId Value="EventProvider_SDK"/>
-            <EventProviderId Value="EventProvider_SDKInitialization"/>
-
+            
             <EventProviderId Value="EventProvider_BS2UMPTransform"/>
             <EventProviderId Value="EventProvider_EndpointMetadataListenerTransform"/>
             <EventProviderId Value="EventProvider_JitterReductionGeneratorTransform"/>
@@ -68,6 +114,19 @@
             <EventProviderId Value="EventProvider_SettingsApp"/>
             <EventProviderId Value="EventProvider_ConsoleApp"/>
 
+            <EventProviderId Value="EventProvider_UserPnP"/>
+            <EventProviderId Value="EventProvider_UmdfDriverFrameworks"/>
+
+          </EventProviders>
+        </EventCollectorId>
+
+        <EventCollectorId Value="EventCollector_MidiSrvKernel">
+          <EventProviders>
+            <EventProviderId Value="EventProvider_KernelPnP"/>
+            <EventProviderId Value="EventProvider_KernelPnPRundown"/>
+            <EventProviderId Value="EventProvider_UsbHub3"/>
+            <EventProviderId Value="EventProvider_UsbUcx"/>
+            <EventProviderId Value="EventProvider_UsbXhci"/>
           </EventProviders>
         </EventCollectorId>
       </Collectors>

--- a/src/api/Inc/Feature_Servicing_MIDI2KSAWatcherHardening.h
+++ b/src/api/Inc/Feature_Servicing_MIDI2KSAWatcherHardening.h
@@ -1,0 +1,18 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License
+// ============================================================================
+// This is part of the Windows MIDI Services App API and should be used
+// in your Windows application via an official binary distribution.
+// Further information: https://aka.ms/midi
+// ============================================================================
+
+#pragma once
+
+class Feature_Servicing_MIDI2KSAWatcherHardening
+{
+public:
+    static bool IsEnabled()
+    {
+        return true;
+    }
+};

--- a/src/api/Inc/Feature_Servicing_MIDI2PortNumberCache.h
+++ b/src/api/Inc/Feature_Servicing_MIDI2PortNumberCache.h
@@ -1,0 +1,18 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License
+// ============================================================================
+// This is part of the Windows MIDI Services App API and should be used
+// in your Windows application via an official binary distribution.
+// Further information: https://aka.ms/midi
+// ============================================================================
+
+#pragma once
+
+class Feature_Servicing_MIDI2PortNumberCache
+{
+public:
+    static bool IsEnabled()
+    {
+        return true;
+    }
+};

--- a/src/api/Service/Exe/MidiDeviceManager.cpp
+++ b/src/api/Service/Exe/MidiDeviceManager.cpp
@@ -20,6 +20,7 @@
 #include "Feature_Servicing_MIDI2NumDevsPerf.h"
 #include "Feature_Servicing_MIDI2LegacyControl.h"
 #include "Feature_Servicing_MIDI2SynchronizedStart.h"
+#include "Feature_Servicing_MIDI2PortNumberCache.h"
 
 using namespace winrt::Windows::Devices::Enumeration;
 
@@ -2211,7 +2212,88 @@ CMidiDeviceManager::CompactPortNumbers()
 
     }
 
+    if (Feature_Servicing_MIDI2PortNumberCache::IsEnabled())
+    {
+        // ports were just renumbered, so anything cached is stale
+        InvalidatePortNumberCache();
+    }
+
     return S_OK;
+}
+
+
+// Rebuilds the in-use port number map for one flow from the device tree.
+// Caller must hold m_portNumberCacheLock.
+_Use_decl_annotations_
+HRESULT
+CMidiDeviceManager::RefreshPortNumberCache(MidiFlow flow)
+{
+    auto const flowIndex = (flow == MidiFlowOut) ? 0 : 1;
+
+    m_assignedPortNumbers[flowIndex].clear();
+    m_portNumberCacheValid[flowIndex] = false;
+
+    winrt::hstring deviceSelector(flow == MidiFlowOut ? MIDI1_OUTPUT_DEVICES : MIDI1_INPUT_DEVICES);
+    deviceSelector = deviceSelector + L" AND System.Devices.InterfaceEnabled:=System.StructuredQueryType.Boolean#True";
+
+    auto additionalProperties = winrt::single_threaded_vector<winrt::hstring>();
+    additionalProperties.Append(STRING_PKEY_MIDI_ServiceAssignedPortNumber);
+
+    auto deviceList = DeviceInformation::FindAllAsync(deviceSelector, additionalProperties).get();
+
+    for (auto const& device : deviceList)
+    {
+        std::wstring id = internal::NormalizeEndpointInterfaceIdWStringCopy(device.Id().c_str());
+
+        // ignore WinRT MIDI 1.0 BLE because WinMM doesn't support them
+        if (id.find(L".ble10#") != std::wstring::npos)
+        {
+            continue;
+        }
+
+        // ignore the GS synth
+        if (id.find(L"#microsoftgswavetablesynth#") != std::wstring::npos)
+        {
+            continue;
+        }
+
+        auto servicePortNum = internal::SafeGetSwdPropertyFromDeviceInformation<UINT32>(STRING_PKEY_MIDI_ServiceAssignedPortNumber, device, 0);
+
+        if (servicePortNum == 0)
+        {
+            continue;
+        }
+
+        m_assignedPortNumbers[flowIndex][servicePortNum] = id;
+    }
+
+    m_portNumberCacheValid[flowIndex] = true;
+
+    TraceLoggingWrite(
+        MidiSrvTelemetryProvider::Provider(),
+        MIDI_TRACE_EVENT_INFO,
+        TraceLoggingString(__FUNCTION__, MIDI_TRACE_EVENT_LOCATION_FIELD),
+        TraceLoggingLevel(WINEVENT_LEVEL_INFO),
+        TraceLoggingPointer(this, "this"),
+        TraceLoggingWideString(L"Port number cache rebuilt", MIDI_TRACE_EVENT_MESSAGE_FIELD),
+        TraceLoggingUInt32(static_cast<uint32_t>(flow), "flow"),
+        TraceLoggingUInt32(static_cast<uint32_t>(m_assignedPortNumbers[flowIndex].size()), "ports in use")
+    );
+
+    return S_OK;
+}
+
+
+void
+CMidiDeviceManager::InvalidatePortNumberCache()
+{
+    auto lock = m_portNumberCacheLock.lock();
+
+    m_portNumberCacheValid[0] = false;
+    m_portNumberCacheValid[1] = false;
+
+    m_assignedPortNumbers[0].clear();
+    m_assignedPortNumbers[1].clear();
 }
 
 
@@ -2237,62 +2319,98 @@ CMidiDeviceManager::AssignPortNumber(
 
     auto thisDeviceInterfaceId = internal::NormalizeEndpointInterfaceIdWStringCopy(deviceInterfaceId);
 
-    std::map<UINT32, winrt::hstring> ports;
+    UINT32 assignedPortNumber{ 0 };
 
-    // for this version, we only check active devices. We're not trying to preserve or reserve numbers
-    winrt::hstring deviceSelector(flow == MidiFlowOut ? MIDI1_OUTPUT_DEVICES : MIDI1_INPUT_DEVICES);
-    deviceSelector = deviceSelector + L" AND System.Devices.InterfaceEnabled:=System.StructuredQueryType.Boolean#True";
-
-    auto additionalProperties = winrt::single_threaded_vector<winrt::hstring>();
-    additionalProperties.Append(STRING_PKEY_MIDI_ServiceAssignedPortNumber);
-
-    auto deviceList = DeviceInformation::FindAllAsync(deviceSelector, additionalProperties).get();
-
-    // because we compact the numbers on device removal, the first available port number is the device count including us
-    // however, we need to exclude devices which are handled specially, like the GS Synth, and also any devices which 
-    // are WinRT-only, like BLE MIDI 1.0 devices. Those mess up the count.
-
-    // store all the existing port numbers
-    for (auto const& device : deviceList)
+    if (Feature_Servicing_MIDI2PortNumberCache::IsEnabled())
     {
-        std::wstring id = internal::NormalizeEndpointInterfaceIdWStringCopy(device.Id().c_str());
+        auto cacheLock = m_portNumberCacheLock.lock();
 
-        // ignore WinRT MIDI 1.0 BLE because WinMM doesn't support them
-        if (id.find(L".ble10#") != std::wstring::npos)
+        auto const flowIndex = (flow == MidiFlowOut) ? 0 : 1;
+
+        if (!m_portNumberCacheValid[flowIndex])
         {
-            continue;
+            RETURN_IF_FAILED(RefreshPortNumberCache(flow));
         }
 
-        // ignore the GS synth
-        if (id.find(L"#microsoftgswavetablesynth#") != std::wstring::npos)
+        auto& ports = m_assignedPortNumbers[flowIndex];
+
+        // we may already be in the map from a previous assignment, so don't count ourselves
+        for (auto it = ports.begin(); it != ports.end(); ++it)
         {
-            continue;
+            if (it->second == thisDeviceInterfaceId)
+            {
+                ports.erase(it);
+                break;
+            }
         }
 
-        // ensure we're not looking at ourselves
-        if (id == thisDeviceInterfaceId)
-        {
-            continue;
-        }
+        UINT32 firstAvailablePortNumber{ 1 };
+        for (firstAvailablePortNumber = 1; ports.find(firstAvailablePortNumber) != ports.end(); firstAvailablePortNumber++);
 
-        // get the ServiceAssignedPortNumber
-        auto servicePortNum = internal::SafeGetSwdPropertyFromDeviceInformation<UINT32>(STRING_PKEY_MIDI_ServiceAssignedPortNumber, device, 0);
+        assignedPortNumber = firstAvailablePortNumber;
 
-        // missing for some reason. We skip it
-        if (servicePortNum == 0) 
-        {
-            continue;
-        }
-
-        ports[servicePortNum] = device.Id();
+        // record it now so the next port in this burst sees it without re-enumerating
+        ports[assignedPortNumber] = thisDeviceInterfaceId;
     }
+    else
+    {
+        std::map<UINT32, winrt::hstring> ports;
 
-    UINT32 firstAvailablePortNumber{ 1 };
+        // for this version, we only check active devices. We're not trying to preserve or reserve numbers
+        winrt::hstring deviceSelector(flow == MidiFlowOut ? MIDI1_OUTPUT_DEVICES : MIDI1_INPUT_DEVICES);
+        deviceSelector = deviceSelector + L" AND System.Devices.InterfaceEnabled:=System.StructuredQueryType.Boolean#True";
 
-    // now find the first available port number
-    for (firstAvailablePortNumber = 1; ports.find(firstAvailablePortNumber) != ports.end(); firstAvailablePortNumber++);
+        auto additionalProperties = winrt::single_threaded_vector<winrt::hstring>();
+        additionalProperties.Append(STRING_PKEY_MIDI_ServiceAssignedPortNumber);
 
-    UINT32 assignedPortNumber = firstAvailablePortNumber;
+        auto deviceList = DeviceInformation::FindAllAsync(deviceSelector, additionalProperties).get();
+
+        // because we compact the numbers on device removal, the first available port number is the device count including us
+        // however, we need to exclude devices which are handled specially, like the GS Synth, and also any devices which 
+        // are WinRT-only, like BLE MIDI 1.0 devices. Those mess up the count.
+
+        // store all the existing port numbers
+        for (auto const& device : deviceList)
+        {
+            std::wstring id = internal::NormalizeEndpointInterfaceIdWStringCopy(device.Id().c_str());
+
+            // ignore WinRT MIDI 1.0 BLE because WinMM doesn't support them
+            if (id.find(L".ble10#") != std::wstring::npos)
+            {
+                continue;
+            }
+
+            // ignore the GS synth
+            if (id.find(L"#microsoftgswavetablesynth#") != std::wstring::npos)
+            {
+                continue;
+            }
+
+            // ensure we're not looking at ourselves
+            if (id == thisDeviceInterfaceId)
+            {
+                continue;
+            }
+
+            // get the ServiceAssignedPortNumber
+            auto servicePortNum = internal::SafeGetSwdPropertyFromDeviceInformation<UINT32>(STRING_PKEY_MIDI_ServiceAssignedPortNumber, device, 0);
+
+            // missing for some reason. We skip it
+            if (servicePortNum == 0) 
+            {
+                continue;
+            }
+
+            ports[servicePortNum] = device.Id();
+        }
+
+        UINT32 firstAvailablePortNumber{ 1 };
+
+        // now find the first available port number
+        for (firstAvailablePortNumber = 1; ports.find(firstAvailablePortNumber) != ports.end(); firstAvailablePortNumber++);
+
+        assignedPortNumber = firstAvailablePortNumber;
+    }
 
     // set the new port number
     std::vector<DEVPROPERTY> newProperties{};

--- a/src/api/Service/Exe/MidiDeviceManager.cpp
+++ b/src/api/Service/Exe/MidiDeviceManager.cpp
@@ -2417,6 +2417,18 @@ CMidiDeviceManager::AssignPortNumber(
     newProperties.push_back(DEVPROPERTY{ {PKEY_MIDI_ServiceAssignedPortNumber, DEVPROP_STORE_SYSTEM, nullptr},
                         DEVPROP_TYPE_UINT32, (ULONG)(sizeof(UINT32)), (PVOID)(&(assignedPortNumber)) });
 
+    TraceLoggingWrite(
+        MidiSrvTelemetryProvider::Provider(),
+        MIDI_TRACE_EVENT_INFO,
+        TraceLoggingString(__FUNCTION__, MIDI_TRACE_EVENT_LOCATION_FIELD),
+        TraceLoggingLevel(WINEVENT_LEVEL_INFO),
+        TraceLoggingPointer(this, "this"),
+        TraceLoggingWideString(L"Port number assigned", MIDI_TRACE_EVENT_MESSAGE_FIELD),
+        TraceLoggingWideString(deviceInterfaceId, MIDI_TRACE_EVENT_DEVICE_SWD_ID_FIELD),
+        TraceLoggingUInt32(static_cast<uint32_t>(flow), "flow"),
+        TraceLoggingUInt32(assignedPortNumber, "assigned port number")
+    );
+
     RETURN_IF_FAILED(SwDeviceInterfacePropertySet(
         SwDevice,
         deviceInterfaceId,

--- a/src/api/Service/Inc/MidiDeviceManager.h
+++ b/src/api/Service/Inc/MidiDeviceManager.h
@@ -184,6 +184,9 @@ private:
         _In_ MidiFlow
     );
 
+    HRESULT RefreshPortNumberCache(_In_ MidiFlow flow);
+    void InvalidatePortNumberCache();
+
     HRESULT GetFunctionBlockPortInfo(
         _In_ LPCWSTR umpDeviceInterfaceId,
         _In_ winrt::Windows::Devices::Enumeration::DeviceInformation deviceInfo,
@@ -240,6 +243,13 @@ private:
     wil::critical_section m_midiPortsLock;
     std::vector<std::unique_ptr<MIDIPORT>> m_midiPorts;
     bool m_CreateMidi1Ports {true};
+
+    // Port numbers in use, indexed by MidiFlow. midisrv is the only assigner of
+    // PKEY_MIDI_ServiceAssignedPortNumber, so this can stand in for re-enumerating
+    // every MIDI 1 device on every assignment.
+    wil::critical_section m_portNumberCacheLock;
+    std::map<UINT32, std::wstring> m_assignedPortNumbers[2];
+    bool m_portNumberCacheValid[2] { false, false };
 
     std::vector<std::unique_ptr<MIDIPARENTDEVICE>> m_midiParents;
 

--- a/src/api/Transport/KSAggregateTransport/Midi2.KSAggregateMidiConfigurationManager.cpp
+++ b/src/api/Transport/KSAggregateTransport/Midi2.KSAggregateMidiConfigurationManager.cpp
@@ -259,10 +259,10 @@ CMidi2KSAggregateMidiConfigurationManager::UpdateConfiguration(
                 // Resolve the EndpointDeviceId in case we matched on something else
                 winrt::hstring matchingEndpointDeviceId{};
 
-                auto em = TransportState::Current().GetEndpointManager2();
+                auto em = TransportState::Current().GetActiveEndpointManager();
                 if (em != nullptr)
                 {
-                    matchingEndpointDeviceId = em->FindMatchingInstantiatedEndpoint(*matchCriteria);
+                    matchingEndpointDeviceId = TransportState::Current().FindMatchingInstantiatedEndpoint(*matchCriteria);
                 }
 
                 // process all the custom props like Name, Description, Image, etc.

--- a/src/api/Transport/KSAggregateTransport/Midi2.KSAggregateMidiEndpointManager3.cpp
+++ b/src/api/Transport/KSAggregateTransport/Midi2.KSAggregateMidiEndpointManager3.cpp
@@ -25,10 +25,34 @@ using namespace winrt::Windows::Foundation::Collections;
 using namespace Microsoft::WRL;
 using namespace Microsoft::WRL::Wrappers;
 
+namespace
+{
+    // DeviceWatcherStatus as a loggable value. 0xFFFFFFFF means the watcher itself is null.
+    uint32_t GetWatcherStatusValue(_In_ DeviceWatcher const& watcher) noexcept
+    {
+        try
+        {
+            return watcher ? static_cast<uint32_t>(watcher.Status()) : 0xFFFFFFFF;
+        }
+        catch (...)
+        {
+            return 0xFFFFFFFE;
+        }
+    }
+
+    uint32_t ElapsedMillisecondsSince(_In_ uint64_t const startTicks) noexcept
+    {
+        auto const frequency = internal::GetMidiTimestampFrequency();
+        if (frequency == 0) return 0;
+
+        return static_cast<uint32_t>(((internal::GetCurrentMidiTimestamp() - startTicks) * MILLISECONDS_PER_SECOND) / frequency);
+    }
+}
+
 #define INITIAL_ENUMERATION_TIMEOUT_MS 40000        // on my PC, with 70+ inputs and outputs this can take 30 seconds. 
 _Use_decl_annotations_
 HRESULT
-CMidi2KSAggregateMidiEndpointManager2::Initialize(
+CMidi2KSAggregateMidiEndpointManager3::Initialize(
     IMidiDeviceManager* midiDeviceManager,
     IMidiEndpointProtocolManager* midiEndpointProtocolManager
 )
@@ -73,58 +97,36 @@ CMidi2KSAggregateMidiEndpointManager2::Initialize(
         );
 
 
-    // the ksa2603 fix enumerates device interfaces instead of parent devices
-    if (Feature_Servicing_MIDI2FailFast::IsEnabled())
-    {
-        winrt::hstring deviceInterfaceSelector(
-            L"System.Devices.InterfaceClassGuid:=\"{6994AD04-93EF-11D0-A3CC-00A0C9223196}\" AND " \
-            L"System.Devices.InterfaceEnabled:=System.StructuredQueryType.Boolean#True");
-
-        try
-        {
-            m_watcher = DeviceInformation::CreateWatcher(deviceInterfaceSelector);
-        }
-        CATCH_RETURN();
-    }
-    else
-    {
-        winrt::hstring deviceInterfaceSelector(
-            L"System.Devices.InterfaceClassGuid:=\"{6994AD04-93EF-11D0-A3CC-00A0C9223196}\" AND " \
-            L"System.Devices.InterfaceEnabled: = System.StructuredQueryType.Boolean#True");
-
-        auto additionalProps = winrt::single_threaded_vector<winrt::hstring>();
-        additionalProps.Append(L"System.Devices.Parent");
-
-        m_watcher = DeviceInformation::CreateWatcher(deviceInterfaceSelector);
-    }
-
-    auto deviceAddedHandler = TypedEventHandler<DeviceWatcher, DeviceInformation>(this, &CMidi2KSAggregateMidiEndpointManager2::OnFilterDeviceInterfaceAdded);
-    auto deviceRemovedHandler = TypedEventHandler<DeviceWatcher, DeviceInformationUpdate>(this, &CMidi2KSAggregateMidiEndpointManager2::OnFilterDeviceInterfaceRemoved);
-    auto deviceUpdatedHandler = TypedEventHandler<DeviceWatcher, DeviceInformationUpdate>(this, &CMidi2KSAggregateMidiEndpointManager2::OnFilterDeviceInterfaceUpdated);
-
-    auto deviceStoppedHandler = TypedEventHandler<DeviceWatcher, winrt::Windows::Foundation::IInspectable>(this, &CMidi2KSAggregateMidiEndpointManager2::OnDeviceWatcherStopped);
-    auto deviceEnumerationCompletedHandler = TypedEventHandler<DeviceWatcher, winrt::Windows::Foundation::IInspectable>(this, &CMidi2KSAggregateMidiEndpointManager2::OnEnumerationCompleted);
-
-    m_DeviceAdded = m_watcher.Added(winrt::auto_revoke, deviceAddedHandler);
-    m_DeviceRemoved = m_watcher.Removed(winrt::auto_revoke, deviceRemovedHandler);
-    m_DeviceUpdated = m_watcher.Updated(winrt::auto_revoke, deviceUpdatedHandler);
-    m_DeviceStopped = m_watcher.Stopped(winrt::auto_revoke, deviceStoppedHandler);
-    m_DeviceEnumerationCompleted = m_watcher.EnumerationCompleted(winrt::auto_revoke, deviceEnumerationCompletedHandler);
-
-
+    // events must exist before the worker thread starts, and the worker must be running
+    // before the watcher starts delivering into the change queue
     m_initialEndpointCreationCompleted.create(wil::EventOptions::ManualReset);
     m_EnumerationCompleted.create(wil::EventOptions::ManualReset);
     m_endpointCreationThreadWakeup.create(wil::EventOptions::ManualReset);
+    m_interfaceChangeQueued.create(wil::EventOptions::ManualReset);
+    m_watcherStopped.create(wil::EventOptions::ManualReset);
 
     // worker thread to handle endpoint creation, since we're enumerating interfaces now and need to aggregate them
-    std::jthread endpointCreationWorkerThread(std::bind_front(&CMidi2KSAggregateMidiEndpointManager2::EndpointCreationThreadWorker, this));
+    std::jthread endpointCreationWorkerThread(std::bind_front(&CMidi2KSAggregateMidiEndpointManager3::EndpointCreationThreadWorker, this));
     m_endpointCreationThread = std::move(endpointCreationWorkerThread);
 
-    m_watcher.Start();
+    RETURN_IF_FAILED(CreateAndStartWatcher());
 
     // Wait for everything to be created so that they're available immediately after service start.
-    m_EnumerationCompleted.wait(INITIAL_ENUMERATION_TIMEOUT_MS);
-    m_initialEndpointCreationCompleted.wait(INITIAL_ENUMERATION_TIMEOUT_MS);
+    bool const enumerationSignaled = m_EnumerationCompleted.wait(INITIAL_ENUMERATION_TIMEOUT_MS);
+    bool const endpointCreationSignaled = m_initialEndpointCreationCompleted.wait(INITIAL_ENUMERATION_TIMEOUT_MS);
+
+    TraceLoggingWrite(
+        MidiKSAggregateTransportTelemetryProvider::Provider(),
+        MIDI_TRACE_EVENT_INFO,
+        TraceLoggingString(__FUNCTION__, MIDI_TRACE_EVENT_LOCATION_FIELD),
+        TraceLoggingLevel(WINEVENT_LEVEL_INFO),
+        TraceLoggingPointer(this, "this"),
+        TraceLoggingWideString(L"Initial enumeration waits completed", MIDI_TRACE_EVENT_MESSAGE_FIELD),
+        TraceLoggingBool(enumerationSignaled, "enumeration signaled"),
+        TraceLoggingBool(endpointCreationSignaled, "endpoint creation signaled"),
+        TraceLoggingBool(m_watcherStopped.is_signaled(), "watcher stopped"),
+        TraceLoggingUInt32(GetWatcherStatusValue(m_watcher), "watcher status")
+    );
 
     if (!m_pendingEndpointDefinitions.empty())
     {
@@ -148,13 +150,13 @@ typedef struct {
     UINT32 PinId;           // KS Pin number
     MidiFlow PinDataFlow;   // an input pin is MidiFlowIn, and from the user's perspective, a MIDI Output
     std::wstring FilterId;  // full filter id for this pin
-} PinMapEntryStagingEntry2;
+} PinMapEntryStagingEntry3;
 
 
 _Use_decl_annotations_
 HRESULT
-CMidi2KSAggregateMidiEndpointManager2::UpdateNameTableWithCustomProperties(
-    std::shared_ptr<KsAggregateEndpointDefinition2> masterEndpointDefinition,
+CMidi2KSAggregateMidiEndpointManager3::UpdateNameTableWithCustomProperties(
+    std::shared_ptr<KsAggregateEndpointDefinition3> masterEndpointDefinition,
     std::shared_ptr<WindowsMidiServicesPluginConfigurationLib::MidiEndpointCustomProperties> customProperties)
 {
     RETURN_HR_IF_NULL(E_INVALIDARG, masterEndpointDefinition);
@@ -212,15 +214,15 @@ CMidi2KSAggregateMidiEndpointManager2::UpdateNameTableWithCustomProperties(
 
 _Use_decl_annotations_
 HRESULT
-CMidi2KSAggregateMidiEndpointManager2::BuildPinsAndGroupTerminalBlocksPropertyData(
-    std::shared_ptr<KsAggregateEndpointDefinition2> masterEndpointDefinition,
+CMidi2KSAggregateMidiEndpointManager3::BuildPinsAndGroupTerminalBlocksPropertyData(
+    std::shared_ptr<KsAggregateEndpointDefinition3> masterEndpointDefinition,
     std::vector<std::byte>& pinMapPropertyData,
     std::vector<internal::GroupTerminalBlockInternal>& groupTerminalBlocks)
 {
     RETURN_HR_IF_NULL(E_INVALIDARG, masterEndpointDefinition);
 
     uint8_t currentBlockNumber{ 0 };
-    std::vector<PinMapEntryStagingEntry2> pinMapEntries{ };
+    std::vector<PinMapEntryStagingEntry3> pinMapEntries{ };
 
     for (auto const& pin : masterEndpointDefinition->GetAllPins())
     {
@@ -231,7 +233,7 @@ CMidi2KSAggregateMidiEndpointManager2::BuildPinsAndGroupTerminalBlocksPropertyDa
         gtb.Number = ++currentBlockNumber;
         gtb.GroupCount = 1; // always a single group for aggregate MIDI 1.0 devices
 
-        PinMapEntryStagingEntry2 pinMapEntry{ };
+        PinMapEntryStagingEntry3 pinMapEntry{ };
 
         pinMapEntry.PinId = pin->PinNumber;
         pinMapEntry.FilterId = pin->FilterDeviceId;
@@ -369,13 +371,13 @@ CMidi2KSAggregateMidiEndpointManager2::BuildPinsAndGroupTerminalBlocksPropertyDa
 
 _Use_decl_annotations_
 HRESULT
-CMidi2KSAggregateMidiEndpointManager2::DeviceCreateMidiUmpEndpoint(
-    std::shared_ptr<KsAggregateEndpointDefinition2> endpointDefinition    
+CMidi2KSAggregateMidiEndpointManager3::DeviceCreateMidiUmpEndpoint(
+    std::shared_ptr<KsAggregateEndpointDefinition3> endpointDefinition    
 )
 {
     RETURN_HR_IF_NULL(E_INVALIDARG, endpointDefinition);
 
-    std::shared_ptr<KsAggregateParentDeviceDefinition2> parentDevice { nullptr };
+    std::shared_ptr<KsAggregateParentDeviceDefinition3> parentDevice { nullptr };
     RETURN_IF_FAILED(FindExistingParentDeviceDefinitionForEndpoint(endpointDefinition, parentDevice));
     RETURN_HR_IF_NULL(E_UNEXPECTED, parentDevice);
 
@@ -658,13 +660,13 @@ CMidi2KSAggregateMidiEndpointManager2::DeviceCreateMidiUmpEndpoint(
 
 _Use_decl_annotations_
 HRESULT
-CMidi2KSAggregateMidiEndpointManager2::DeviceUpdateExistingMidiUmpEndpointWithFilterChanges(
-    std::shared_ptr<KsAggregateEndpointDefinition2> endpointDefinition
+CMidi2KSAggregateMidiEndpointManager3::DeviceUpdateExistingMidiUmpEndpointWithFilterChanges(
+    std::shared_ptr<KsAggregateEndpointDefinition3> endpointDefinition
 )
 {
     RETURN_HR_IF_NULL(E_INVALIDARG, endpointDefinition);
 
-    std::shared_ptr<KsAggregateParentDeviceDefinition2> parentDevice{ nullptr };
+    std::shared_ptr<KsAggregateParentDeviceDefinition3> parentDevice{ nullptr };
     RETURN_IF_FAILED(FindExistingParentDeviceDefinitionForEndpoint(endpointDefinition, parentDevice));
     RETURN_HR_IF_NULL(E_UNEXPECTED, parentDevice);
 
@@ -873,7 +875,7 @@ CMidi2KSAggregateMidiEndpointManager2::DeviceUpdateExistingMidiUmpEndpointWithFi
 
 _Use_decl_annotations_
 HRESULT
-CMidi2KSAggregateMidiEndpointManager2::GetPinName(HANDLE const hFilter, UINT const pinIndex, std::wstring& pinName)
+CMidi2KSAggregateMidiEndpointManager3::GetPinName(HANDLE const hFilter, UINT const pinIndex, std::wstring& pinName)
 {
     std::unique_ptr<WCHAR> pinNameData;
     ULONG pinNameDataSize{ 0 };
@@ -903,7 +905,7 @@ CMidi2KSAggregateMidiEndpointManager2::GetPinName(HANDLE const hFilter, UINT con
 
 _Use_decl_annotations_
 HRESULT
-CMidi2KSAggregateMidiEndpointManager2::GetPinDataFlow(_In_ HANDLE const hFilter, _In_ UINT const pinIndex, _Inout_ KSPIN_DATAFLOW& dataFlow)
+CMidi2KSAggregateMidiEndpointManager3::GetPinDataFlow(_In_ HANDLE const hFilter, _In_ UINT const pinIndex, _Inout_ KSPIN_DATAFLOW& dataFlow)
 {
     auto dataFlowHR = PinPropertySimple(
         hFilter,
@@ -925,7 +927,7 @@ CMidi2KSAggregateMidiEndpointManager2::GetPinDataFlow(_In_ HANDLE const hFilter,
 
 _Use_decl_annotations_
 HRESULT 
-CMidi2KSAggregateMidiEndpointManager2::GetKSDriverSuppliedName(HANDLE hInstantiatedFilter, std::wstring& name, KSCOMPONENTID &ksComponentId, DWORD& ksComponentIdSize)
+CMidi2KSAggregateMidiEndpointManager3::GetKSDriverSuppliedName(HANDLE hInstantiatedFilter, std::wstring& name, KSCOMPONENTID &ksComponentId, DWORD& ksComponentIdSize)
 {
     TraceLoggingWrite(
         MidiKSAggregateTransportTelemetryProvider::Provider(),
@@ -1023,9 +1025,9 @@ CMidi2KSAggregateMidiEndpointManager2::GetKSDriverSuppliedName(HANDLE hInstantia
 
 _Use_decl_annotations_
 HRESULT
-CMidi2KSAggregateMidiEndpointManager2::ParseParentIdIntoVidPidSerial(
+CMidi2KSAggregateMidiEndpointManager3::ParseParentIdIntoVidPidSerial(
     std::wstring systemDevicesParentValue, 
-    std::shared_ptr<KsAggregateParentDeviceDefinition2> parentDevice)
+    std::shared_ptr<KsAggregateParentDeviceDefinition3> parentDevice)
 {
     RETURN_HR_IF_NULL(E_INVALIDARG, parentDevice);
 
@@ -1121,9 +1123,9 @@ CMidi2KSAggregateMidiEndpointManager2::ParseParentIdIntoVidPidSerial(
 
 _Use_decl_annotations_
 HRESULT
-CMidi2KSAggregateMidiEndpointManager2::FindPendingEndpointDefinitionForParentDevice(
+CMidi2KSAggregateMidiEndpointManager3::FindPendingEndpointDefinitionForParentDevice(
     std::wstring parentDeviceInstanceId,
-    std::shared_ptr<KsAggregateEndpointDefinition2>& endpointDefinition)
+    std::shared_ptr<KsAggregateEndpointDefinition3>& endpointDefinition)
 {
     TraceLoggingWrite(
         MidiKSAggregateTransportTelemetryProvider::Provider(),
@@ -1174,9 +1176,9 @@ CMidi2KSAggregateMidiEndpointManager2::FindPendingEndpointDefinitionForParentDev
 
 _Use_decl_annotations_
 HRESULT
-CMidi2KSAggregateMidiEndpointManager2::FindActivatedEndpointDefinitionForFilterDevice(
+CMidi2KSAggregateMidiEndpointManager3::FindActivatedEndpointDefinitionForFilterDevice(
     std::wstring filterDeviceId,
-    std::shared_ptr<KsAggregateEndpointDefinition2>& endpointDefinition
+    std::shared_ptr<KsAggregateEndpointDefinition3>& endpointDefinition
 )
 {
     TraceLoggingWrite(
@@ -1195,18 +1197,18 @@ CMidi2KSAggregateMidiEndpointManager2::FindActivatedEndpointDefinitionForFilterD
     {
         for (auto const& pin: endpoint.second->GetAllPins())
         {
-            TraceLoggingWrite(
-                MidiKSAggregateTransportTelemetryProvider::Provider(),
-                MIDI_TRACE_EVENT_VERBOSE,
-                TraceLoggingString(__FUNCTION__, MIDI_TRACE_EVENT_LOCATION_FIELD),
-                TraceLoggingLevel(WINEVENT_LEVEL_INFO),
-                TraceLoggingPointer(this, "this"),
-                TraceLoggingWideString(L"Matching Endpoint found", MIDI_TRACE_EVENT_MESSAGE_FIELD),
-                TraceLoggingWideString(cleanFilterDeviceId.c_str(), "filter device id")
-            );
-
             if (internal::NormalizeEndpointInterfaceIdWStringCopy(pin->FilterDeviceId) == cleanFilterDeviceId)
             {
+                TraceLoggingWrite(
+                    MidiKSAggregateTransportTelemetryProvider::Provider(),
+                    MIDI_TRACE_EVENT_VERBOSE,
+                    TraceLoggingString(__FUNCTION__, MIDI_TRACE_EVENT_LOCATION_FIELD),
+                    TraceLoggingLevel(WINEVENT_LEVEL_INFO),
+                    TraceLoggingPointer(this, "this"),
+                    TraceLoggingWideString(L"Matching Endpoint found", MIDI_TRACE_EVENT_MESSAGE_FIELD),
+                    TraceLoggingWideString(cleanFilterDeviceId.c_str(), "filter device id")
+                );
+
                 endpointDefinition = endpoint.second;
                 return S_OK;
             }
@@ -1230,9 +1232,9 @@ CMidi2KSAggregateMidiEndpointManager2::FindActivatedEndpointDefinitionForFilterD
 
 _Use_decl_annotations_
 HRESULT
-CMidi2KSAggregateMidiEndpointManager2::FindAllActivatedEndpointDefinitionsForParentDevice(
+CMidi2KSAggregateMidiEndpointManager3::FindAllActivatedEndpointDefinitionsForParentDevice(
     std::wstring parentDeviceInstanceId,
-    std::vector<std::shared_ptr<KsAggregateEndpointDefinition2>>& endpointDefinitions
+    std::vector<std::shared_ptr<KsAggregateEndpointDefinition3>>& endpointDefinitions
 )
 {
     TraceLoggingWrite(
@@ -1292,9 +1294,9 @@ CMidi2KSAggregateMidiEndpointManager2::FindAllActivatedEndpointDefinitionsForPar
 
 _Use_decl_annotations_
 HRESULT
-CMidi2KSAggregateMidiEndpointManager2::FindAllPendingEndpointDefinitionsForParentDevice(
+CMidi2KSAggregateMidiEndpointManager3::FindAllPendingEndpointDefinitionsForParentDevice(
     std::wstring parentDeviceInstanceId,
-    std::vector<std::shared_ptr<KsAggregateEndpointDefinition2>>& endpointDefinitions
+    std::vector<std::shared_ptr<KsAggregateEndpointDefinition3>>& endpointDefinitions
 )
 {
     TraceLoggingWrite(
@@ -1356,9 +1358,9 @@ CMidi2KSAggregateMidiEndpointManager2::FindAllPendingEndpointDefinitionsForParen
 
 _Use_decl_annotations_
 HRESULT
-CMidi2KSAggregateMidiEndpointManager2::FindExistingParentDeviceDefinitionForEndpoint(
-    std::shared_ptr<KsAggregateEndpointDefinition2> endpointDefinition,
-    std::shared_ptr<KsAggregateParentDeviceDefinition2>& parentDeviceDefinition
+CMidi2KSAggregateMidiEndpointManager3::FindExistingParentDeviceDefinitionForEndpoint(
+    std::shared_ptr<KsAggregateEndpointDefinition3> endpointDefinition,
+    std::shared_ptr<KsAggregateParentDeviceDefinition3>& parentDeviceDefinition
 )
 {
     RETURN_HR_IF_NULL(E_INVALIDARG, endpointDefinition);
@@ -1408,9 +1410,9 @@ CMidi2KSAggregateMidiEndpointManager2::FindExistingParentDeviceDefinitionForEndp
 
 _Use_decl_annotations_
 HRESULT
-CMidi2KSAggregateMidiEndpointManager2::FindOrCreateParentDeviceDefinitionForFilterDevice(
+CMidi2KSAggregateMidiEndpointManager3::FindOrCreateParentDeviceDefinitionForFilterDevice(
     DeviceInformation filterDevice,
-    std::shared_ptr<KsAggregateParentDeviceDefinition2>& parentDeviceDefinition
+    std::shared_ptr<KsAggregateParentDeviceDefinition3>& parentDeviceDefinition
 )
 {
     TraceLoggingWrite(
@@ -1473,7 +1475,7 @@ CMidi2KSAggregateMidiEndpointManager2::FindOrCreateParentDeviceDefinitionForFilt
         TraceLoggingWideString(cleanParentDeviceInstanceId.c_str(), "parent")
     );
 
-    auto newParentDeviceDefinition = std::make_shared<KsAggregateParentDeviceDefinition2>();
+    auto newParentDeviceDefinition = std::make_shared<KsAggregateParentDeviceDefinition3>();
     RETURN_HR_IF_NULL(E_OUTOFMEMORY, newParentDeviceDefinition);
 
     newParentDeviceDefinition->DeviceName = parentDevice.Name();
@@ -1564,8 +1566,8 @@ CMidi2KSAggregateMidiEndpointManager2::FindOrCreateParentDeviceDefinitionForFilt
 
 _Use_decl_annotations_
 HRESULT 
-CMidi2KSAggregateMidiEndpointManager2::FindUnusedEndpointIndexForParentDevice(
-    std::shared_ptr<KsAggregateParentDeviceDefinition2> parentDeviceDefinition,
+CMidi2KSAggregateMidiEndpointManager3::FindUnusedEndpointIndexForParentDevice(
+    std::shared_ptr<KsAggregateParentDeviceDefinition3> parentDeviceDefinition,
     uint32_t& unusedIndex)
 {
     auto cleanParentDeviceInstanceId = internal::NormalizeDeviceInstanceIdWStringCopy(parentDeviceDefinition->DeviceInstanceId);
@@ -1620,9 +1622,9 @@ CMidi2KSAggregateMidiEndpointManager2::FindUnusedEndpointIndexForParentDevice(
 
 _Use_decl_annotations_
 HRESULT
-CMidi2KSAggregateMidiEndpointManager2::CreatePendingEndpointDefinitionForFilterDevice(
+CMidi2KSAggregateMidiEndpointManager3::CreatePendingEndpointDefinitionForFilterDevice(
     DeviceInformation filterDevice,
-    std::shared_ptr<KsAggregateEndpointDefinition2>& endpointDefinition
+    std::shared_ptr<KsAggregateEndpointDefinition3>& endpointDefinition
 
 )
 {
@@ -1636,7 +1638,7 @@ CMidi2KSAggregateMidiEndpointManager2::CreatePendingEndpointDefinitionForFilterD
         TraceLoggingWideString(filterDevice.Id().c_str(), "filter device id")
     );
 
-    std::shared_ptr<KsAggregateParentDeviceDefinition2> parentDeviceDefinition{ nullptr };
+    std::shared_ptr<KsAggregateParentDeviceDefinition3> parentDeviceDefinition{ nullptr };
 
     RETURN_IF_FAILED(FindOrCreateParentDeviceDefinitionForFilterDevice(
         filterDevice,
@@ -1646,7 +1648,7 @@ CMidi2KSAggregateMidiEndpointManager2::CreatePendingEndpointDefinitionForFilterD
     RETURN_HR_IF_NULL(E_POINTER, parentDeviceDefinition);
 
     // create a new endpoint
-    auto newEndpointDefinition = std::make_shared<KsAggregateEndpointDefinition2>();
+    auto newEndpointDefinition = std::make_shared<KsAggregateEndpointDefinition3>();
     RETURN_HR_IF_NULL(E_POINTER, newEndpointDefinition);
 
     // We need to ensure each endpoint has a unique id. They can't all use the ParentDeviceInstanceId as the
@@ -1706,8 +1708,8 @@ CMidi2KSAggregateMidiEndpointManager2::CreatePendingEndpointDefinitionForFilterD
 
 //_Use_decl_annotations_
 //HRESULT
-//CMidi2KSAggregateMidiEndpointManager2::IncrementAndGetNextGroupIndex(
-//    std::shared_ptr<KsAggregateEndpointDefinition2> definition,
+//CMidi2KSAggregateMidiEndpointManager3::IncrementAndGetNextGroupIndex(
+//    std::shared_ptr<KsAggregateEndpointDefinition3> definition,
 //    MidiFlow dataFlowFromUserPerspective,
 //    uint8_t& groupIndex)
 //{
@@ -1736,7 +1738,7 @@ CMidi2KSAggregateMidiEndpointManager2::CreatePendingEndpointDefinitionForFilterD
 //}
 
 _Use_decl_annotations_
-void CMidi2KSAggregateMidiEndpointManager2::EndpointCreationThreadWorker(
+void CMidi2KSAggregateMidiEndpointManager3::EndpointCreationThreadWorker(
     std::stop_token token)
 {
     TraceLoggingWrite(
@@ -1751,6 +1753,9 @@ void CMidi2KSAggregateMidiEndpointManager2::EndpointCreationThreadWorker(
 
     while (!token.stop_requested())
     {
+        DrainInterfaceChangeQueue(token);
+        RestartWatcherIfAborted();
+
         if (m_pendingEndpointDefinitions.empty())
         {
             m_endpointCreationThreadWakeup.ResetEvent();
@@ -1759,7 +1764,7 @@ void CMidi2KSAggregateMidiEndpointManager2::EndpointCreationThreadWorker(
             // has completed. The addition of a new endpoint will wake this up but endpoint
             // creation is something that happens a lot at start and then rarely afterwards, so 
             // we don't want to chew more CPU than necessary
-            if (m_initialEndpointCreationCompleted && !token.stop_requested())
+            if (m_initialEndpointCreationCompleted && !token.stop_requested() && InterfaceChangeQueueIsEmpty())
             {
                 TraceLoggingWrite(
                     MidiKSAggregateTransportTelemetryProvider::Provider(),
@@ -1767,7 +1772,11 @@ void CMidi2KSAggregateMidiEndpointManager2::EndpointCreationThreadWorker(
                     TraceLoggingString(__FUNCTION__, MIDI_TRACE_EVENT_LOCATION_FIELD),
                     TraceLoggingLevel(WINEVENT_LEVEL_INFO),
                     TraceLoggingPointer(this, "this"),
-                    TraceLoggingWideString(L"Worker: Initial endpoint creation completed. Taking a nap", MIDI_TRACE_EVENT_MESSAGE_FIELD)
+                    TraceLoggingWideString(L"Worker: Initial endpoint creation completed. Taking a nap", MIDI_TRACE_EVENT_MESSAGE_FIELD),
+                    TraceLoggingBool(m_watcherStopped.is_signaled(), "watcher stopped"),
+                    TraceLoggingUInt32(GetWatcherStatusValue(m_watcher), "watcher status"),
+                    TraceLoggingUInt32(static_cast<uint32_t>(m_activatedEndpointDefinitions.size()), "activated endpoint count"),
+                    TraceLoggingUInt32(static_cast<uint32_t>(InterfaceChangeQueueDepth()), "queue depth")
                 );
 
                 m_endpointCreationThreadWakeup.wait(KSA_EMPTY_PENDING_ENDPOINT_QUEUE_WAIT_MS);
@@ -1792,6 +1801,10 @@ void CMidi2KSAggregateMidiEndpointManager2::EndpointCreationThreadWorker(
             {
                 Sleep(m_individualInterfaceEnumTimeoutMilliseconds);
                 m_endpointCreationThreadWakeup.ResetEvent();
+
+                // the debounce sleep above must not delay removals, and resetting the shared
+                // wakeup can drop a queue signal, so re-drain before continuing
+                DrainInterfaceChangeQueue(token);
             }
 
 
@@ -1830,6 +1843,11 @@ void CMidi2KSAggregateMidiEndpointManager2::EndpointCreationThreadWorker(
                             TraceLoggingPointer(this, "this"),
                             TraceLoggingWideString(L"Worker: Endpoint created", MIDI_TRACE_EVENT_MESSAGE_FIELD)
                         );
+
+                        // Endpoint activation takes seconds. Go back to the top of the outer loop so the
+                        // interface change queue and watcher health get serviced between each one, and so
+                        // we never hold an iterator into the pending list across a call that can append to it.
+                        break;
                     }
                     else
                     {
@@ -1882,7 +1900,7 @@ void CMidi2KSAggregateMidiEndpointManager2::EndpointCreationThreadWorker(
 }
 
 _Use_decl_annotations_
-bool CMidi2KSAggregateMidiEndpointManager2::ActiveKSAEndpointForDeviceExists(
+bool CMidi2KSAggregateMidiEndpointManager3::ActiveKSAEndpointForDeviceExists(
     _In_ std::wstring parentDeviceInstanceId)
 {
     auto cleanParentDeviceInstanceId = internal::NormalizeDeviceInstanceIdWStringCopy(parentDeviceInstanceId.c_str());
@@ -1898,8 +1916,8 @@ bool CMidi2KSAggregateMidiEndpointManager2::ActiveKSAEndpointForDeviceExists(
     return false;
 }
 
-
-bool ShouldSkipOpeningKsPin(_In_ KsHandleWrapper& deviceHandleWrapper, _In_ UINT pinIndex)
+_Use_decl_annotations_
+bool CMidi2KSAggregateMidiEndpointManager3::ShouldSkipOpeningKsPin(KsHandleWrapper& deviceHandleWrapper, UINT pinIndex)
 {
     std::unique_ptr<KSMULTIPLE_ITEM> dataRanges;
     ULONG dataRangesSize{ 0 };
@@ -1926,9 +1944,9 @@ bool ShouldSkipOpeningKsPin(_In_ KsHandleWrapper& deviceHandleWrapper, _In_ UINT
 
 _Use_decl_annotations_
 HRESULT
-CMidi2KSAggregateMidiEndpointManager2::GetMidi1FilterPins(
+CMidi2KSAggregateMidiEndpointManager3::GetMidi1FilterPins(
     DeviceInformation filterDevice,
-    std::vector<std::shared_ptr<KsAggregateEndpointMidiPinDefinition2>>& pinListToAddTo,
+    std::vector<std::shared_ptr<KsAggregateEndpointMidiPinDefinition3>>& pinListToAddTo,
     uint32_t& countMidiSourcePinsAdded,
     uint32_t& countMidiDestinationPinsAdded,
     KSCOMPONENTID& ksComponentId,
@@ -2007,7 +2025,7 @@ CMidi2KSAggregateMidiEndpointManager2::GetMidi1FilterPins(
 
         if (SUCCEEDED(pinHandleWrapper.Open()))
         {
-            auto pinDefinition = std::make_shared<KsAggregateEndpointMidiPinDefinition2>();
+            auto pinDefinition = std::make_shared<KsAggregateEndpointMidiPinDefinition3>();
             RETURN_HR_IF_NULL(E_POINTER, pinDefinition);
 
             //pinDefinition.KSDriverSuppliedName = driverSuppliedName;
@@ -2096,9 +2114,9 @@ CMidi2KSAggregateMidiEndpointManager2::GetMidi1FilterPins(
 
 _Use_decl_annotations_
 HRESULT 
-CMidi2KSAggregateMidiEndpointManager2::UpdateNewPinDefinitions(
-    std::shared_ptr<KsAggregateEndpointDefinition2> endpointDefinition,
-    std::shared_ptr<KsAggregateParentDeviceDefinition2> parentDevice)
+CMidi2KSAggregateMidiEndpointManager3::UpdateNewPinDefinitions(
+    std::shared_ptr<KsAggregateEndpointDefinition3> endpointDefinition,
+    std::shared_ptr<KsAggregateParentDeviceDefinition3> parentDevice)
 {
     RETURN_HR_IF_NULL(E_INVALIDARG, endpointDefinition);
     RETURN_HR_IF_NULL(E_INVALIDARG, parentDevice);
@@ -2285,7 +2303,7 @@ CMidi2KSAggregateMidiEndpointManager2::UpdateNewPinDefinitions(
 // need to see what impact that will have on enumerated MIDI ports
 
 //bool EndpointHasRoomForMoreNewPins(
-//    _In_ std::shared_ptr<KsAggregateEndpointDefinition2> endpoint,
+//    _In_ std::shared_ptr<KsAggregateEndpointDefinition3> endpoint,
 //    _In_ uint32_t countNewSourcePins,
 //    _In_ uint32_t countNewDestinationPins)
 //{
@@ -2320,9 +2338,9 @@ CMidi2KSAggregateMidiEndpointManager2::UpdateNewPinDefinitions(
 //}
 
 _Use_decl_annotations_
-bool CMidi2KSAggregateMidiEndpointManager2::AddPinToEndpoint(
-    std::shared_ptr<KsAggregateEndpointDefinition2> endpoint,
-    std::shared_ptr<KsAggregateEndpointMidiPinDefinition2> pin
+bool CMidi2KSAggregateMidiEndpointManager3::AddPinToEndpoint(
+    std::shared_ptr<KsAggregateEndpointDefinition3> endpoint,
+    std::shared_ptr<KsAggregateEndpointMidiPinDefinition3> pin
 )
 {
     if (endpoint == nullptr) return false;
@@ -2338,8 +2356,21 @@ bool CMidi2KSAggregateMidiEndpointManager2::AddPinToEndpoint(
         TraceLoggingWideString(endpoint->EndpointDeviceId.c_str(), "endpoint device id")
     );
 
+    // a replayed interface arrival must not append a pin the endpoint already has
+    auto const alreadyPresent = [&pin](auto const& existing)
+        {
+            return existing->PinNumber == pin->PinNumber &&
+                internal::NormalizeDeviceInstanceIdWStringCopy(existing->FilterDeviceId) ==
+                internal::NormalizeDeviceInstanceIdWStringCopy(pin->FilterDeviceId);
+        };
+
     if (pin->DataFlowFromUserPerspective == MidiFlow::MidiFlowOut)
     {
+        if (std::any_of(endpoint->MidiDestinationPins.begin(), endpoint->MidiDestinationPins.end(), alreadyPresent))
+        {
+            return false;
+        }
+
         if (endpoint->MidiDestinationPins.size() < 16)
         {
             endpoint->MidiDestinationPins.push_back(pin);
@@ -2353,6 +2384,11 @@ bool CMidi2KSAggregateMidiEndpointManager2::AddPinToEndpoint(
 
     if (pin->DataFlowFromUserPerspective == MidiFlow::MidiFlowIn)
     {
+        if (std::any_of(endpoint->MidiSourcePins.begin(), endpoint->MidiSourcePins.end(), alreadyPresent))
+        {
+            return false;
+        }
+
         if (endpoint->MidiSourcePins.size() < 16)
         {
             endpoint->MidiSourcePins.push_back(pin);
@@ -2370,8 +2406,18 @@ bool CMidi2KSAggregateMidiEndpointManager2::AddPinToEndpoint(
 
 _Use_decl_annotations_
 HRESULT
-CMidi2KSAggregateMidiEndpointManager2::OnFilterDeviceInterfaceAdded(
+CMidi2KSAggregateMidiEndpointManager3::OnFilterDeviceInterfaceAdded(
     DeviceWatcher /* watcher */,
+    DeviceInformation filterDevice
+)
+{
+    QueueInterfaceChange({ KsaInterfaceChangeType3::Added, filterDevice, nullptr });
+    return S_OK;
+}
+
+_Use_decl_annotations_
+HRESULT
+CMidi2KSAggregateMidiEndpointManager3::ProcessFilterDeviceInterfaceAdded(
     DeviceInformation filterDevice
 )
 {
@@ -2394,7 +2440,7 @@ CMidi2KSAggregateMidiEndpointManager2::OnFilterDeviceInterfaceAdded(
     // get all the MIDI 1 pins. These are only partially processed because some things
     // like group index and naming require the full context of all filters/pins on the
     // parent device. We want to get these before we try creating parents or endpoints
-    std::vector<std::shared_ptr<KsAggregateEndpointMidiPinDefinition2>> pinList{ };
+    std::vector<std::shared_ptr<KsAggregateEndpointMidiPinDefinition3>> pinList{ };
     uint32_t countEnumeratedMidiSourcePins{ 0 };
     uint32_t countEnumeratedMidiDestinationPins{ 0 };
     KSCOMPONENTID ksComponentId {0};
@@ -2429,7 +2475,7 @@ CMidi2KSAggregateMidiEndpointManager2::OnFilterDeviceInterfaceAdded(
     auto parentInstanceId = internal::SafeGetSwdPropertyFromDeviceInformation<winrt::hstring>(L"System.Devices.DeviceInstanceId", filterDevice, L"");
     RETURN_HR_IF(E_FAIL, parentInstanceId.empty());
 
-    std::shared_ptr<KsAggregateParentDeviceDefinition2> parentDeviceDefinition{ nullptr };
+    std::shared_ptr<KsAggregateParentDeviceDefinition3> parentDeviceDefinition{ nullptr };
 
     RETURN_IF_FAILED(FindOrCreateParentDeviceDefinitionForFilterDevice(
         filterDevice,
@@ -2454,12 +2500,12 @@ CMidi2KSAggregateMidiEndpointManager2::OnFilterDeviceInterfaceAdded(
     {
         bool foundExistingEndpoint{ false };
 
-        std::vector<std::shared_ptr<KsAggregateEndpointDefinition2>> foundEndpoints{};
+        std::vector<std::shared_ptr<KsAggregateEndpointDefinition3>> foundEndpoints{};
 
         // do we already have one or more pending endpoints for this?
         if (SUCCEEDED(FindAllPendingEndpointDefinitionsForParentDevice(parentInstanceId.c_str(), foundEndpoints)))
         {
-            std::shared_ptr<KsAggregateEndpointDefinition2> existingPendingEndpointDefinition{ nullptr };
+            std::shared_ptr<KsAggregateEndpointDefinition3> existingPendingEndpointDefinition{ nullptr };
 
             if (!foundEndpoints.empty())
             {
@@ -2518,7 +2564,34 @@ CMidi2KSAggregateMidiEndpointManager2::OnFilterDeviceInterfaceAdded(
         }
         else if (ActiveKSAEndpointForDeviceExists(parentInstanceId.c_str()))
         {
-            std::shared_ptr<KsAggregateEndpointDefinition2> existingActivatedEndpointDefinition{ nullptr };
+            std::shared_ptr<KsAggregateEndpointDefinition3> existingActivatedEndpointDefinition{ nullptr };
+
+            foundEndpoints.clear();
+
+            // A watcher restart replays Added for every interface already known to us. Without this
+            // check those replays append duplicate pins and trigger a full SWD update per filter,
+            // which takes seconds each and starves the queue.
+            if (SUCCEEDED(FindAllActivatedEndpointDefinitionsForParentDevice(parentInstanceId.c_str(), foundEndpoints)))
+            {
+                for (auto const& endpoint : foundEndpoints)
+                {
+                    if (ActivatedEndpointContainsPinsForFilter(filterDevice.Id().c_str(), endpoint))
+                    {
+                        TraceLoggingWrite(
+                            MidiKSAggregateTransportTelemetryProvider::Provider(),
+                            MIDI_TRACE_EVENT_INFO,
+                            TraceLoggingString(__FUNCTION__, MIDI_TRACE_EVENT_LOCATION_FIELD),
+                            TraceLoggingLevel(WINEVENT_LEVEL_INFO),
+                            TraceLoggingPointer(this, "this"),
+                            TraceLoggingWideString(L"Exit. Filter already present in an activated endpoint. Nothing to do.", MIDI_TRACE_EVENT_MESSAGE_FIELD),
+                            TraceLoggingWideString(filterDevice.Id().c_str(), "filter device id"),
+                            TraceLoggingWideString(endpoint->EndpointDeviceInstanceId.c_str(), "endpoint device instance id")
+                        );
+
+                        return S_OK;
+                    }
+                }
+            }
 
             // check to see if we already have any activated endpoints for this device
 
@@ -2533,9 +2606,7 @@ CMidi2KSAggregateMidiEndpointManager2::OnFilterDeviceInterfaceAdded(
                 TraceLoggingWideString(parentInstanceId.c_str(), "parent instance id")
             );
 
-            foundEndpoints.clear();
-
-            if (SUCCEEDED(FindAllActivatedEndpointDefinitionsForParentDevice(parentInstanceId.c_str(), foundEndpoints)))
+            if (!foundEndpoints.empty())
             {
                 // find an endpoint with room for another interface with pins.
                 // We're going by the pin counts returned when we enumerated 
@@ -2622,7 +2693,7 @@ CMidi2KSAggregateMidiEndpointManager2::OnFilterDeviceInterfaceAdded(
             // ===================================================================
             // Create new pending endpoint
 
-            std::shared_ptr<KsAggregateEndpointDefinition2> endpointDefinition{ nullptr };
+            std::shared_ptr<KsAggregateEndpointDefinition3> endpointDefinition{ nullptr };
 
             RETURN_IF_FAILED(CreatePendingEndpointDefinitionForFilterDevice(filterDevice, endpointDefinition));
             RETURN_HR_IF_NULL(E_POINTER, endpointDefinition);
@@ -2675,15 +2746,28 @@ CMidi2KSAggregateMidiEndpointManager2::OnFilterDeviceInterfaceAdded(
         m_endpointCreationThreadWakeup.SetEvent();
     }
 
+    TraceLoggingWrite(
+        MidiKSAggregateTransportTelemetryProvider::Provider(),
+        MIDI_TRACE_EVENT_INFO,
+        TraceLoggingString(__FUNCTION__, MIDI_TRACE_EVENT_LOCATION_FIELD),
+        TraceLoggingLevel(WINEVENT_LEVEL_INFO),
+        TraceLoggingPointer(this, "this"),
+        TraceLoggingWideString(L"Exit", MIDI_TRACE_EVENT_MESSAGE_FIELD),
+        TraceLoggingWideString(filterDevice.Id().c_str(), "added interface"),
+        TraceLoggingBool(newPendingEndpointsCreated, "new pending endpoints created"),
+        TraceLoggingBool(existingPendingEndpointUpdated, "existing pending endpoint updated"),
+        TraceLoggingUInt32(static_cast<uint32_t>(m_pendingEndpointDefinitions.size()), "pending endpoint count")
+    );
+
     return S_OK;
 }
 
 
 _Use_decl_annotations_
 bool
-CMidi2KSAggregateMidiEndpointManager2::ActivatedEndpointContainsPinsForFilter(
+CMidi2KSAggregateMidiEndpointManager3::ActivatedEndpointContainsPinsForFilter(
     std::wstring filterDeviceId,
-    std::shared_ptr<KsAggregateEndpointDefinition2> endpoint
+    std::shared_ptr<KsAggregateEndpointDefinition3> endpoint
 )
 {
     auto cleanedFilterDeviceId = internal::NormalizeDeviceInstanceIdWStringCopy(filterDeviceId);
@@ -2701,9 +2785,9 @@ CMidi2KSAggregateMidiEndpointManager2::ActivatedEndpointContainsPinsForFilter(
 
 _Use_decl_annotations_
 HRESULT
-CMidi2KSAggregateMidiEndpointManager2::FindParentDeviceForActivatedFilter(
+CMidi2KSAggregateMidiEndpointManager3::FindParentDeviceForActivatedFilter(
     std::wstring filterDeviceId,
-    std::shared_ptr<KsAggregateParentDeviceDefinition2>& parent
+    std::shared_ptr<KsAggregateParentDeviceDefinition3>& parent
 )
 {
     for (auto& epIt : m_activatedEndpointDefinitions)
@@ -2731,15 +2815,26 @@ CMidi2KSAggregateMidiEndpointManager2::FindParentDeviceForActivatedFilter(
 
 
 
+
 _Use_decl_annotations_
 HRESULT
-CMidi2KSAggregateMidiEndpointManager2::OnFilterDeviceInterfaceRemoved(
+CMidi2KSAggregateMidiEndpointManager3::OnFilterDeviceInterfaceRemoved(
     DeviceWatcher watcher,
     DeviceInformationUpdate deviceInterfaceUpdate
 )
 {
     UNREFERENCED_PARAMETER(watcher);
 
+    QueueInterfaceChange({ KsaInterfaceChangeType3::Removed, nullptr, deviceInterfaceUpdate });
+    return S_OK;
+}
+
+_Use_decl_annotations_
+HRESULT
+CMidi2KSAggregateMidiEndpointManager3::ProcessFilterDeviceInterfaceRemoved(
+    DeviceInformationUpdate deviceInterfaceUpdate
+)
+{
     // TODO: This only handles a single endpoint with the filter
     // Logic needs to be rewritten to remove pins from potentially multiple endpoints
 
@@ -2762,7 +2857,7 @@ CMidi2KSAggregateMidiEndpointManager2::OnFilterDeviceInterfaceRemoved(
 
     // get the parent device and see if it's still present. If not, then skip all the filter work and just remove the device
 
-    std::shared_ptr<KsAggregateParentDeviceDefinition2> parent;
+    std::shared_ptr<KsAggregateParentDeviceDefinition3> parent;
     if (SUCCEEDED(FindParentDeviceForActivatedFilter(deviceInterfaceUpdate.Id().c_str(), parent)))
     {
         TraceLoggingWrite(
@@ -2824,6 +2919,10 @@ CMidi2KSAggregateMidiEndpointManager2::OnFilterDeviceInterfaceRemoved(
             // remove endpoints from list
             // unlock endpoints
 
+            auto const removalStartTicks = internal::GetCurrentMidiTimestamp();
+            uint32_t countRemoved{ 0 };
+            size_t remainingActivatedCount{ 0 };
+
             {
                 auto endpointsLock = m_activatedEndpointDefinitionsLock.lock();
 
@@ -2843,6 +2942,7 @@ CMidi2KSAggregateMidiEndpointManager2::OnFilterDeviceInterfaceRemoved(
                         if (SUCCEEDED(hr))
                         {
                             iter = m_activatedEndpointDefinitions.erase(iter);
+                            countRemoved++;
                         }
                         else
                         {
@@ -2866,22 +2966,51 @@ CMidi2KSAggregateMidiEndpointManager2::OnFilterDeviceInterfaceRemoved(
                         ++iter;
                     }
                 }
+
+                remainingActivatedCount = m_activatedEndpointDefinitions.size();
             }
+
+            TraceLoggingWrite(
+                MidiKSAggregateTransportTelemetryProvider::Provider(),
+                MIDI_TRACE_EVENT_INFO,
+                TraceLoggingString(__FUNCTION__, MIDI_TRACE_EVENT_LOCATION_FIELD),
+                TraceLoggingLevel(WINEVENT_LEVEL_INFO),
+                TraceLoggingPointer(this, "this"),
+                TraceLoggingWideString(L"Exit. Removed all endpoints for absent parent.", MIDI_TRACE_EVENT_MESSAGE_FIELD),
+                TraceLoggingWideString(removedFilterDeviceId.c_str(), "removed interface"),
+                TraceLoggingUInt32(countRemoved, "endpoints removed"),
+                TraceLoggingUInt32(ElapsedMillisecondsSince(removalStartTicks), "duration ms"),
+                TraceLoggingUInt32(static_cast<uint32_t>(remainingActivatedCount), "activated endpoint count")
+            );
 
             return S_OK;
         }
+    }
+    else
+    {
+        // the filter was never part of an activated endpoint, so the pin removal below is a no-op.
+        // logged because silence here is otherwise indistinguishable from a hung callback.
+        TraceLoggingWrite(
+            MidiKSAggregateTransportTelemetryProvider::Provider(),
+            MIDI_TRACE_EVENT_INFO,
+            TraceLoggingString(__FUNCTION__, MIDI_TRACE_EVENT_LOCATION_FIELD),
+            TraceLoggingLevel(WINEVENT_LEVEL_INFO),
+            TraceLoggingPointer(this, "this"),
+            TraceLoggingWideString(L"No parent device in internal collection for this filter.", MIDI_TRACE_EVENT_MESSAGE_FIELD),
+            TraceLoggingWideString(removedFilterDeviceId.c_str(), "removed interface")
+        );
     }
 
     // if we get to this point, then the parent device was not actually deactivated/removed, and we're removing individual filters.
     // this requires that by the time the filter removal notification comes in, the device is already considered "not present".
 
-    std::vector<std::shared_ptr<KsAggregateEndpointDefinition2>> endpointsToUpdate;
-    std::vector<std::shared_ptr<KsAggregateEndpointDefinition2>> endpointsToRemove;
+    std::vector<std::shared_ptr<KsAggregateEndpointDefinition3>> endpointsToUpdate;
+    std::vector<std::shared_ptr<KsAggregateEndpointDefinition3>> endpointsToRemove;
 
     // TODO: This should also remove from pending endpoints if someone adds and removes immediately
 
 
-    std::shared_ptr<KsAggregateEndpointDefinition2> endpointDefinition{ nullptr };
+    std::shared_ptr<KsAggregateEndpointDefinition3> endpointDefinition{ nullptr };
 
     for (auto& endpointListIterator : m_activatedEndpointDefinitions)
     {
@@ -2933,7 +3062,8 @@ CMidi2KSAggregateMidiEndpointManager2::OnFilterDeviceInterfaceRemoved(
 
         if (SUCCEEDED(hr))
         {
-            m_activatedEndpointDefinitions.erase(ep->EndpointDeviceInstanceId);
+            // must match the normalized form used when inserting, or this silently does nothing
+            m_activatedEndpointDefinitions.erase(internal::NormalizeDeviceInstanceIdWStringCopy(ep->EndpointDeviceInstanceId));
         }
         else
         {
@@ -2969,24 +3099,48 @@ CMidi2KSAggregateMidiEndpointManager2::OnFilterDeviceInterfaceRemoved(
         LOG_IF_FAILED(DeviceUpdateExistingMidiUmpEndpointWithFilterChanges(ep));
     }
 
-    return S_OK;
-}
-
-_Use_decl_annotations_
-HRESULT
-CMidi2KSAggregateMidiEndpointManager2::OnFilterDeviceInterfaceUpdated(
-    DeviceWatcher watcher,
-    DeviceInformationUpdate deviceInterfaceUpdate
-)
-{
-    UNREFERENCED_PARAMETER(watcher);
-
     TraceLoggingWrite(
         MidiKSAggregateTransportTelemetryProvider::Provider(),
         MIDI_TRACE_EVENT_INFO,
         TraceLoggingString(__FUNCTION__, MIDI_TRACE_EVENT_LOCATION_FIELD),
         TraceLoggingLevel(WINEVENT_LEVEL_INFO),
         TraceLoggingPointer(this, "this"),
+        TraceLoggingWideString(L"Exit. Removed filter from individual endpoints.", MIDI_TRACE_EVENT_MESSAGE_FIELD),
+        TraceLoggingWideString(removedFilterDeviceId.c_str(), "removed interface"),
+        TraceLoggingUInt32(static_cast<uint32_t>(endpointsToRemove.size()), "endpoints removed"),
+        TraceLoggingUInt32(static_cast<uint32_t>(endpointsToUpdate.size()), "endpoints updated"),
+        TraceLoggingUInt32(static_cast<uint32_t>(m_activatedEndpointDefinitions.size()), "activated endpoint count")
+    );
+
+    return S_OK;
+}
+
+_Use_decl_annotations_
+HRESULT
+CMidi2KSAggregateMidiEndpointManager3::OnFilterDeviceInterfaceUpdated(
+    DeviceWatcher watcher,
+    DeviceInformationUpdate deviceInterfaceUpdate
+)
+{
+    UNREFERENCED_PARAMETER(watcher);
+
+    QueueInterfaceChange({ KsaInterfaceChangeType3::Updated, nullptr, deviceInterfaceUpdate });
+    return S_OK;
+}
+
+_Use_decl_annotations_
+HRESULT
+CMidi2KSAggregateMidiEndpointManager3::ProcessFilterDeviceInterfaceUpdated(
+    DeviceInformationUpdate deviceInterfaceUpdate
+)
+{
+    TraceLoggingWrite(
+        MidiKSAggregateTransportTelemetryProvider::Provider(),
+        MIDI_TRACE_EVENT_INFO,
+        TraceLoggingString(__FUNCTION__, MIDI_TRACE_EVENT_LOCATION_FIELD),
+        TraceLoggingLevel(WINEVENT_LEVEL_INFO),
+        TraceLoggingPointer(this, "this"),
+        TraceLoggingWideString(L"Interface update received. Not currently acted upon.", MIDI_TRACE_EVENT_MESSAGE_FIELD),
         TraceLoggingWideString(deviceInterfaceUpdate.Id().c_str(), "updated interface")
     );
 
@@ -3018,9 +3172,26 @@ CMidi2KSAggregateMidiEndpointManager2::OnFilterDeviceInterfaceUpdated(
 
 _Use_decl_annotations_
 HRESULT
-CMidi2KSAggregateMidiEndpointManager2::OnDeviceWatcherStopped(DeviceWatcher watcher, winrt::Windows::Foundation::IInspectable)
+CMidi2KSAggregateMidiEndpointManager3::OnDeviceWatcherStopped(DeviceWatcher watcher, winrt::Windows::Foundation::IInspectable)
 {
-    UNREFERENCED_PARAMETER(watcher);
+    // Both Stopped and Aborted arrive here, and neither delivers anything further.
+    TraceLoggingWrite(
+        MidiKSAggregateTransportTelemetryProvider::Provider(),
+        MIDI_TRACE_EVENT_WARNING,
+        TraceLoggingString(__FUNCTION__, MIDI_TRACE_EVENT_LOCATION_FIELD),
+        TraceLoggingLevel(WINEVENT_LEVEL_WARNING),
+        TraceLoggingPointer(this, "this"),
+        TraceLoggingWideString(L"Device watcher stopped. No further interface notifications will be delivered.", MIDI_TRACE_EVENT_MESSAGE_FIELD),
+        TraceLoggingUInt32(GetWatcherStatusValue(watcher), "watcher status")
+    );
+
+    m_watcherStopped.SetEvent();
+
+    if (!m_shuttingDown.load())
+    {
+        m_watcherRestartRequested.store(true);
+        m_endpointCreationThreadWakeup.SetEvent();
+    }
 
     m_EnumerationCompleted.SetEvent();
     return S_OK;
@@ -3028,20 +3199,248 @@ CMidi2KSAggregateMidiEndpointManager2::OnDeviceWatcherStopped(DeviceWatcher watc
 
 _Use_decl_annotations_
 HRESULT
-CMidi2KSAggregateMidiEndpointManager2::OnEnumerationCompleted(DeviceWatcher watcher, winrt::Windows::Foundation::IInspectable)
+CMidi2KSAggregateMidiEndpointManager3::OnEnumerationCompleted(DeviceWatcher watcher, winrt::Windows::Foundation::IInspectable)
 {
-    UNREFERENCED_PARAMETER(watcher);
+    TraceLoggingWrite(
+        MidiKSAggregateTransportTelemetryProvider::Provider(),
+        MIDI_TRACE_EVENT_INFO,
+        TraceLoggingString(__FUNCTION__, MIDI_TRACE_EVENT_LOCATION_FIELD),
+        TraceLoggingLevel(WINEVENT_LEVEL_INFO),
+        TraceLoggingPointer(this, "this"),
+        TraceLoggingWideString(L"Device watcher initial enumeration completed", MIDI_TRACE_EVENT_MESSAGE_FIELD),
+        TraceLoggingUInt32(GetWatcherStatusValue(watcher), "watcher status")
+    );
+
+    // a clean enumeration means the previous restart worked, so drop any pending backoff
+    m_watcherRestartCount.store(0);
+    m_watcherRestartDelayCycles.store(0);
 
     m_EnumerationCompleted.SetEvent();
     return S_OK;
 }
 
 
+HRESULT
+CMidi2KSAggregateMidiEndpointManager3::CreateAndStartWatcher()
+{
+    winrt::hstring deviceInterfaceSelector(
+        L"System.Devices.InterfaceClassGuid:=\"{6994AD04-93EF-11D0-A3CC-00A0C9223196}\" AND " \
+        L"System.Devices.InterfaceEnabled:=System.StructuredQueryType.Boolean#True");
+
+    try
+    {
+        // requested up-front so the handlers can read them from the watcher's own snapshot
+        // instead of issuing a second DevQuery per interface
+        auto additionalProperties = winrt::single_threaded_vector<winrt::hstring>();
+        additionalProperties.Append(L"System.Devices.DeviceInstanceId");
+        additionalProperties.Append(L"System.Devices.Parent");
+        additionalProperties.Append(L"System.Devices.InterfaceEnabled");
+        additionalProperties.Append(L"System.Devices.Present");
+
+        m_watcher = DeviceInformation::CreateWatcher(
+            deviceInterfaceSelector,
+            additionalProperties,
+            DeviceInformationKind::DeviceInterface);
+    }
+    CATCH_RETURN();
+
+    RETURN_HR_IF(E_FAIL, !m_watcher);
+
+    auto deviceAddedHandler = TypedEventHandler<DeviceWatcher, DeviceInformation>(this, &CMidi2KSAggregateMidiEndpointManager3::OnFilterDeviceInterfaceAdded);
+    auto deviceRemovedHandler = TypedEventHandler<DeviceWatcher, DeviceInformationUpdate>(this, &CMidi2KSAggregateMidiEndpointManager3::OnFilterDeviceInterfaceRemoved);
+    auto deviceUpdatedHandler = TypedEventHandler<DeviceWatcher, DeviceInformationUpdate>(this, &CMidi2KSAggregateMidiEndpointManager3::OnFilterDeviceInterfaceUpdated);
+
+    auto deviceStoppedHandler = TypedEventHandler<DeviceWatcher, winrt::Windows::Foundation::IInspectable>(this, &CMidi2KSAggregateMidiEndpointManager3::OnDeviceWatcherStopped);
+    auto deviceEnumerationCompletedHandler = TypedEventHandler<DeviceWatcher, winrt::Windows::Foundation::IInspectable>(this, &CMidi2KSAggregateMidiEndpointManager3::OnEnumerationCompleted);
+
+    m_DeviceAdded = m_watcher.Added(winrt::auto_revoke, deviceAddedHandler);
+    m_DeviceRemoved = m_watcher.Removed(winrt::auto_revoke, deviceRemovedHandler);
+    m_DeviceUpdated = m_watcher.Updated(winrt::auto_revoke, deviceUpdatedHandler);
+    m_DeviceStopped = m_watcher.Stopped(winrt::auto_revoke, deviceStoppedHandler);
+    m_DeviceEnumerationCompleted = m_watcher.EnumerationCompleted(winrt::auto_revoke, deviceEnumerationCompletedHandler);
+
+    try
+    {
+        m_watcher.Start();
+    }
+    CATCH_RETURN();
+
+    return S_OK;
+}
+
+
+void
+CMidi2KSAggregateMidiEndpointManager3::RestartWatcherIfAborted()
+{
+    if (m_shuttingDown.load()) return;
+    if (!m_watcherRestartRequested.load()) return;
+
+    if (m_watcherRestartDelayCycles.load() > 0)
+    {
+        --m_watcherRestartDelayCycles;
+        return;
+    }
+
+    m_watcherRestartRequested.store(false);
+
+    auto const attempt = m_watcherRestartCount.fetch_add(1) + 1;
+    m_watcherRestartDelayCycles.store(min(attempt, (uint32_t)KSA_WATCHER_RESTART_MAX_DELAY_CYCLES));
+
+    TraceLoggingWrite(
+        MidiKSAggregateTransportTelemetryProvider::Provider(),
+        MIDI_TRACE_EVENT_WARNING,
+        TraceLoggingString(__FUNCTION__, MIDI_TRACE_EVENT_LOCATION_FIELD),
+        TraceLoggingLevel(WINEVENT_LEVEL_WARNING),
+        TraceLoggingPointer(this, "this"),
+        TraceLoggingWideString(L"Recreating aborted device watcher", MIDI_TRACE_EVENT_MESSAGE_FIELD),
+        TraceLoggingUInt32(attempt, "attempt")
+    );
+
+    m_DeviceAdded.revoke();
+    m_DeviceRemoved.revoke();
+    m_DeviceUpdated.revoke();
+    m_DeviceStopped.revoke();
+    m_DeviceEnumerationCompleted.revoke();
+
+    m_watcher = nullptr;
+    m_watcherStopped.ResetEvent();
+
+    if (FAILED(CreateAndStartWatcher()))
+    {
+        TraceLoggingWrite(
+            MidiKSAggregateTransportTelemetryProvider::Provider(),
+            MIDI_TRACE_EVENT_ERROR,
+            TraceLoggingString(__FUNCTION__, MIDI_TRACE_EVENT_LOCATION_FIELD),
+            TraceLoggingLevel(WINEVENT_LEVEL_ERROR),
+            TraceLoggingPointer(this, "this"),
+            TraceLoggingWideString(L"Failed to recreate device watcher. Will retry.", MIDI_TRACE_EVENT_MESSAGE_FIELD),
+            TraceLoggingUInt32(attempt, "attempt")
+        );
+
+        m_watcherRestartRequested.store(true);
+    }
+    else
+    {
+        TraceLoggingWrite(
+            MidiKSAggregateTransportTelemetryProvider::Provider(),
+            MIDI_TRACE_EVENT_INFO,
+            TraceLoggingString(__FUNCTION__, MIDI_TRACE_EVENT_LOCATION_FIELD),
+            TraceLoggingLevel(WINEVENT_LEVEL_INFO),
+            TraceLoggingPointer(this, "this"),
+            TraceLoggingWideString(L"Device watcher recreated and started", MIDI_TRACE_EVENT_MESSAGE_FIELD),
+            TraceLoggingUInt32(attempt, "attempt"),
+            TraceLoggingUInt32(GetWatcherStatusValue(m_watcher), "watcher status")
+        );
+    }
+}
+
+
 _Use_decl_annotations_
-winrt::hstring CMidi2KSAggregateMidiEndpointManager2::FindMatchingInstantiatedEndpoint(
+void
+CMidi2KSAggregateMidiEndpointManager3::QueueInterfaceChange(KsaInterfaceChange3&& change)
+{
+    size_t depth{ 0 };
+
+    {
+        auto lock = m_interfaceChangeQueueLock.lock();
+        m_interfaceChangeQueue.push_back(std::move(change));
+        depth = m_interfaceChangeQueue.size();
+    }
+
+    TraceLoggingWrite(
+        MidiKSAggregateTransportTelemetryProvider::Provider(),
+        MIDI_TRACE_EVENT_VERBOSE,
+        TraceLoggingString(__FUNCTION__, MIDI_TRACE_EVENT_LOCATION_FIELD),
+        TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE),
+        TraceLoggingPointer(this, "this"),
+        TraceLoggingWideString(L"Interface change queued", MIDI_TRACE_EVENT_MESSAGE_FIELD),
+        TraceLoggingUInt32(static_cast<uint32_t>(depth), "queue depth")
+    );
+
+    m_interfaceChangeQueued.SetEvent();
+    m_endpointCreationThreadWakeup.SetEvent();
+}
+
+bool
+CMidi2KSAggregateMidiEndpointManager3::InterfaceChangeQueueIsEmpty()
+{
+    auto lock = m_interfaceChangeQueueLock.lock();
+    return m_interfaceChangeQueue.empty();
+}
+
+
+size_t
+CMidi2KSAggregateMidiEndpointManager3::InterfaceChangeQueueDepth()
+{
+    auto lock = m_interfaceChangeQueueLock.lock();
+    return m_interfaceChangeQueue.size();
+}
+
+
+_Use_decl_annotations_
+void
+CMidi2KSAggregateMidiEndpointManager3::DrainInterfaceChangeQueue(std::stop_token const& token)
+{
+    while (!token.stop_requested())
+    {
+        KsaInterfaceChange3 change{};
+        size_t remaining{ 0 };
+
+        {
+            auto lock = m_interfaceChangeQueueLock.lock();
+
+            if (m_interfaceChangeQueue.empty())
+            {
+                m_interfaceChangeQueued.ResetEvent();
+                return;
+            }
+
+            change = std::move(m_interfaceChangeQueue.front());
+            m_interfaceChangeQueue.pop_front();
+            remaining = m_interfaceChangeQueue.size();
+        }
+
+        auto const startTicks = internal::GetCurrentMidiTimestamp();
+
+        switch (change.ChangeType)
+        {
+        case KsaInterfaceChangeType3::Added:
+            LOG_IF_FAILED(ProcessFilterDeviceInterfaceAdded(change.FilterDevice));
+            break;
+
+        case KsaInterfaceChangeType3::Removed:
+            LOG_IF_FAILED(ProcessFilterDeviceInterfaceRemoved(change.InterfaceUpdate));
+            break;
+
+        case KsaInterfaceChangeType3::Updated:
+            LOG_IF_FAILED(ProcessFilterDeviceInterfaceUpdated(change.InterfaceUpdate));
+            break;
+        }
+
+        TraceLoggingWrite(
+            MidiKSAggregateTransportTelemetryProvider::Provider(),
+            MIDI_TRACE_EVENT_VERBOSE,
+            TraceLoggingString(__FUNCTION__, MIDI_TRACE_EVENT_LOCATION_FIELD),
+            TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE),
+            TraceLoggingPointer(this, "this"),
+            TraceLoggingWideString(L"Interface change processed", MIDI_TRACE_EVENT_MESSAGE_FIELD),
+            TraceLoggingUInt32(static_cast<uint32_t>(change.ChangeType), "change type"),
+            TraceLoggingUInt32(ElapsedMillisecondsSince(startTicks), "duration ms"),
+            TraceLoggingUInt32(static_cast<uint32_t>(remaining), "queue depth remaining")
+        );
+    }
+}
+
+
+_Use_decl_annotations_
+winrt::hstring CMidi2KSAggregateMidiEndpointManager3::FindMatchingInstantiatedEndpoint(
     WindowsMidiServicesPluginConfigurationLib::MidiEndpointMatchCriteria& criteria)
 {
     criteria.Normalize();
+
+    // called from the configuration manager on a different thread than the worker which mutates these
+    auto activatedLock = m_activatedEndpointDefinitionsLock.lock();
+    auto parentLock = m_allParentDeviceDefinitionsLock.lock();
 
     for (auto const& def : m_activatedEndpointDefinitions)
     {
@@ -3051,7 +3450,7 @@ winrt::hstring CMidi2KSAggregateMidiEndpointManager2::FindMatchingInstantiatedEn
         available.EndpointDeviceId = def.second->EndpointDeviceId;
         available.TransportSuppliedEndpointName = def.second->EndpointName;
 
-        std::shared_ptr<KsAggregateParentDeviceDefinition2> parent { nullptr };
+        std::shared_ptr<KsAggregateParentDeviceDefinition3> parent { nullptr };
 
         if (SUCCEEDED(FindExistingParentDeviceDefinitionForEndpoint(def.second, parent)))
         {
@@ -3072,8 +3471,11 @@ winrt::hstring CMidi2KSAggregateMidiEndpointManager2::FindMatchingInstantiatedEn
 }
 
 HRESULT
-CMidi2KSAggregateMidiEndpointManager2::Shutdown()
+CMidi2KSAggregateMidiEndpointManager3::Shutdown()
 {
+    m_shuttingDown.store(true);
+    m_watcherRestartRequested.store(false);
+
     TraceLoggingWrite(
         MidiKSAggregateTransportTelemetryProvider::Provider(),
         MIDI_TRACE_EVENT_INFO,
@@ -3087,28 +3489,70 @@ CMidi2KSAggregateMidiEndpointManager2::Shutdown()
     m_DeviceUpdated.revoke();
     m_DeviceStopped.revoke();
     m_DeviceEnumerationCompleted.revoke();
-    m_watcher.Stop();
 
-    auto pendingLock = m_pendingEndpointDefinitionsLock.lock();
-    m_pendingEndpointDefinitions.clear();
+    if (m_watcher)
+    {
+        try
+        {
+            m_watcher.Stop();
+        }
+        catch (...) {}
+    }
 
+    // wake and join the worker before touching any of the collections it uses,
+    // otherwise the jthread member would join during destruction instead
     m_endpointCreationThread.request_stop();
     m_EnumerationCompleted.SetEvent();
-
-    m_endpointCreationThreadWakeup.SetEvent();
     m_initialEndpointCreationCompleted.SetEvent();
+    m_interfaceChangeQueued.SetEvent();
+    m_endpointCreationThreadWakeup.SetEvent();
 
-    m_activatedEndpointDefinitions.clear();
-    m_pendingEndpointDefinitions.clear();
+    if (m_endpointCreationThread.joinable())
+    {
+        m_endpointCreationThread.join();
+    }
 
+    {
+        auto lock = m_interfaceChangeQueueLock.lock();
+        m_interfaceChangeQueue.clear();
+    }
+
+    {
+        auto lock = m_pendingEndpointDefinitionsLock.lock();
+        m_pendingEndpointDefinitions.clear();
+    }
+
+    {
+        auto lock = m_activatedEndpointDefinitionsLock.lock();
+        m_activatedEndpointDefinitions.clear();
+    }
+
+    {
+        auto lock = m_allParentDeviceDefinitionsLock.lock();
+        m_allParentDeviceDefinitions.clear();
+    }
+
+    // an aborted watcher never reports Stopped, so don't wait out the full timeout on it
     uint8_t tries{ 0 };
-    while (m_watcher.Status() != DeviceWatcherStatus::Stopped && tries < 50)
+    while (m_watcher &&
+           m_watcher.Status() != DeviceWatcherStatus::Stopped &&
+           m_watcher.Status() != DeviceWatcherStatus::Aborted &&
+           tries < 50)
     {
         Sleep(100);
         tries++;
     }
 
-    TransportState::Current().Shutdown();
+    TraceLoggingWrite(
+        MidiKSAggregateTransportTelemetryProvider::Provider(),
+        MIDI_TRACE_EVENT_INFO,
+        TraceLoggingString(__FUNCTION__, MIDI_TRACE_EVENT_LOCATION_FIELD),
+        TraceLoggingLevel(WINEVENT_LEVEL_INFO),
+        TraceLoggingPointer(this, "this"),
+        TraceLoggingWideString(L"Exit", MIDI_TRACE_EVENT_MESSAGE_FIELD),
+        TraceLoggingUInt32(GetWatcherStatusValue(m_watcher), "watcher status"),
+        TraceLoggingUInt32(tries, "watcher stop poll iterations")
+    );
 
     m_midiDeviceManager.reset();
     m_midiProtocolManager.reset();

--- a/src/api/Transport/KSAggregateTransport/Midi2.KSAggregateMidiEndpointManager3.h
+++ b/src/api/Transport/KSAggregateTransport/Midi2.KSAggregateMidiEndpointManager3.h
@@ -1,0 +1,304 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License
+// ============================================================================
+// This is part of the Windows MIDI Services App API and should be used
+// in your Windows application via an official binary distribution.
+// Further information: https://aka.ms/midi
+// ============================================================================
+
+#pragma once
+
+#include <deque>
+
+#include "MidiEndpointCustomProperties.h"
+#include "MidiEndpointMatchCriteria.h"
+#include "MidiEndpointNameTable.h"
+
+using namespace winrt::Windows::Devices::Enumeration;
+
+#define DEFAULT_KSA_INTERFACE_ENUM_TIMEOUT_MS           300 //250 is the minimum for some of my 16 port USB devices
+#define KSA_INTERFACE_ENUM_TIMEOUT_MS_MINIMUM_VALUE     20
+#define KSA_INTERFACE_ENUM_TIMEOUT_MS_MAXIMUM_VALUE     2500
+#define KSA_INTERFACE_ENUM_TIMEOUT_REG_VALUE            L"KsaInterfaceEnumTimeoutMS"
+
+#define KSA_EMPTY_PENDING_ENDPOINT_QUEUE_WAIT_MS        10000       // this is just to avoid an infinite wait
+
+// worker cycles to wait between watcher restart attempts, so a persistently failing restart can't spin
+#define KSA_WATCHER_RESTART_MAX_DELAY_CYCLES            6
+
+enum class KsaInterfaceChangeType3
+{
+    Added,
+    Removed,
+    Updated
+};
+
+// Device watcher callbacks queue these and return immediately. All real work happens
+// on the endpoint creation worker thread. Blocking a DevQuery notification callback
+// (especially by waiting on another DevQuery operation) can get the watcher aborted.
+struct KsaInterfaceChange3
+{
+    KsaInterfaceChangeType3 ChangeType{ KsaInterfaceChangeType3::Added };
+    DeviceInformation FilterDevice{ nullptr };
+    DeviceInformationUpdate InterfaceUpdate{ nullptr };
+};
+
+struct KsAggregateEndpointMidiPinDefinition3
+{
+    std::wstring FilterDeviceId{ };                // this is also the value needed by WinMM for DRV_QUERYDEVICEINTERFACE
+    std::wstring FilterName{ };
+
+    std::wstring DriverSuppliedName{};          // value from registry. Required for WinMM classic naming. This was at parent level efore, but loopMIDI and similar register per-interface
+
+    ULONG PinNumber{ 0 };
+    std::wstring PinName;
+
+    MidiFlow PinDataFlow{ MidiFlow::MidiFlowOut };
+    MidiFlow DataFlowFromUserPerspective{ MidiFlow::MidiFlowOut };
+
+    bool NeedsGroupIndexAssigned{ true };
+
+    uint8_t GroupIndex{ 0 };
+    uint8_t PortIndexWithinThisFilterAndDirection{ 0 }; // not always the same as the group index. Example: MOTU Express 128 with separate filter for each in/out pair
+};
+
+struct KsAggregateEndpointDefinition3
+{
+    std::wstring ParentDeviceInstanceId{};
+
+    std::wstring EndpointDeviceId{};
+
+    std::wstring EndpointName{};
+    std::wstring EndpointDeviceInstanceId{};
+
+    std::vector<std::shared_ptr<KsAggregateEndpointMidiPinDefinition3>> MidiSourcePins{ };
+    std::vector<std::shared_ptr<KsAggregateEndpointMidiPinDefinition3>> MidiDestinationPins{ };
+
+    inline std::vector<std::shared_ptr<KsAggregateEndpointMidiPinDefinition3>> GetAllPins()
+    {
+        std::vector<std::shared_ptr<KsAggregateEndpointMidiPinDefinition3>> allPins;
+        allPins.reserve(MidiSourcePins.size() + MidiDestinationPins.size());
+        allPins.insert(allPins.end(), MidiSourcePins.begin(), MidiSourcePins.end());
+        allPins.insert(allPins.end(), MidiDestinationPins.begin(), MidiDestinationPins.end());
+
+        return allPins;
+    }
+
+ //   inline void RemoveAllPinsForFilter(_In_ std::wstring const& filterId);
+
+    WindowsMidiServicesNamingLib::MidiEndpointNameTable EndpointNameTable{ };
+
+    uint32_t EndpointIndexForThisParentDevice{ 0 };  
+
+    //wil::slim_event_manual_reset UpdateTimeout;
+    //std::atomic<bool> UpdatedSinceLastCheck{ true };
+
+    std::atomic<uint64_t> LastUpdatedTimestamp{ 0 };
+    std::atomic<bool> LockedForUpdating { false };
+
+    KSCOMPONENTID KsComponentId {0};
+    DWORD KsComponentIdSize {0};
+};
+
+
+class KsAggregateParentDeviceDefinition3
+{
+public:
+    std::wstring DeviceName{};
+    std::wstring DeviceInstanceId{};
+
+    uint32_t IndexOfDevicesWithThisSameName{ 0 };   // for when there are multiple of the same device
+
+
+    uint16_t VID{ 0 };  // USB-only
+    uint16_t PID{ 0 };  // USB-only
+    std::wstring SerialNumber{};
+
+    std::wstring ManufacturerName{};
+};
+
+
+class CMidi2KSAggregateMidiEndpointManager3 :
+    public Microsoft::WRL::RuntimeClass<
+        Microsoft::WRL::RuntimeClassFlags<Microsoft::WRL::ClassicCom>,
+        IMidiEndpointManager>
+{
+public:
+
+    STDMETHOD(Initialize(_In_ IMidiDeviceManager*, _In_ IMidiEndpointProtocolManager*));
+    STDMETHOD(Shutdown)();
+
+    // returns the endpointDeviceInterfaceId for a matching endpoint found in m_availableEndpointDefinitions
+    winrt::hstring FindMatchingInstantiatedEndpoint(_In_ WindowsMidiServicesPluginConfigurationLib::MidiEndpointMatchCriteria& criteria);
+
+private:
+    uint64_t m_individualInterfaceEnumTimeoutTicks{ 0 };
+    DWORD m_individualInterfaceEnumTimeoutMilliseconds{ 0 };
+
+    wil::com_ptr_nothrow<IMidiDeviceManager> m_midiDeviceManager;
+    wil::com_ptr_nothrow<IMidiEndpointProtocolManager> m_midiProtocolManager;
+
+    HRESULT OnFilterDeviceInterfaceAdded(_In_ DeviceWatcher, _In_ DeviceInformation);
+    HRESULT OnFilterDeviceInterfaceRemoved(_In_ DeviceWatcher, _In_ DeviceInformationUpdate);
+    HRESULT OnFilterDeviceInterfaceUpdated(_In_ DeviceWatcher, _In_ DeviceInformationUpdate);
+
+    HRESULT OnEnumerationCompleted(_In_ DeviceWatcher, _In_ winrt::Windows::Foundation::IInspectable);
+    HRESULT OnDeviceWatcherStopped(_In_ DeviceWatcher, _In_ winrt::Windows::Foundation::IInspectable);
+
+    HRESULT ProcessFilterDeviceInterfaceAdded(_In_ DeviceInformation);
+    HRESULT ProcessFilterDeviceInterfaceRemoved(_In_ DeviceInformationUpdate);
+    HRESULT ProcessFilterDeviceInterfaceUpdated(_In_ DeviceInformationUpdate);
+
+    void QueueInterfaceChange(KsaInterfaceChange3&& change);
+    bool InterfaceChangeQueueIsEmpty();
+    size_t InterfaceChangeQueueDepth();
+    void DrainInterfaceChangeQueue(_In_ std::stop_token const& token);
+
+    HRESULT CreateAndStartWatcher();
+    void RestartWatcherIfAborted();
+
+    std::deque<KsaInterfaceChange3> m_interfaceChangeQueue;
+    wil::critical_section m_interfaceChangeQueueLock;
+
+    // separate from m_endpointCreationThreadWakeup, which the pending-endpoint path resets
+    wil::unique_event_nothrow m_interfaceChangeQueued;
+
+    wil::unique_event_nothrow m_watcherStopped;
+    std::atomic<bool> m_watcherRestartRequested{ false };
+    std::atomic<bool> m_shuttingDown{ false };
+    std::atomic<uint32_t> m_watcherRestartCount{ 0 };
+    std::atomic<uint32_t> m_watcherRestartDelayCycles{ 0 };
+
+
+    // key is parent device instance id. These don't get "activated" so we keep a single list
+    std::map<std::wstring, std::shared_ptr<KsAggregateParentDeviceDefinition3>> m_allParentDeviceDefinitions;
+    wil::critical_section m_allParentDeviceDefinitionsLock;
+
+    // these are all endpoints which have not yet been activated
+    std::vector<std::shared_ptr<KsAggregateEndpointDefinition3>> m_pendingEndpointDefinitions;
+    wil::critical_section m_pendingEndpointDefinitionsLock;
+
+    // key is the normalized endpoint device instance id. Always key and erase through
+    // internal::NormalizeDeviceInstanceIdWStringCopy or lookups will silently miss.
+    std::map<std::wstring, std::shared_ptr<KsAggregateEndpointDefinition3>> m_activatedEndpointDefinitions;
+    wil::critical_section m_activatedEndpointDefinitionsLock;
+
+    bool ShouldSkipOpeningKsPin(_In_ KsHandleWrapper& deviceHandleWrapper, _In_ UINT pinIndex);
+
+    bool ActiveKSAEndpointForDeviceExists(
+        _In_ std::wstring deviceInstanceId);
+
+    HRESULT ParseParentIdIntoVidPidSerial(
+        _In_ std::wstring systemDevicesParentValue,
+        _In_ std::shared_ptr<KsAggregateParentDeviceDefinition3> parentDevice);
+
+
+    HRESULT FindActivatedEndpointDefinitionForFilterDevice(
+        _In_ std::wstring filterDeviceId,
+        _Inout_ std::shared_ptr<KsAggregateEndpointDefinition3>&);
+
+    HRESULT FindAllActivatedEndpointDefinitionsForParentDevice(
+        _In_ std::wstring parentDeviceInstanceId,
+        _Inout_ std::vector<std::shared_ptr<KsAggregateEndpointDefinition3>>& endpointDefinitions);
+
+    HRESULT FindAllPendingEndpointDefinitionsForParentDevice(
+        _In_ std::wstring parentDeviceInstanceId,
+        _Inout_ std::vector<std::shared_ptr<KsAggregateEndpointDefinition3>>& endpointDefinitions);
+
+
+    bool ActivatedEndpointContainsPinsForFilter(
+        _In_ std::wstring filterDeviceId,
+        _In_ std::shared_ptr<KsAggregateEndpointDefinition3> endpoint);
+
+
+    HRESULT FindParentDeviceForActivatedFilter(
+        _In_ std::wstring filterDeviceId,
+        _Inout_ std::shared_ptr<KsAggregateParentDeviceDefinition3>& parent);
+
+
+
+    HRESULT FindPendingEndpointDefinitionForParentDevice(
+        _In_ std::wstring parentDeviceInstanceId,
+        _Inout_ std::shared_ptr<KsAggregateEndpointDefinition3>&);
+
+    HRESULT FindExistingParentDeviceDefinitionForEndpoint(
+        _In_ std::shared_ptr<KsAggregateEndpointDefinition3> endpointDefinition,
+        _Inout_ std::shared_ptr<KsAggregateParentDeviceDefinition3>& parentDeviceDefinition);
+
+    HRESULT FindOrCreateParentDeviceDefinitionForFilterDevice(
+        _In_ DeviceInformation filterDevice,
+        _Inout_ std::shared_ptr<KsAggregateParentDeviceDefinition3>& parentDeviceDefinition);
+
+    HRESULT CreatePendingEndpointDefinitionForFilterDevice(
+        _In_ DeviceInformation,
+        _Inout_ std::shared_ptr<KsAggregateEndpointDefinition3>&
+    );
+    
+
+    HRESULT FindUnusedEndpointIndexForParentDevice(
+        _In_ std::shared_ptr<KsAggregateParentDeviceDefinition3> parentDeviceDefinition, 
+        _In_ uint32_t& unusedIndex);
+
+    bool AddPinToEndpoint(
+        _In_ std::shared_ptr<KsAggregateEndpointDefinition3> endpoint,
+        _In_ std::shared_ptr<KsAggregateEndpointMidiPinDefinition3> pin
+    );
+
+
+    HRESULT GetPinName(_In_ HANDLE const hFilter, _In_ UINT const pinIndex, _Inout_ std::wstring& pinName);
+    HRESULT GetPinDataFlow(_In_ HANDLE const hFilter, _In_ UINT const pinIndex, _Inout_ KSPIN_DATAFLOW& dataFlow);
+
+    HRESULT GetMidi1FilterPins(
+        _In_ DeviceInformation,
+        _In_ std::vector<std::shared_ptr<KsAggregateEndpointMidiPinDefinition3>>&,
+        _Inout_ uint32_t& countMidiSourcePinsAdded,
+        _Inout_ uint32_t& countMidiDestinationPinsAdded,
+        _Inout_ KSCOMPONENTID& ksComponentId,
+        _Inout_ DWORD& ksComponentIdSize);
+
+    HRESULT GetKSDriverSuppliedName(_In_ HANDLE hFilter, _Inout_ std::wstring& name, _Inout_ KSCOMPONENTID &ksComponentId, _Inout_ DWORD& ksComponentIdSize);
+
+    //HRESULT IncrementAndGetNextGroupIndex(
+    //    _In_ std::shared_ptr<KsAggregateEndpointDefinition3> definition,
+    //    _In_ MidiFlow dataFlowFromUserPerspective,
+    //    _In_ uint8_t& groupIndex);
+
+    HRESULT UpdateNewPinDefinitions(
+        _In_ std::shared_ptr<KsAggregateEndpointDefinition3> endpointDefinition,
+        _In_ std::shared_ptr<KsAggregateParentDeviceDefinition3> parentDevice);
+
+    HRESULT BuildPinsAndGroupTerminalBlocksPropertyData(
+        _In_ std::shared_ptr<KsAggregateEndpointDefinition3> masterEndpointDefinition,
+        _In_ std::vector<std::byte>& pinMapPropertyData,
+        _In_ std::vector<internal::GroupTerminalBlockInternal>& groupTerminalBlocks);
+
+    HRESULT UpdateNameTableWithCustomProperties(
+        _In_ std::shared_ptr<KsAggregateEndpointDefinition3> masterEndpointDefinition,
+        _In_ std::shared_ptr<WindowsMidiServicesPluginConfigurationLib::MidiEndpointCustomProperties> customProperties);
+
+
+    // these two functions actually update the software devices in Windows
+
+    HRESULT DeviceCreateMidiUmpEndpoint(
+        _In_ std::shared_ptr<KsAggregateEndpointDefinition3> masterEndpointDefinition);
+
+    HRESULT DeviceUpdateExistingMidiUmpEndpointWithFilterChanges(
+        _In_ std::shared_ptr<KsAggregateEndpointDefinition3> masterEndpointDefinition);
+
+
+    wil::unique_event_nothrow m_EnumerationCompleted;
+    wil::unique_event_nothrow m_initialEndpointCreationCompleted;
+
+    wil::unique_event_nothrow m_endpointCreationThreadWakeup;
+    std::jthread m_endpointCreationThread;
+    void EndpointCreationThreadWorker(_In_ std::stop_token token);
+
+
+    DeviceWatcher m_watcher{0};
+    winrt::impl::consume_Windows_Devices_Enumeration_IDeviceWatcher<IDeviceWatcher>::Added_revoker m_DeviceAdded;
+    winrt::impl::consume_Windows_Devices_Enumeration_IDeviceWatcher<IDeviceWatcher>::Removed_revoker m_DeviceRemoved;
+    winrt::impl::consume_Windows_Devices_Enumeration_IDeviceWatcher<IDeviceWatcher>::Updated_revoker m_DeviceUpdated;
+    winrt::impl::consume_Windows_Devices_Enumeration_IDeviceWatcher<IDeviceWatcher>::Stopped_revoker m_DeviceStopped;
+    winrt::impl::consume_Windows_Devices_Enumeration_IDeviceWatcher<IDeviceWatcher>::EnumerationCompleted_revoker m_DeviceEnumerationCompleted;
+
+};

--- a/src/api/Transport/KSAggregateTransport/Midi2.KSAggregateTransport.cpp
+++ b/src/api/Transport/KSAggregateTransport/Midi2.KSAggregateTransport.cpp
@@ -45,12 +45,15 @@ CMidi2KSAggregateTransport::Activate(
         );
 
         // check to see if this is the first time we're creating the endpoint manager. If so, create it.
-        if (TransportState::Current().GetEndpointManager2() == nullptr)
+        if (TransportState::Current().GetActiveEndpointManager() == nullptr)
         {
             TransportState::Current().ConstructEndpointManager();
         }
 
-        RETURN_IF_FAILED(TransportState::Current().GetEndpointManager2()->QueryInterface(iid, activatedInterface));
+        auto endpointManager = TransportState::Current().GetActiveEndpointManager();
+        RETURN_HR_IF_NULL(E_FAIL, endpointManager);
+
+        RETURN_IF_FAILED(endpointManager->QueryInterface(iid, activatedInterface));
     }
     else if (__uuidof(IMidiTransportConfigurationManager) == iid)
     {

--- a/src/api/Transport/KSAggregateTransport/Midi2.KSAggregateTransport.vcxproj
+++ b/src/api/Transport/KSAggregateTransport/Midi2.KSAggregateTransport.vcxproj
@@ -370,6 +370,7 @@
     <ClCompile Include="Midi2.KSAggregateMidiPluginMetadataProvider.cpp" />
     <ClCompile Include="pch.cpp" />
     <ClCompile Include="Midi2.KSAggregateMidiEndpointManager2.cpp" />
+    <ClCompile Include="Midi2.KSAggregateMidiEndpointManager3.cpp" />
   </ItemGroup>
   <ItemGroup>
     <Midl Include="Midi2KSAggregateTransport.idl">
@@ -402,6 +403,7 @@
     <ClInclude Include="pch.h" />
     <ClInclude Include="Resource.h" />
     <ClInclude Include="Midi2.KSAggregateMidiEndpointManager2.h" />
+    <ClInclude Include="Midi2.KSAggregateMidiEndpointManager3.h" />
   </ItemGroup>
   <ItemGroup>
     <ResourceCompile Include="Midi2.KSAggregateTransport.rc" />

--- a/src/api/Transport/KSAggregateTransport/Midi2.KSAggregateTransport.vcxproj.filters
+++ b/src/api/Transport/KSAggregateTransport/Midi2.KSAggregateTransport.vcxproj.filters
@@ -42,6 +42,9 @@
     <ClCompile Include="Midi2.KSAggregateMidiEndpointManager2.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="Midi2.KSAggregateMidiEndpointManager3.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
     <ClCompile Include="Midi2.KSAggregateMidiInProxy.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
@@ -95,6 +98,9 @@
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="Midi2.KSAggregateMidiEndpointManager2.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="Midi2.KSAggregateMidiEndpointManager3.h">
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="Midi2.KSAggregateMidiInProxy.h">

--- a/src/api/Transport/KSAggregateTransport/TransportState.cpp
+++ b/src/api/Transport/KSAggregateTransport/TransportState.cpp
@@ -8,6 +8,8 @@
 
 #include "pch.h"
 
+#include "Feature_Servicing_MIDI2KSAWatcherHardening.h"
+
 
 TransportState::TransportState() = default;
 TransportState::~TransportState() = default;
@@ -25,9 +27,51 @@ TransportState& TransportState::Current()
 HRESULT
 TransportState::ConstructEndpointManager()
 {
-    RETURN_IF_FAILED(Microsoft::WRL::MakeAndInitialize<CMidi2KSAggregateMidiEndpointManager2>(&m_endpointManager2));
+    if (Feature_Servicing_MIDI2KSAWatcherHardening::IsEnabled())
+    {
+        RETURN_IF_FAILED(Microsoft::WRL::MakeAndInitialize<CMidi2KSAggregateMidiEndpointManager3>(&m_endpointManager3));
+    }
+    else
+    {
+        RETURN_IF_FAILED(Microsoft::WRL::MakeAndInitialize<CMidi2KSAggregateMidiEndpointManager2>(&m_endpointManager2));
+    }
 
     return S_OK;
+}
+
+
+wil::com_ptr<IMidiEndpointManager>
+TransportState::GetActiveEndpointManager()
+{
+    if (m_endpointManager3 != nullptr)
+    {
+        return m_endpointManager3.query<IMidiEndpointManager>();
+    }
+
+    if (m_endpointManager2 != nullptr)
+    {
+        return m_endpointManager2.query<IMidiEndpointManager>();
+    }
+
+    return nullptr;
+}
+
+
+_Use_decl_annotations_
+winrt::hstring
+TransportState::FindMatchingInstantiatedEndpoint(WindowsMidiServicesPluginConfigurationLib::MidiEndpointMatchCriteria& criteria)
+{
+    if (m_endpointManager3 != nullptr)
+    {
+        return m_endpointManager3->FindMatchingInstantiatedEndpoint(criteria);
+    }
+
+    if (m_endpointManager2 != nullptr)
+    {
+        return m_endpointManager2->FindMatchingInstantiatedEndpoint(criteria);
+    }
+
+    return L"";
 }
 
 

--- a/src/api/Transport/KSAggregateTransport/TransportState.h
+++ b/src/api/Transport/KSAggregateTransport/TransportState.h
@@ -25,6 +25,16 @@ public:
         return m_endpointManager2;
     }
 
+    wil::com_ptr<CMidi2KSAggregateMidiEndpointManager3> GetEndpointManager3()
+    {
+        return m_endpointManager3;
+    }
+
+    // whichever implementation the KIR selected
+    wil::com_ptr<IMidiEndpointManager> GetActiveEndpointManager();
+
+    winrt::hstring FindMatchingInstantiatedEndpoint(_In_ WindowsMidiServicesPluginConfigurationLib::MidiEndpointMatchCriteria& criteria);
+
     wil::com_ptr<CMidi2KSAggregateMidiConfigurationManager> GetConfigurationManager()
     {
         return m_configurationManager;
@@ -34,6 +44,7 @@ public:
     HRESULT Shutdown()
     {
         m_endpointManager2.reset();
+        m_endpointManager3.reset();
         m_configurationManager.reset();
 
         return S_OK;
@@ -49,6 +60,7 @@ private:
     ~TransportState();
 
     wil::com_ptr<CMidi2KSAggregateMidiEndpointManager2> m_endpointManager2 { nullptr };
+    wil::com_ptr<CMidi2KSAggregateMidiEndpointManager3> m_endpointManager3 { nullptr };
 
     wil::com_ptr<CMidi2KSAggregateMidiConfigurationManager> m_configurationManager;
 

--- a/src/api/Transport/KSAggregateTransport/pch.h
+++ b/src/api/Transport/KSAggregateTransport/pch.h
@@ -115,6 +115,7 @@ namespace internal = ::WindowsMidiServicesInternal;
 #include "Midi2UMP2BSTransform_i.c"
 
 class CMidi2KSAggregateMidiEndpointManager2;
+class CMidi2KSAggregateMidiEndpointManager3;
 class CMidi2KSAggregateMidiInProxy;
 class CMidi2KSAggregateMidiOutProxy;
 class CMidi2KSAggregateMidiConfigurationManager;
@@ -127,6 +128,7 @@ class TransportState;
 #include "Midi2.KSAggregateMidi.h"
 #include "Midi2.KSAggregateMidiBidi.h"
 #include "Midi2.KSAggregateMidiEndpointManager2.h"
+#include "Midi2.KSAggregateMidiEndpointManager3.h"
 #include "Midi2.KSAggregateMidiConfigurationManager.h"
 #include "Midi2.KSAggregateMidiPluginMetadataProvider.h"
 


### PR DESCRIPTION
This pull request introduces a new port number cache feature for MIDI device management, improves trace logging and diagnostics, and makes minor code cleanups. The main goal is to optimize port number assignment by caching assigned port numbers, reducing the need to re-enumerate MIDI devices on every assignment. Additionally, the diagnostics profile is enhanced with new event providers for better debugging, and some code comments and structure are improved for maintainability.

**MIDI Port Number Cache Feature:**

* Added a new feature flag class `Feature_Servicing_MIDI2PortNumberCache` to enable port number caching (`src/api/Inc/Feature_Servicing_MIDI2PortNumberCache.h`).
* Implemented port number cache logic in `CMidiDeviceManager`, including methods to refresh and invalidate the cache, and updated `AssignPortNumber` to use the cache when enabled (`src/api/Service/Exe/MidiDeviceManager.cpp`, `src/api/Service/Inc/MidiDeviceManager.h`). [[1]](diffhunk://#diff-78f3eef28bd13c15505a8d033e330cc78daf7de62dbaa4cc6ad362cc06bcec11R2215-R2299) [[2]](diffhunk://#diff-78f3eef28bd13c15505a8d033e330cc78daf7de62dbaa4cc6ad362cc06bcec11R2322-R2356) [[3]](diffhunk://#diff-78f3eef28bd13c15505a8d033e330cc78daf7de62dbaa4cc6ad362cc06bcec11L2295-R2431) [[4]](diffhunk://#diff-7469b1dd0b3410c2fec3a2ff0d267ec483bc7eb3522b1b19532a403526f7e84bR187-R189) [[5]](diffhunk://#diff-7469b1dd0b3410c2fec3a2ff0d267ec483bc7eb3522b1b19532a403526f7e84bR247-R253) [[6]](diffhunk://#diff-78f3eef28bd13c15505a8d033e330cc78daf7de62dbaa4cc6ad362cc06bcec11R23)

**Diagnostics and Trace Logging Improvements:**

* Enhanced the `MidiServices.wprp` diagnostics profile with additional event providers for kernel and user-mode Plug and Play, USB stack, and kernel events; separated kernel-mode providers into their own session for reliability (`diagnostics/trace-logging/MidiServices.wprp`). [[1]](diffhunk://#diff-9b97f7d897bd6e13d1b64cbc5cd60f6d209cc4651c212f8b4c32509b8aeb6fefR4-R28) [[2]](diffhunk://#diff-9b97f7d897bd6e13d1b64cbc5cd60f6d209cc4651c212f8b4c32509b8aeb6fefR56-R86) [[3]](diffhunk://#diff-9b97f7d897bd6e13d1b64cbc5cd60f6d209cc4651c212f8b4c32509b8aeb6fefR117-R129)
* Improved trace logging in port number assignment and cache refresh operations for better telemetry and debugging (`src/api/Service/Exe/MidiDeviceManager.cpp`).

**Code Cleanups and Minor Enhancements:**

* Removed the unused `EventProvider_SDKInitialization` from the diagnostics profile for clarity (`diagnostics/trace-logging/MidiServices.wprp`). [[1]](diffhunk://#diff-9b97f7d897bd6e13d1b64cbc5cd60f6d209cc4651c212f8b4c32509b8aeb6fefL26) [[2]](diffhunk://#diff-9b97f7d897bd6e13d1b64cbc5cd60f6d209cc4651c212f8b4c32509b8aeb6fefL59)
* Added a stub feature flag for MIDI2KSAWatcherHardening (`src/api/Inc/Feature_Servicing_MIDI2KSAWatcherHardening.h`).
* Updated endpoint manager references to use the active endpoint manager and improved code comments and structure in KSAggregate transport files (`src/api/Transport/KSAggregateTransport/Midi2.KSAggregateMidiConfigurationManager.cpp`, `src/api/Transport/KSAggregateTransport/Midi2.KSAggregateMidiEndpointManager2.cpp`). [[1]](diffhunk://#diff-3668972a8d8c8434dec086bf074aaaec16f4cac07999ec0a68774e8266057df7L262-R265) [[2]](diffhunk://#diff-a78b145b1a5a882bd7858d012794e2c968419760aa6d72f7b9211bb71e5105fdR2993-R3005)