### PR TITLE
Fix garbage message coming from uninitialized conversion code

### DIFF
--- a/build/vcpkg-overlay-ports/.gitattributes
+++ b/build/vcpkg-overlay-ports/.gitattributes
@@ -1,0 +1,2 @@
+# Patch context must match the upstream sources, which are LF.
+*.patch text eol=lf

--- a/build/vcpkg-overlay-ports/libmidi2/fix-uninitialized-running-status.patch
+++ b/build/vcpkg-overlay-ports/libmidi2/fix-uninitialized-running-status.patch
@@ -1,0 +1,28 @@
+Initialize the running status bytes d0 and d1.
+
+Neither is initialized by the constructor (clearAll() only touches the bank and RPN
+arrays) and resetBuffer() assigns d1 but never d0. A converter with automatic or
+dynamic storage therefore starts with indeterminate values, and the first data byte
+received before any status byte is turned into a fabricated MIDI 1.0 Channel Voice
+message built from that uninitialized memory.
+
+d1 = 255 is the library's own "no pending data byte" sentinel and d0 = 0 its "no
+running status" state, so this just gives them the values the rest of the parser
+already assumes.
+
+Upstream: https://github.com/midi2-dev/AM_MIDI2.0Lib
+
+diff --git a/include/bytestreamToUMP.h b/include/bytestreamToUMP.h
+--- a/include/bytestreamToUMP.h
++++ b/include/bytestreamToUMP.h
+@@ -29,8 +29,8 @@
+ class bytestreamToUMP{
+ 
+ 	private:
+-		uint8_t d0;
+-		uint8_t d1;
++		uint8_t d0 = 0;
++		uint8_t d1 = 255;
+ 		
+ 		uint8_t sysex7State = 0;
+ 		uint8_t sysex7Pos = 0;

--- a/build/vcpkg-overlay-ports/libmidi2/portfile.cmake
+++ b/build/vcpkg-overlay-ports/libmidi2/portfile.cmake
@@ -1,0 +1,24 @@
+# Overlay of the upstream libmidi2 port. Identical to the registry port except for the
+# patch below. Delete this overlay once the upstream fix ships in a released version.
+
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO midi2-dev/AM_MIDI2.0Lib
+    REF "v${VERSION}"
+    SHA512 867968c6a9a1c7ae31f685fc833df79860d6989e39ba1e76ee6848e2f9e49dc4af6b49a85000b643aa77afeb5b99dbc2e29f769dc7709f0e20ccdcfd7dc3acca
+    HEAD_REF main
+    PATCHES
+        fix-uninitialized-running-status.patch
+)
+
+if(VCPKG_TARGET_IS_WINDOWS)
+    vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
+endif()
+
+vcpkg_cmake_configure(SOURCE_PATH "${SOURCE_PATH}")
+vcpkg_cmake_install()
+vcpkg_cmake_config_fixup()
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/build/vcpkg-overlay-ports/libmidi2/vcpkg.json
+++ b/build/vcpkg-overlay-ports/libmidi2/vcpkg.json
@@ -1,0 +1,18 @@
+{
+  "name": "libmidi2",
+  "version": "0.16",
+  "port-version": 1,
+  "description": "General purpose Midi 2 library for bytestream conversions and midi-ci",
+  "homepage": "https://github.com/midi2-dev/AM_MIDI2.0Lib",
+  "license": "MIT",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
+}

--- a/src/api/Client/WinRT/user-tools/mididiag/mididiag_main.cpp
+++ b/src/api/Client/WinRT/user-tools/mididiag/mididiag_main.cpp
@@ -1488,7 +1488,8 @@ bool DoSectionSystemInfo(_In_ bool verbose)
 #include "Feature_Servicing_MIDI2KSOutputWriteHang.h"
 #include "Feature_Servicing_MIDI2KSAWatcherHardening.h"
 #include "Feature_Servicing_MIDI2PortNumberCache.h"
