### PR TITLE
Potentially fix padded clock messages coming from MIDI2 driver.

### DIFF
--- a/diagnostics/trace-logging/MidiServices.wprp
+++ b/diagnostics/trace-logging/MidiServices.wprp
@@ -30,6 +30,9 @@
     <EventProvider Id="EventProvider_MidiSrv" Stack="true" ProcessExeFilter="Midisrv.exe" Name="*Microsoft.Windows.Midi2.MidiSrv"/>
     <EventProvider Id="EventProvider_MidiSrvTransport" Name="*Microsoft.Windows.Midi2.MidiSrvTransport"/>
 
+    <!-- Statically linked into midisrv.exe, the transports and wdmaud2, so this covers both sides of the shared ring buffer. -->
+    <EventProvider Id="EventProvider_MidiXproc" Name="*Microsoft.Windows.Midi2.MidiXproc"/>
+
     <EventProvider Id="EventProvider_KSTransport" Name="*Microsoft.Windows.Midi2.KSTransport"/>
     <EventProvider Id="EventProvider_KSAggregateTransport" Name="*Microsoft.Windows.Midi2.KSAggregateTransport"/>
     <EventProvider Id="EventProvider_DiagnosticsTransport" Name="*Microsoft.Windows.Midi2.DiagnosticsTransport"/>
@@ -49,6 +52,10 @@
     <EventProvider Id="EventProvider_JitterReductionListenerTransform" Name="*Microsoft.Windows.Midi2.JitterReductionListenerTransform"/>
     <EventProvider Id="EventProvider_SchedulerTransform" Name="*Microsoft.Windows.Midi2.SchedulerTransform"/>
     <EventProvider Id="EventProvider_UMP2BSTransform" Name="*Microsoft.Windows.Midi2.UMP2BSTransform"/>
+    <EventProvider Id="EventProvider_UmpProtocolDownscalerTransform" Name="*Microsoft.Windows.Midi2.UmpProtocolDownscalerTransform"/>
+    <EventProvider Id="EventProvider_ChannelTransform" Name="*Microsoft.Windows.Midi2.ChannelTransform"/>
+    <EventProvider Id="EventProvider_GroupTransform" Name="*Microsoft.Windows.Midi2.GroupTransform"/>
+    <EventProvider Id="EventProvider_MessageTypeFilterTransform" Name="*Microsoft.Windows.Midi2.MessageTypeFilterTransform"/>
 
     <EventProvider Id="EventProvider_SettingsApp" Name="*Microsoft.Midi.Settings"/>
     <EventProvider Id="EventProvider_ConsoleApp" Name="*Microsoft.Midi.Console"/>
@@ -89,6 +96,7 @@
           <EventProviders>
             <EventProviderId Value="EventProvider_MidiSrv"/>
             <EventProviderId Value="EventProvider_MidiSrvTransport"/>
+            <EventProviderId Value="EventProvider_MidiXproc"/>
 
             <EventProviderId Value="EventProvider_KSTransport"/>
             <EventProviderId Value="EventProvider_KSAggregateTransport"/>
@@ -110,6 +118,10 @@
             <EventProviderId Value="EventProvider_JitterReductionListenerTransform"/>
             <EventProviderId Value="EventProvider_SchedulerTransform"/>
             <EventProviderId Value="EventProvider_UMP2BSTransform"/>
+            <EventProviderId Value="EventProvider_UmpProtocolDownscalerTransform"/>
+            <EventProviderId Value="EventProvider_ChannelTransform"/>
+            <EventProviderId Value="EventProvider_GroupTransform"/>
+            <EventProviderId Value="EventProvider_MessageTypeFilterTransform"/>
 
             <EventProviderId Value="EventProvider_SettingsApp"/>
             <EventProviderId Value="EventProvider_ConsoleApp"/>
@@ -120,6 +132,7 @@
           </EventProviders>
         </EventCollectorId>
 
+        <!--
         <EventCollectorId Value="EventCollector_MidiSrvKernel">
           <EventProviders>
             <EventProviderId Value="EventProvider_KernelPnP"/>
@@ -129,6 +142,8 @@
             <EventProviderId Value="EventProvider_UsbXhci"/>
           </EventProviders>
         </EventCollectorId>
+        -->
+        
       </Collectors>
     </Profile>
 

--- a/src/api/Client/WinRT/t/core/MidiEndpointConnection_Receive.cpp
+++ b/src/api/Client/WinRT/t/core/MidiEndpointConnection_Receive.cpp
@@ -22,6 +22,22 @@ namespace winrt::Windows::Devices::Midi2::implementation
         RETURN_HR_IF_NULL(E_INVALIDARG, data);
         RETURN_HR_IF(E_INVALIDARG, size < sizeof(uint32_t));
 
