### PR TITLE
IsMuted support

### DIFF
--- a/src/api/Client/WinRT/t/core/MidiEndpointDeviceInformationUpdatedEventArgs.cpp
+++ b/src/api/Client/WinRT/t/core/MidiEndpointDeviceInformationUpdatedEventArgs.cpp
@@ -26,7 +26,8 @@ namespace winrt::Windows::Devices::Midi2::Enumeration::implementation
         bool const updatedUserMetadata,
         bool const updatedAdditionalCapabilities,
         bool const updatedUniqueIds,
-        bool const updatedGroupTerminalBlocks
+        bool const updatedGroupTerminalBlocks,
+        bool const updatedMutedState
     ) noexcept
     {
 
@@ -44,6 +45,8 @@ namespace winrt::Windows::Devices::Midi2::Enumeration::implementation
         m_updatedUniqueIds = updatedUniqueIds;
 
         m_updatedGroupTerminalBlocks = updatedGroupTerminalBlocks;
+
+        m_updatedMutedState = updatedMutedState;
     }
 
 }

--- a/src/api/Client/WinRT/t/core/MidiEndpointDeviceInformationUpdatedEventArgs.h
+++ b/src/api/Client/WinRT/t/core/MidiEndpointDeviceInformationUpdatedEventArgs.h
@@ -29,6 +29,8 @@ namespace winrt::Windows::Devices::Midi2::Enumeration::implementation
 
         bool AreGroupTerminalBlocksUpdated() const noexcept { return m_updatedGroupTerminalBlocks; }
 
+        bool IsMutedStateUpdated() const noexcept { return m_updatedMutedState; }
+
         enumeration::DeviceInformationUpdate DeviceInformationUpdate() const noexcept { return m_deviceInformationUpdate; }
 
         void InternalInitialize(
@@ -42,7 +44,8 @@ namespace winrt::Windows::Devices::Midi2::Enumeration::implementation
             _In_ bool const updatedUserMetadata,
             _In_ bool const updatedAdditionalCapabilities,
             _In_ bool const updatedUniqueIds,
-            _In_ bool const updatedGroupTerminalBlocks
+            _In_ bool const updatedGroupTerminalBlocks,
+            _In_ bool const updatedMutedState
         ) noexcept;
 
     private:
@@ -56,6 +59,8 @@ namespace winrt::Windows::Devices::Midi2::Enumeration::implementation
         bool m_updatedUniqueIds{ false };
 
         bool m_updatedGroupTerminalBlocks{ false };
+
+        bool m_updatedMutedState{ false };
 
         winrt::hstring m_endpointDeviceId{};
         enumeration::DeviceInformationUpdate m_deviceInformationUpdate{ nullptr };

--- a/src/api/Client/WinRT/t/core/MidiEndpointDeviceInformationUpdatedEventArgs.idl
+++ b/src/api/Client/WinRT/t/core/MidiEndpointDeviceInformationUpdatedEventArgs.idl
@@ -32,6 +32,8 @@ namespace Windows.Devices.Midi2.Enumeration
         [noexcept] Boolean AreUniqueIdsUpdated{ get; };
         [noexcept] Boolean AreGroupTerminalBlocksUpdated{ get; };
 
+        [noexcept] Boolean IsMutedStateUpdated{ get; };
+
     }
 }
 

--- a/src/api/Client/WinRT/t/core/MidiEndpointDeviceWatcher.cpp
+++ b/src/api/Client/WinRT/t/core/MidiEndpointDeviceWatcher.cpp
@@ -248,6 +248,7 @@ namespace winrt::Windows::Devices::Midi2::Enumeration::implementation
                     bool updatedAdditionalCapabilities{ false };
                     bool updatedUniqueIds{ false };
                     bool updatedGroupTerminalBlocks{ false };
+                    bool updatedMutedState{ false };
 
 
                     if (args.Properties().HasKey(STRING_PKEY_MIDI_EndpointName) ||
@@ -332,6 +333,12 @@ namespace winrt::Windows::Devices::Midi2::Enumeration::implementation
                         updatedGroupTerminalBlocks = true;
                     }
 
+
+                    if (args.Properties().HasKey(STRING_PKEY_MIDI_IsMuted))
+                    {
+                        updatedMutedState = true;
+                    }
+
                     newArgs->InternalInitialize(
                         args.Id(),
                         args,
@@ -343,7 +350,8 @@ namespace winrt::Windows::Devices::Midi2::Enumeration::implementation
                         updatedUserMetadata,
                         updatedAdditionalCapabilities,
                         updatedUniqueIds,
-                        updatedGroupTerminalBlocks
+                        updatedGroupTerminalBlocks,
+                        updatedMutedState
                         );
 
                     m_deviceUpdatedEvent(*this, *newArgs);

--- a/src/api/Transport/LoopbackMidiTransport/Midi2.LoopbackMidiEndpointManager.cpp
+++ b/src/api/Transport/LoopbackMidiTransport/Midi2.LoopbackMidiEndpointManager.cpp
@@ -290,7 +290,6 @@ CMidi2LoopbackMidiEndpointManager::CreateSingleEndpoint(
     std::wstring transportCode(TRANSPORT_CODE);
 
     //DEVPROP_BOOLEAN devPropTrue = DEVPROP_TRUE;
-    //   DEVPROP_BOOLEAN devPropFalse = DEVPROP_FALSE;
 
     std::wstring endpointName = definition->EndpointName;
     std::wstring endpointDescription = definition->EndpointDescription;
@@ -321,6 +320,14 @@ CMidi2LoopbackMidiEndpointManager::CreateSingleEndpoint(
         DEVPROP_TYPE_STRING, (ULONG)(sizeof(wchar_t) * (definition->AssociationId.length() + 1)), (PVOID)definition->AssociationId.c_str() });
 
     // Device properties
+
+    if (Feature_Servicing_MIDI2LoopbackMuteAndList::IsEnabled())
+    {
+        DEVPROP_BOOLEAN devPropFalse = DEVPROP_FALSE;
+
+        interfaceDevProperties.push_back(DEVPROPERTY{ {PKEY_MIDI_IsMuted, DEVPROP_STORE_SYSTEM, nullptr},
+            DEVPROP_TYPE_BOOLEAN, (ULONG)(sizeof(DEVPROP_BOOLEAN)), &devPropFalse });
+    }
 
 
     SW_DEVICE_CREATE_INFO createInfo = {};


### PR DESCRIPTION
Fix missing Muted initialization for Loopbacks.

Add IsMuted to updated information for Endpoint Device Watcher.