-
+#include "Feature_Servicing_MIDI2USBSystemRealTimeUmpSize.h"
+#include "Feature_Servicing_MIDI2BsToUMPConvDisallowNOOPs.h"
 
 void OutputSingleFeatureEnablement(_In_ bool enabled, _In_ std::wstring const& featureName)
 {
@@ -1532,10 +1533,11 @@ bool DoSectionFeatureEnablement(_In_ bool verbose)
     OutputSingleFeatureEnablement(Feature_Servicing_MIDI2KSOutputWriteHang::IsEnabled(),        L"MIDI2KSOutputWriteHang (fix for declared midi out when none present)");
     OutputSingleFeatureEnablement(Feature_Servicing_MIDI2KSAWatcherHardening::IsEnabled(),      L"MIDI2KSAWatcherHardening (fix for MONTAGE M / MODX usb port move)");
     OutputSingleFeatureEnablement(Feature_Servicing_MIDI2PortNumberCache::IsEnabled(),          L"MIDI2PortNumberCache (greatly speeds up service startup)");
+    OutputSingleFeatureEnablement(Feature_Servicing_MIDI2USBSystemRealTimeUmpSize::IsEnabled(), L"MIDI2USBSystemRealTimeUmpSize (fix timing clock coming in as NOOP on MIDI2 driver)");
+    OutputSingleFeatureEnablement(Feature_Servicing_MIDI2BsToUMPConvDisallowNOOPs::IsEnabled(), L"MIDI2BsToUMPConvDisallowNOOPs (ensure over-stated MIDI 1 packet size doesn't result in trailing NOOPs)");
 
     
-        
-        
+    
         
 
     return true;

--- a/src/api/Directory.Build.props
+++ b/src/api/Directory.Build.props
@@ -1,0 +1,11 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project>
+
+  <!-- Points every vcpkg manifest project under src/api at the patched libmidi2 port.
+       Remove the overlay and this property once the upstream fix for the uninitialized
+       bytestreamToUMP running status bytes reaches the vcpkg registry. -->
+  <PropertyGroup>
+    <VcpkgAdditionalInstallOptions>$(VcpkgAdditionalInstallOptions) --overlay-ports="$(MSBuildThisFileDirectory)..\..\build\vcpkg-overlay-ports"</VcpkgAdditionalInstallOptions>
+  </PropertyGroup>
+
+</Project>

--- a/src/api/Inc/Feature_Servicing_MIDI2BsToUMPConvDisallowNOOPs.h
+++ b/src/api/Inc/Feature_Servicing_MIDI2BsToUMPConvDisallowNOOPs.h
@@ -1,0 +1,18 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License
+// ============================================================================
+// This is part of the Windows MIDI Services App API and should be used
+// in your Windows application via an official binary distribution.
+// Further information: https://aka.ms/midi
+// ============================================================================
+
+#pragma once
+
+class Feature_Servicing_MIDI2BsToUMPConvDisallowNOOPs
+{
+public:
+    static bool IsEnabled()
+    {
+        return true;
+    }
+};

--- a/src/api/Test/Midi2.Transform.unittests/MidiBSToUMPTransformTests.cpp
+++ b/src/api/Test/Midi2.Transform.unittests/MidiBSToUMPTransformTests.cpp
@@ -63,25 +63,29 @@ void MidiBSToUMPTransformTests::InternalTestBytes(
             {
                 countWordsCreated++;
 
-                if (countWordsCreated > expectedWords.size())
+                std::cout
+                    << std::dec << std::setw(3) << countWordsCreated
+                    << ", Received: " << std::setfill('0') << std::setw(8) << std::hex << receivedWords[i];
+
+                if (expectedWordsIndex < expectedWords.size())
                 {
-                    std::cout << "More words created than expected" << std::endl;
-                    VERIFY_FAIL();
+
+                    std::cout 
+                        << ", Expected: " << std::setfill('0') << std::setw(8) << std::hex << expectedWords[expectedWordsIndex];
                 }
                 else
                 {
-                    std::cout
-                        << std::dec << std::setw(3) << countWordsCreated
-                        << ", Received: " << std::setfill('0') << std::setw(8) << std::hex << receivedWords[i]
-                        << ", Expected: " << std::setfill('0') << std::setw(8) << std::hex << expectedWords[expectedWordsIndex]
-                        << std::endl;
-
-                    VERIFY_ARE_EQUAL(expectedWords[expectedWordsIndex], receivedWords[i]);
-
-                    expectedWordsIndex++;
+                    std::cout << ", Expected: <none>";
                 }
+
+                std::cout << std::endl;
+
+                VERIFY_ARE_EQUAL(expectedWords[expectedWordsIndex], receivedWords[i]);
+
+                expectedWordsIndex++;
             }
 
+            VERIFY_ARE_EQUAL(expectedWords.size(), countWordsCreated);
 
             std::cout << std::endl;
 
@@ -221,6 +225,7 @@ void MidiBSToUMPTransformTests::TestTimingClock()
 
     InternalTestBytes(groupIndex, bytes, _countof(bytes), expectedWords);
 }
+
 
 void MidiBSToUMPTransformTests::TestTimingClockPadded()
 {

--- a/src/api/Transform/ByteStreamToUMP/Midi2.BS2UMPMidiTransform.cpp
+++ b/src/api/Transform/ByteStreamToUMP/Midi2.BS2UMPMidiTransform.cpp
@@ -7,6 +7,7 @@
 #pragma warning(pop)
 #include "midi2.BS2UMPtransform.h"
 #include <Feature_Servicing_MIDI2BsToUMPConv.h>
+#include <Feature_Servicing_MIDI2BsToUMPConvDisallowNOOPs.h>
 
 _Use_decl_annotations_
 HRESULT
@@ -110,6 +111,10 @@ CMidi2BS2UMPMidiTransform::SendMidiMessage(
         m_BS2UMP.enableRunningStatus = (optionFlags & MessageOptionFlags_HasRunningStatus);
     }
 
+    // Words remaining in the multi-word message currently being copied out of the converter.
+    // Only a message's first word can identify a NOOP.
+    uint8_t remainingMessageWords{ 0 };
+
     for (UINT i = 0; i < length; i++)
     {
         // Send the bytestream byte(s) to the parser. The way the parser works, we need
@@ -128,7 +133,30 @@ CMidi2BS2UMPMidiTransform::SendMidiMessage(
         // retrieve the UMP(s) from the parser and add to the outgoing message
         while (m_BS2UMP.availableUMP())
         {
-            translatedWords.push_back(m_BS2UMP.readUMP());
+            auto word = m_BS2UMP.readUMP();
+
+            if (Feature_Servicing_MIDI2BsToUMPConvDisallowNOOPs::IsEnabled())
+            {
+                if (remainingMessageWords == 0)
+                {
+                    // Drop only a whole message type 0 status 0. Later words of a multi-word
+                    // message are payload and are legitimately zero, for example the second
+                    // word of a SysEx7 carrying two or fewer data bytes.
+                    if (internal::GetUmpMessageTypeFromFirstWord(word) == 0 && MIDIWORDNIBBLE3(word) == 0)
+                    {
+                        continue;
+                    }
+
+                    remainingMessageWords = internal::GetUmpLengthInMidiWordsFromFirstWord(word);
+                }
+
+                if (remainingMessageWords > 0)
+                {
+                    remainingMessageWords--;
+                }
+            }
+
+            translatedWords.push_back(word);
         }
     }
 

--- a/src/user-tools/midi-console/Midi/Commands/Endpoint/EndpointMonitorCommand.cs
+++ b/src/user-tools/midi-console/Midi/Commands/Endpoint/EndpointMonitorCommand.cs
@@ -107,6 +107,11 @@ namespace Microsoft.Midi.ConsoleApp
             [DefaultValue(false)]
             public bool IncludeRealTimeMessages { get; set; }
 
+            [LocalizedDescription("ParameterMonitorEndpointIncludeUtilityMessages")]
+            [CommandOption("-u|--include-utility-messages")]
+            [DefaultValue(true)]
+            public bool IncludeUtilityMessages { get; set; }
+
 
 
 
@@ -311,6 +316,10 @@ namespace Microsoft.Midi.ConsoleApp
                 UInt64 lastMessageReceivedEventTimestamp = 0;
                 UInt32 countMessagesReceived = 0;
 
+                // Tallied before display filtering, so these remain accurate when the messages are hidden.
+                UInt32 countTimingClockMessages = 0;
+                UInt32 countNoopMessages = 0;
+
                 UInt64 maxDeltaBetweenMessages = UInt64.MinValue;
                 UInt64 minDeltaBetweenMessages = UInt64.MaxValue;
                 UInt64 totalDeltaBetweenMessages = 0;
@@ -351,6 +360,21 @@ namespace Microsoft.Midi.ConsoleApp
 
                         connection.MessageReceived += (s, e) =>
                         {
+                            if (e.MessageType == MidiMessageType.SystemCommon32)
+                            {
+                                if (MidiMessageHelper.GetStatusFromSystemCommonMessage(e.PeekFirstWord()) == 0xF8)
+                                {
+                                    countTimingClockMessages++;
+                                }
+                            }
+                            else if (e.MessageType == MidiMessageType.UtilityMessage32)
+                            {
+                                if (MidiMessageHelper.GetStatusFromUtilityMessage(e.PeekFirstWord()) == 0x0)
+                                {
+                                    countNoopMessages++;
+                                }
+                            }
+
                             if (!settings.IncludeRealTimeMessages && e.MessageType == MidiMessageType.SystemCommon32)
                             {
                                 var status = MidiMessageHelper.GetStatusFromSystemCommonMessage(e.PeekFirstWord());
@@ -362,12 +386,10 @@ namespace Microsoft.Midi.ConsoleApp
                                     return;
                             }
 
-
-                            //if (!settings.IncludeRealTimeMessages &&  e.MessageType == MidiMessageType.UtilityMessage32)
-                            //{
-                            //    // TODO: filter out JR Clock etc
-                            //}
-
+                            if (!settings.IncludeUtilityMessages && e.MessageType == MidiMessageType.UtilityMessage32)
+                            {
+                                return;
+                            }
 
                             countMessagesReceived++;
 
@@ -666,6 +688,48 @@ namespace Microsoft.Midi.ConsoleApp
                     }
 
                     AnsiConsole.MarkupLine(message);
+                }
+
+                if (countTimingClockMessages > 0)
+                {
+                    string message = "➡️ [steelblue1]";
+
+                    if (countTimingClockMessages == 1)
+                    {
+                        message += "One Timing Clock message received";
+                    }
+                    else
+                    {
+                        message += $"{countTimingClockMessages.ToString("N0")} Timing Clock messages received";
+                    }
+                    if (!settings.IncludeRealTimeMessages)
+                    {
+                        message += " (hidden)";
+                    }
+                    message += "[/]";
+
+                    AnsiConsole.MarkupLine(message);
+                }
+
+                if (countNoopMessages > 0)
+                {
+                    string message = "❎ ";
+
+                    if (countNoopMessages == 1)
+                    {
+                        message += "One NOOP message received";
+                    }
+                    else
+                    {
+                        message += $"{countNoopMessages.ToString("N0")} NOOP messages received";
+                    }
+                    if (!settings.IncludeUtilityMessages)
+                    {
+                        message += " (hidden)";
+                    }
+                    message += ". NOOP is valid, but receiving them usually indicates a bug in an upstream component.";
+
+                    AnsiConsole.MarkupLine(AnsiMarkupFormatter.FormatError(message));
                 }
 
                 if (countMessagesReceived > 1)

--- a/src/user-tools/midi-console/Midi/Resources/Strings.Designer.cs
+++ b/src/user-tools/midi-console/Midi/Resources/Strings.Designer.cs
@@ -914,7 +914,7 @@ namespace Microsoft.Midi.ConsoleApp.Resources {
                 return ResourceManager.GetString("GenericTotal", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Association Id.
         /// </summary>
@@ -1287,6 +1287,42 @@ namespace Microsoft.Midi.ConsoleApp.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Unique name to use for the newly created UMP endpoint.
+        /// </summary>
+        internal static string ParameterBridgeEndpointsNewEndpointName {
+            get {
+                return ResourceManager.GetString("ParameterBridgeEndpointsNewEndpointName", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Reduce the amount of information displayed while the bridge is running.
+        /// </summary>
+        internal static string ParameterBridgeEndpointsQuiet {
+            get {
+                return ResourceManager.GetString("ParameterBridgeEndpointsQuiet", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The WinRT MIDI 1.0 input port id of the Bluetooth LE device to bridge from.
+        /// </summary>
+        internal static string ParameterBridgeEndpointsWinRTBleInputPortId {
+            get {
+                return ResourceManager.GetString("ParameterBridgeEndpointsWinRTBleInputPortId", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The WinRT MIDI 1.0 output port id of the Bluetooth LE device to bridge from. This must be on the same device as the input port.
+        /// </summary>
+        internal static string ParameterBridgeEndpointsWinRTBleOutputPortId {
+            get {
+                return ResourceManager.GetString("ParameterBridgeEndpointsWinRTBleOutputPortId", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to True to annotate messages written to the file. Annotations begin with the # sign and are written on the line before the UMP data line. The annotation includes timestamp information as well as the specific message type..
         /// </summary>
         internal static string ParameterCaptureMessagesAnnotate {
@@ -1431,6 +1467,15 @@ namespace Microsoft.Midi.ConsoleApp.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Path and filename of the report file to create. The file must not already exist.
+        /// </summary>
+        internal static string ParameterDiagnosticsReportOutputFile {
+            get {
+                return ResourceManager.GetString("ParameterDiagnosticsReportOutputFile", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Include the list of possible MIDI 1.0 port names generated on endpoint creation or customization..
         /// </summary>
         internal static string ParameterEndpointPropertiesIncludeNameTable {
@@ -1539,6 +1584,24 @@ namespace Microsoft.Midi.ConsoleApp.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Include sessions which currently have no open connections.
+        /// </summary>
+        internal static string ParameterEnumSessionsIncludeAll {
+            get {
+                return ResourceManager.GetString("ParameterEnumSessionsIncludeAll", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Include additional details for each transport, such as the transport id, image file name, and creation capabilities.
+        /// </summary>
+        internal static string ParameterEnumTransportsVerbose {
+            get {
+                return ResourceManager.GetString("ParameterEnumTransportsVerbose", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to (not yet implemented).
         /// </summary>
         internal static string ParameterListenerMessagesFilter {
@@ -1629,7 +1692,7 @@ namespace Microsoft.Midi.ConsoleApp.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Include frequent/noisy messages like Clock pulse and Active Sense.
+        ///   Looks up a localized string similar to Include frequent/noisy system real-time messages like Clock pulse and Active Sense. Other real-time messages are included regardless of this setting..
         /// </summary>
         internal static string ParameterMonitorEndpointIncludeRealTimeMessages {
             get {
@@ -1643,6 +1706,15 @@ namespace Microsoft.Midi.ConsoleApp.Resources {
         internal static string ParameterMonitorEndpointIncludeTimestamp {
             get {
                 return ResourceManager.GetString("ParameterMonitorEndpointIncludeTimestamp", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Include Type 0 utility messages, like NOOP.
+        /// </summary>
+        internal static string ParameterMonitorEndpointIncludeUtilityMessages {
+            get {
+                return ResourceManager.GetString("ParameterMonitorEndpointIncludeUtilityMessages", resourceCulture);
             }
         }
         
@@ -2104,73 +2176,7 @@ namespace Microsoft.Midi.ConsoleApp.Resources {
                 return ResourceManager.GetString("ParameterServiceRestart", resourceCulture);
             }
         }
-
-        /// <summary>
-        ///   Looks up a localized string similar to Include sessions which currently have no open connections.
-        /// </summary>
-        internal static string ParameterEnumSessionsIncludeAll {
-            get {
-                return ResourceManager.GetString("ParameterEnumSessionsIncludeAll", resourceCulture);
-            }
-        }
-
-        /// <summary>
-        ///   Looks up a localized string similar to Include additional details for each transport, such as the transport id, image file name, and creation capabilities.
-        /// </summary>
-        internal static string ParameterEnumTransportsVerbose {
-            get {
-                return ResourceManager.GetString("ParameterEnumTransportsVerbose", resourceCulture);
-            }
-        }
-
-        /// <summary>
-        ///   Looks up a localized string similar to The WinRT MIDI 1.0 input port id of the Bluetooth LE device to bridge from.
-        /// </summary>
-        internal static string ParameterBridgeEndpointsWinRTBleInputPortId {
-            get {
-                return ResourceManager.GetString("ParameterBridgeEndpointsWinRTBleInputPortId", resourceCulture);
-            }
-        }
-
-        /// <summary>
-        ///   Looks up a localized string similar to The WinRT MIDI 1.0 output port id of the Bluetooth LE device to bridge from. This must be on the same device as the input port.
-        /// </summary>
-        internal static string ParameterBridgeEndpointsWinRTBleOutputPortId {
-            get {
-                return ResourceManager.GetString("ParameterBridgeEndpointsWinRTBleOutputPortId", resourceCulture);
-            }
-        }
-
-        /// <summary>
-        ///   Looks up a localized string similar to Unique name to use for the newly created UMP endpoint.
-        /// </summary>
-        internal static string ParameterBridgeEndpointsNewEndpointName {
-            get {
-                return ResourceManager.GetString("ParameterBridgeEndpointsNewEndpointName", resourceCulture);
-            }
-        }
-
-        /// <summary>
-        ///   Looks up a localized string similar to Reduce the amount of information displayed while the bridge is running.
-        /// </summary>
-        internal static string ParameterBridgeEndpointsQuiet {
-            get {
-                return ResourceManager.GetString("ParameterBridgeEndpointsQuiet", resourceCulture);
-            }
-        }
-
-        /// <summary>
-        ///   Looks up a localized string similar to Path and filename of the report file to create. The file must not already exist.
-        /// </summary>
-        internal static string ParameterDiagnosticsReportOutputFile {
-            get {
-                return ResourceManager.GetString("ParameterDiagnosticsReportOutputFile", resourceCulture);
-            }
-        }
-
-
-
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Report additional details about the service.
         /// </summary>

--- a/src/user-tools/midi-console/Midi/Resources/Strings.resx
+++ b/src/user-tools/midi-console/Midi/Resources/Strings.resx
@@ -1113,7 +1113,7 @@ Timestamp</value>
     <value>Include the timestamp in the displayed output</value>
   </data>
   <data name="ParameterMonitorEndpointIncludeRealTimeMessages" xml:space="preserve">
-    <value>Include frequent/noisy messages like Clock pulse and Active Sense</value>
+    <value>Include frequent/noisy system real-time messages like Clock pulse and Active Sense. Other real-time messages are included regardless of this setting.</value>
   </data>
   <data name="ParameterCreateLoopbackAssociationId" xml:space="preserve">
     <value>Id (must be a valid GUID) used to associate the two endpoints. Also used when removing the loopback pair.</value>
@@ -1279,5 +1279,8 @@ These endpoints will disappear when the service or PC is restarted. To create pe
   </data>
   <data name="CommandWatchPortsDescription" xml:space="preserve">
     <value>Watch MIDI 1.0 ports for add/remove and PnP property change notifications</value>
+  </data>
+  <data name="ParameterMonitorEndpointIncludeUtilityMessages" xml:space="preserve">
+    <value>Include Type 0 utility messages, like NOOP</value>
   </data>
 </root>


### PR DESCRIPTION
This pull request introduces a fix for uninitialized running status bytes in the `libmidi2` dependency by overlaying a patched port, and adds new diagnostics and filtering capabilities for MIDI Utility (NOOP) messages throughout the codebase. It also improves test coverage and user feedback for these changes, and updates localization resources for new command-line options.

**Dependency and Patch Management:**

* Adds a vcpkg overlay port for `libmidi2` with a patch (`fix-uninitialized-running-status.patch`) to initialize running status bytes, preventing fabricated MIDI messages from uninitialized memory. This overlay is referenced in the build props and should be removed once the fix is upstreamed. [[1]](diffhunk://#diff-e7b7ad4a17121053bca186fce9779cadbcecc21e2d5255df7afcb359cc78762dR1-R2) [[2]](diffhunk://#diff-78e4e662cb38efe20c78ea63a37ce0ba408fbc227a579547c008c0538abbaa40R1-R28) [[3]](diffhunk://#diff-4fde30973cce2b561a73448265515596f3ce26bf1696a53877effd05e5eb0433R1-R24) [[4]](diffhunk://#diff-6f7b2ce3745adf345ba592ea64a73b7b2c86a579121301e11eed5d342c59acf0R1-R18) [[5]](diffhunk://#diff-794aaaaed01446d80cec251379644347e1b4de6815a53e70ac330699b6fc2a6eR1-R11)

**NOOP Message Filtering and Diagnostics:**

* Implements a new feature flag (`Feature_Servicing_MIDI2BsToUMPConvDisallowNOOPs`) and logic in `CMidi2BS2UMPMidiTransform::SendMidiMessage` to filter out fabricated NOOP messages resulting from overstated MIDI 1 packet sizes, addressing a common upstream bug. [[1]](diffhunk://#diff-8e5e70737dea9da8482b05c54bc1c91d76d003380e07724e0b1c5697aec9aa12R1-R18) [[2]](diffhunk://#diff-c149b18179854c2c1db2174bef3a111b5e6df05fa6e9b80b68f531d74fbecda2R10) [[3]](diffhunk://#diff-c149b18179854c2c1db2174bef3a111b5e6df05fa6e9b80b68f531d74fbecda2R114-R117) [[4]](diffhunk://#diff-c149b18179854c2c1db2174bef3a111b5e6df05fa6e9b80b68f531d74fbecda2L131-R159) [[5]](diffhunk://#diff-0d21c24c94b71ff41ffd5f175e912eba59bfd13543f5886652e0a667d53830ffL1491-R1492) [[6]](diffhunk://#diff-0d21c24c94b71ff41ffd5f175e912eba59bfd13543f5886652e0a667d53830ffL1535-R1537)
* Updates the `midi-console` endpoint monitor command to add a user option for including/excluding Utility (NOOP) messages, tallies and reports the number of NOOP and Timing Clock messages received, and provides clearer feedback when these are hidden or detected. [[1]](diffhunk://#diff-4a124db32228fe391386f6557191d0f31e79024bbb45366fd76bc2183849f64aR110-R114) [[2]](diffhunk://#diff-4a124db32228fe391386f6557191d0f31e79024bbb45366fd76bc2183849f64aR319-R322) [[3]](diffhunk://#diff-4a124db32228fe391386f6557191d0f31e79024bbb45366fd76bc2183849f64aR363-R377) [[4]](diffhunk://#diff-4a124db32228fe391386f6557191d0f31e79024bbb45366fd76bc2183849f64aL365-R392) [[5]](diffhunk://#diff-4a124db32228fe391386f6557191d0f31e79024bbb45366fd76bc2183849f64aR693-R734)

**Testing and Diagnostics Improvements:**

* Enhances unit tests for byte stream to UMP transformation to provide clearer output and stricter verification of expected vs. received words, supporting the new NOOP filtering logic. [[1]](diffhunk://#diff-e0562f085ab218bfb8b4585294442c7527d5685db00aadbbd1a0680ea72b49ebL66-R88) [[2]](diffhunk://#diff-e0562f085ab218bfb8b4585294442c7527d5685db00aadbbd1a0680ea72b49ebR229)

**Localization and User Interface:**

* Adds and updates localized resource strings for new command-line options and improved descriptions for real-time and utility message filtering in the `midi-console` tool. [[1]](diffhunk://#diff-20a3a0d1bf9a151d723f25d58fcb80b2c7bdedefdd927d690947351cfef80b71R1289-R1324) [[2]](diffhunk://#diff-20a3a0d1bf9a151d723f25d58fcb80b2c7bdedefdd927d690947351cfef80b71R1469-R1477) [[3]](diffhunk://#diff-20a3a0d1bf9a151d723f25d58fcb80b2c7bdedefdd927d690947351cfef80b71R1586-R1603) [[4]](diffhunk://#diff-20a3a0d1bf9a151d723f25d58fcb80b2c7bdedefdd927d690947351cfef80b71L1632-R1695)Includes libMIDI2 overlay port related to https://github.com/midi2-dev/AM_MIDI2.0Lib/issues/39