+#ifdef _DEBUG
+        // Debug builds only. Logging message data in a shipping binary is a privacy violation.
+        TraceLoggingWrite(
+            Midi2SdkTelemetryProvider::Provider(),
+            MIDI_SDK_TRACE_EVENT_INFO,
+            TraceLoggingString(__FUNCTION__, MIDI_SDK_TRACE_LOCATION_FIELD),
+            TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE),
+            TraceLoggingPointer(this, MIDI_SDK_TRACE_THIS_FIELD),
+            TraceLoggingWideString(L"Buffer received from service.", MIDI_SDK_TRACE_MESSAGE_FIELD),
+            TraceLoggingWideString(m_endpointDeviceId.c_str(), MIDI_SDK_TRACE_ENDPOINT_DEVICE_ID_FIELD),
+            TraceLoggingHexUInt32Array(static_cast<uint32_t*>(data), static_cast<uint16_t>(size / sizeof(uint32_t)), "data words"),
+            TraceLoggingUInt32(size, MIDI_SDK_TRACE_MESSAGE_SIZE_BYTES_FIELD),
+            TraceLoggingInt64(timestamp, MIDI_SDK_TRACE_MESSAGE_TIMESTAMP_FIELD)
+        );
+#endif
+
         // COM Extension Handling ===================================================================================
         {
             std::lock_guard<std::mutex> guard(m_comCallbackLock);

--- a/src/api/Drivers/USBMIDI2/Driver/Device.cpp
+++ b/src/api/Drivers/USBMIDI2/Driver/Device.cpp
@@ -48,6 +48,7 @@ Environment:
 #include "Device.tmh"
 
 #include "Feature_Servicing_MIDI2USBSerial.h"
+#include "Feature_Servicing_MIDI2USBSystemRealTimeUmpSize.h"
 
 UNICODE_STRING g_RegistryPath = {0};      // This is used to store the registry settings path for the driver
 
@@ -3501,6 +3502,17 @@ Return Value:
             umpPkt->umpData.umpBytes[1] = pBuffer[1];
             firstByte = 1;
             lastByte = 1;
+
+            if (Feature_Servicing_MIDI2USBSystemRealTimeUmpSize_IsEnabled())
+            {
+                // UMP_MT_SYSTEM is one word. The shared tail below belongs to UMP_MT_DATA_64,
+                // which is two, and the extra word reaches clients as a spurious NOOP.
+                umpPkt->umpData.umpBytes[2] = 0x00;
+                umpPkt->umpData.umpBytes[3] = 0x00;
+                umpPkt->wordCount = 1;
+                break;
+            }
+
             goto COMPLETE_1BYTE;
         }
 

--- a/src/api/Inc/Feature_Servicing_MIDI2USBSystemRealTimeUmpSize.h
+++ b/src/api/Inc/Feature_Servicing_MIDI2USBSystemRealTimeUmpSize.h
@@ -1,0 +1,23 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License
+// ============================================================================
+// This is part of the Windows MIDI Services App API and should be used
+// in your Windows application via an official binary distribution.
+// Further information: https://aka.ms/midi
+// ============================================================================
+
+#pragma once
+
+class Feature_Servicing_MIDI2USBSystemRealTimeUmpSize
+{
+public:
+    static bool IsEnabled()
+    {
+        return true;
+    }
+};
+
+inline bool Feature_Servicing_MIDI2USBSystemRealTimeUmpSize_IsEnabled()
+{
+    return true;
+}

--- a/src/api/Libs/MidiXProc/MidiXProc.cpp
+++ b/src/api/Libs/MidiXProc/MidiXProc.cpp
@@ -600,6 +600,38 @@ CMidiXProc::SendMidiMessageInternal(
     ULONG bufferWrittenPosition {0};
     ULONG startingReadPosition {0};
 
+#ifdef _DEBUG
+    // Debug builds only. Logging message data in a shipping binary is a privacy violation.
+    if (m_MidiOut->DataFormat == MidiDataFormats_UMP)
+    {
+        TraceLoggingWrite(
+            MidiXProcTelemetryProvider::Provider(),
+            MIDI_TRACE_EVENT_VERBOSE,
+            TraceLoggingString(__FUNCTION__, MIDI_TRACE_EVENT_LOCATION_FIELD),
+            TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE),
+            TraceLoggingPointer(this, "this"),
+            TraceLoggingWideString(L"Writing to cross-process queue", MIDI_TRACE_EVENT_MESSAGE_FIELD),
+            TraceLoggingHexUInt32Array(static_cast<uint32_t*>(midiData), static_cast<uint16_t>(length / sizeof(uint32_t)), "words"),
+            TraceLoggingUInt32(length, "length bytes"),
+            TraceLoggingUInt64(static_cast<uint64_t>(position), MIDI_TRACE_EVENT_MESSAGE_TIMESTAMP_FIELD)
+        );
+    }
+    else
+    {
+        TraceLoggingWrite(
+            MidiXProcTelemetryProvider::Provider(),
+            MIDI_TRACE_EVENT_VERBOSE,
+            TraceLoggingString(__FUNCTION__, MIDI_TRACE_EVENT_LOCATION_FIELD),
+            TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE),
+            TraceLoggingPointer(this, "this"),
+            TraceLoggingWideString(L"Writing to cross-process queue", MIDI_TRACE_EVENT_MESSAGE_FIELD),
+            TraceLoggingHexUInt8Array(static_cast<uint8_t*>(midiData), static_cast<uint16_t>(length), "bytes"),
+            TraceLoggingUInt32(length, "length bytes"),
+            TraceLoggingUInt64(static_cast<uint64_t>(position), MIDI_TRACE_EVENT_MESSAGE_TIMESTAMP_FIELD)
+        );
+    }
+#endif
+
     {
         // only 1 caller may add a message to the xproc queue at a time
         auto lock = m_MessageSendLock.lock();
@@ -903,6 +935,38 @@ CMidiXProc::ProcessMidiIn()
 
                     PVOID data = (PVOID)(((BYTE*)header) + sizeof(LOOPEDDATAFORMAT));
                     HRESULT hr = S_OK;
+
+#ifdef _DEBUG
+                    // Debug builds only. Logging message data in a shipping binary is a privacy violation.
+                    if (m_MidiIn->DataFormat == MidiDataFormats_UMP)
+                    {
+                        TraceLoggingWrite(
+                            MidiXProcTelemetryProvider::Provider(),
+                            MIDI_TRACE_EVENT_VERBOSE,
+                            TraceLoggingString(__FUNCTION__, MIDI_TRACE_EVENT_LOCATION_FIELD),
+                            TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE),
+                            TraceLoggingPointer(this, "this"),
+                            TraceLoggingWideString(L"Read from cross-process queue", MIDI_TRACE_EVENT_MESSAGE_FIELD),
+                            TraceLoggingHexUInt32Array(static_cast<uint32_t*>(data), static_cast<uint16_t>(dataSize / sizeof(uint32_t)), "words"),
+                            TraceLoggingUInt32(dataSize, "length bytes"),
+                            TraceLoggingUInt64(static_cast<uint64_t>(header->Position), MIDI_TRACE_EVENT_MESSAGE_TIMESTAMP_FIELD)
+                        );
+                    }
+                    else
+                    {
+                        TraceLoggingWrite(
+                            MidiXProcTelemetryProvider::Provider(),
+                            MIDI_TRACE_EVENT_VERBOSE,
+                            TraceLoggingString(__FUNCTION__, MIDI_TRACE_EVENT_LOCATION_FIELD),
+                            TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE),
+                            TraceLoggingPointer(this, "this"),
+                            TraceLoggingWideString(L"Read from cross-process queue", MIDI_TRACE_EVENT_MESSAGE_FIELD),
+                            TraceLoggingHexUInt8Array(static_cast<uint8_t*>(data), static_cast<uint16_t>(dataSize), "bytes"),
+                            TraceLoggingUInt32(dataSize, "length bytes"),
+                            TraceLoggingUInt64(static_cast<uint64_t>(header->Position), MIDI_TRACE_EVENT_MESSAGE_TIMESTAMP_FIELD)
+                        );
+                    }
+#endif
 
                     if (m_MidiInCallback)
                     {

--- a/src/api/Transform/ByteStreamToUMP/Midi2.BS2UMPMidiTransform.cpp
+++ b/src/api/Transform/ByteStreamToUMP/Midi2.BS2UMPMidiTransform.cpp
@@ -134,6 +134,22 @@ CMidi2BS2UMPMidiTransform::SendMidiMessage(
 
     if (translatedWords.size() > 0)
     {
+#ifdef _DEBUG
+        // Debug builds only. Logging message data in a shipping binary is a privacy violation.
+        TraceLoggingWrite(
+            MidiBS2UMPTransformTelemetryProvider::Provider(),
+            MIDI_TRACE_EVENT_VERBOSE,
+            TraceLoggingString(__FUNCTION__, MIDI_TRACE_EVENT_LOCATION_FIELD),
+            TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE),
+            TraceLoggingPointer(this, "this"),
+            TraceLoggingWideString(L"Translated MIDI 1.0 bytes to UMP", MIDI_TRACE_EVENT_MESSAGE_FIELD),
+            TraceLoggingHexUInt32Array(translatedWords.data(), static_cast<uint16_t>(translatedWords.size()), "translated words"),
+            TraceLoggingUInt32(static_cast<uint32_t>(translatedWords.size()), "translated word count"),
+            TraceLoggingUInt8(m_BS2UMP.defaultGroup, "group index"),
+            TraceLoggingUInt64(static_cast<uint64_t>(position), MIDI_TRACE_EVENT_MESSAGE_TIMESTAMP_FIELD)
+        );
+#endif
+
         // send the message. The context contains the group index
         // If the message contained running status, it no longer does
 

--- a/src/api/Transform/UmpProtocolDownscaler/Midi2.UmpProtocolDownscalerMidiTransform.cpp
+++ b/src/api/Transform/UmpProtocolDownscaler/Midi2.UmpProtocolDownscalerMidiTransform.cpp
@@ -254,16 +254,26 @@ CMidi2UmpProtocolDownscalerMidiTransform::SendMidiMessage(
     LONGLONG timestamp
 )
 {
-    //TraceLoggingWrite(
-    //    MidiUmpProtocolDownscalerTransformTelemetryProvider::Provider(),
-    //    MIDI_TRACE_EVENT_INFO,
-    //    TraceLoggingString(__FUNCTION__, MIDI_TRACE_EVENT_LOCATION_FIELD),
-    //    TraceLoggingLevel(WINEVENT_LEVEL_INFO),
-    //    TraceLoggingPointer(this, "this")
-    //);
-
     // only 1 message may be downscaled at a time
     auto lock = m_SendLock.lock();
+
+#ifdef _DEBUG
+    // Debug builds only. Logging message data in a shipping binary is a privacy violation.
+    TraceLoggingWrite(
+        MidiUmpProtocolDownscalerTransformTelemetryProvider::Provider(),
+        MIDI_TRACE_EVENT_VERBOSE,
+        TraceLoggingString(__FUNCTION__, MIDI_TRACE_EVENT_LOCATION_FIELD),
+        TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE),
+        TraceLoggingPointer(this, "this"),
+        TraceLoggingWideString(L"Downscaler input", MIDI_TRACE_EVENT_MESSAGE_FIELD),
+        TraceLoggingWideString(m_Device.c_str(), MIDI_TRACE_EVENT_DEVICE_SWD_ID_FIELD),
+        TraceLoggingHexUInt32Array(static_cast<uint32_t*>(inputData), static_cast<uint16_t>(length / sizeof(uint32_t)), "input words"),
+        TraceLoggingUInt32(length, "input length bytes"),
+        TraceLoggingBool(m_downscalingRequiredForEndpoint, "downscaling required"),
+        TraceLoggingBool(m_upscalingRequiredForEndpoint, "upscaling required"),
+        TraceLoggingUInt64(static_cast<uint64_t>(timestamp), MIDI_TRACE_EVENT_MESSAGE_TIMESTAMP_FIELD)
+    );
+#endif
 
     // if downscaling and upscaling aren't required, quickly move on
     if (!m_downscalingRequiredForEndpoint && !m_upscalingRequiredForEndpoint)
@@ -308,6 +318,22 @@ CMidi2UmpProtocolDownscalerMidiTransform::SendMidiMessage(
             }
 
         }
+
+#ifdef _DEBUG
+        // Debug builds only. Logging message data in a shipping binary is a privacy violation.
+        TraceLoggingWrite(
+            MidiUmpProtocolDownscalerTransformTelemetryProvider::Provider(),
+            MIDI_TRACE_EVENT_VERBOSE,
+            TraceLoggingString(__FUNCTION__, MIDI_TRACE_EVENT_LOCATION_FIELD),
+            TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE),
+            TraceLoggingPointer(this, "this"),
+            TraceLoggingWideString(L"Downscaler output", MIDI_TRACE_EVENT_MESSAGE_FIELD),
+            TraceLoggingWideString(m_Device.c_str(), MIDI_TRACE_EVENT_DEVICE_SWD_ID_FIELD),
+            TraceLoggingHexUInt32Array(translatedWords.data(), static_cast<uint16_t>(translatedWords.size()), "output words"),
+            TraceLoggingUInt32(static_cast<uint32_t>(translatedWords.size()), "output word count"),
+            TraceLoggingUInt64(static_cast<uint64_t>(timestamp), MIDI_TRACE_EVENT_MESSAGE_TIMESTAMP_FIELD)
+        );
+#endif
 
         // send all the translated or copied messages
         RETURN_IF_FAILED(m_Callback->Callback(

--- a/src/user-tools/midi-console/Midi/Commands/Endpoint/EndpointMonitorCommand.cs
+++ b/src/user-tools/midi-console/Midi/Commands/Endpoint/EndpointMonitorCommand.cs
@@ -427,7 +427,6 @@ namespace Microsoft.Midi.ConsoleApp
                             }
                             lastMessageTimestamp = e.Timestamp;
 
-
                             receivedMessage.NumWords = e.FillWords(
                                 out receivedMessage.Word0,
                                 out receivedMessage.Word1,

--- a/src/user-tools/midi-console/Midi/CustomTable/MidiMessageTable.cs
+++ b/src/user-tools/midi-console/Midi/CustomTable/MidiMessageTable.cs
@@ -228,6 +228,7 @@ namespace Microsoft.Midi.ConsoleApp
             string word2 = string.Empty;
             string word3 = string.Empty;
 
+
             word0 = string.Format("{0:X8}", message.Word0);
 
 


### PR DESCRIPTION
## Feature_Servicing_MIDI2USBSystemRealTimeUmpSize

**Bug.** `USBMIDI1ToUMP` in Device.cpp emits two words instead of one for every single-byte System Real-Time and System Common message received from a USB MIDI 1.0 device. A `0xF8` clock arrives as CIN `0xF`, gets remapped to `MIDI_CIN_SYSEX_END_1BYTE`, and that case's System Common branch correctly sets `UMP_MT_SYSTEM` — message type 1, one word — but then does `goto COMPLETE_1BYTE`, a tail shared with the SysEx7 End path which hardcodes `wordCount = 2`. That is right for `UMP_MT_DATA_64` (message type 3) and wrong here. The caller computes `ByteCount = wordCount * sizeof(UINT32)`, so the driver publishes 8 bytes, and the tail's zero-fill loop makes the extra word `0x00000000`. UMP clients therefore receive every clock, start, continue, stop, active sensing, reset, tune request and undefined `F4`/`F5`/`F9`/`FD` as the real message followed by a spurious NOOP — doubling message counts and callback rate on clock-heavy streams, which run at 24 ppqn. MIDI 1.0 and WinMM clients are unaffected because `umpToMidi1::UMPStreamParse` emits no bytes for message type 0, which is exactly why this presented as an SDK or service defect rather than a driver one. Observed with a Korg nanoKEY, where MIDI Console showed a `0x00000000` after every `0x10F80000`. The 2-byte and 3-byte System Common cases (`F1`/`F2`/`F3`) already set `wordCount = 1` and are unaffected, as is the native UMP receive path.

**Solution.** The System Common branch now sets `wordCount = 1`, explicitly zeroes payload bytes 2–3, and breaks rather than jumping into the SysEx7 tail. When the feature is disabled the original `goto COMPLETE_1BYTE` is taken, with `firstByte`/`lastByte` still assigned on that path, so rollback restores the previous two-word behaviour exactly. Note that the rollback direction reintroduces the defect; that is acceptable here because the impact is an extra benign message rather than data loss or corruption. Delete the `goto`, the `COMPLETE_1BYTE` label's second entry point, and the branch when the KIR is retired.

**Validation.** Diagnosed from an ETL capture with new `_DEBUG`-only buffer traces added to both sides of the `CMidiXProc` shared ring and to `MidiEndpointConnection::Callback`. Across 252 clock messages, `ByteCount` was 8 with payload `0x10F80000 0x00000000` at the *first* read out of the driver's cyclic buffer in midisrv, and byte-identical at every downstream stage — device pipe, client pipe, ring write, client-side ring read, and the SDK callback — which exonerated the service and SDK entirely and located the defect upstream of all of them. UMP Stream messages in the same trace were correctly sized at 16 bytes, confirming the driver's `ByteCount` is right for four-word messages. **By inspection only beyond that point**: the driver has not been built or run with the fix, and SysEx7 single-packet and multi-packet paths, which share the modified `case`, have not been re-tested. Both are worth follow-ups, along with unit coverage for `USBMIDI1ToUMP` — it is a pure function over a 4-byte input and is trivially testable.