### PR TITLE
Fix issue with yesterday's virtual endpoint connection detection and fix a send message timing inconsistency

### DIFF
--- a/src/api/Client/WinRT/NuGet/Windows.Devices.Midi2.NuGet/nuget/Windows.Devices.Midi2.nuspec
+++ b/src/api/Client/WinRT/NuGet/Windows.Devices.Midi2.NuGet/nuget/Windows.Devices.Midi2.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2012/06/nuspec.xsd">
 	<metadata>
 		<id>Windows.Devices.Midi2</id>
-		<version>0.99.53-devpreview.5</version>
+		<version>0.99.54-devpreview.5</version>
 		<authors>Microsoft</authors>
 		<description>Windows MIDI Services App SDK. Temporary package to use until the metadata is in an official Windows SDK</description>
 		<license type="expression">MIT</license>

--- a/src/api/Client/WinRT/NuGet/Windows.Devices.Midi2.NuGet/nuget/Windows.Devices.Midi2.nuspec
+++ b/src/api/Client/WinRT/NuGet/Windows.Devices.Midi2.NuGet/nuget/Windows.Devices.Midi2.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2012/06/nuspec.xsd">
 	<metadata>
 		<id>Windows.Devices.Midi2</id>
-		<version>0.99.52-devpreview.5</version>
+		<version>0.99.53-devpreview.5</version>
 		<authors>Microsoft</authors>
 		<description>Windows MIDI Services App SDK. Temporary package to use until the metadata is in an official Windows SDK</description>
 		<license type="expression">MIT</license>
@@ -17,10 +17,7 @@
         </dependencies>
     </metadata>
     
-    <files>          
-      <!-- TODO -->
-      <!-- Create a coalesce project that has x64 and Arm64x output and use that to source the files -->
-        
+    <files>                 
       <!-- Compile-time References  ================================================ -->
 
       <!-- Reference winmds -->

--- a/src/api/Client/WinRT/t/core/Windows.Devices.Midi2.vcxproj
+++ b/src/api/Client/WinRT/t/core/Windows.Devices.Midi2.vcxproj
@@ -539,11 +539,21 @@
     <ClInclude Include="MidiSystemExclusiveSendProgress.h">
       <DependentUpon>MidiSystemExclusiveSendProgress.idl</DependentUpon>
     </ClInclude>
-    <ClInclude Include="MidiNetworkConfiguredClient.h" />
-    <ClInclude Include="MidiNetworkPendingRemoteClient.h" />
-    <ClInclude Include="MidiNetworkConfiguredHost.h" />
-    <ClInclude Include="MidiNetworkRemoteClientApprovalConfig.h" />
-    <ClInclude Include="MidiNetworkRemoteClientApprovalResponse.h" />
+    <ClInclude Include="MidiNetworkConfiguredClient.h">
+      <DependentUpon>MidiNetworkConfiguredClient.idl</DependentUpon>
+    </ClInclude>
+    <ClInclude Include="MidiNetworkPendingRemoteClient.h">
+      <DependentUpon>MidiNetworkPendingRemoteClient.idl</DependentUpon>
+    </ClInclude>
+    <ClInclude Include="MidiNetworkConfiguredHost.h">
+      <DependentUpon>MidiNetworkConfiguredHost.idl</DependentUpon>
+    </ClInclude>
+    <ClInclude Include="MidiNetworkRemoteClientApprovalConfig.h">
+      <DependentUpon>MidiNetworkRemoteClientApprovalConfig.idl</DependentUpon>
+    </ClInclude>
+    <ClInclude Include="MidiNetworkRemoteClientApprovalResponse.h">
+      <DependentUpon>MidiNetworkRemoteClientApprovalResponse.idl</DependentUpon>
+    </ClInclude>
     <ClInclude Include="winrt_devpkey_util.h" />
     <ClInclude Include="MidiNetworkClientConnectResponse.h">
       <DependentUpon>MidiNetworkClientConnectResponse.idl</DependentUpon>
@@ -911,11 +921,21 @@
     <ClCompile Include="MidiNetworkHostRemovalConfig.cpp">
       <DependentUpon>MidiNetworkHostRemovalConfig.idl</DependentUpon>
     </ClCompile>
-    <ClCompile Include="MidiNetworkConfiguredClient.cpp" />
-    <ClCompile Include="MidiNetworkPendingRemoteClient.cpp" />
-    <ClCompile Include="MidiNetworkConfiguredHost.cpp" />
-    <ClCompile Include="MidiNetworkRemoteClientApprovalConfig.cpp" />
-    <ClCompile Include="MidiNetworkRemoteClientApprovalResponse.cpp" />
+    <ClCompile Include="MidiNetworkConfiguredClient.cpp">
+      <DependentUpon>MidiNetworkConfiguredClient.idl</DependentUpon>
+    </ClCompile>
+    <ClCompile Include="MidiNetworkPendingRemoteClient.cpp">
+      <DependentUpon>MidiNetworkPendingRemoteClient.idl</DependentUpon>
+    </ClCompile>
+    <ClCompile Include="MidiNetworkConfiguredHost.cpp">
+      <DependentUpon>MidiNetworkConfiguredHost.idl</DependentUpon>
+    </ClCompile>
+    <ClCompile Include="MidiNetworkRemoteClientApprovalConfig.cpp">
+      <DependentUpon>MidiNetworkRemoteClientApprovalConfig.idl</DependentUpon>
+    </ClCompile>
+    <ClCompile Include="MidiNetworkRemoteClientApprovalResponse.cpp">
+      <DependentUpon>MidiNetworkRemoteClientApprovalResponse.idl</DependentUpon>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <Midl Include="MidiApiContracts.idl" />

--- a/src/api/Client/WinRT/user-tools/mididiag/mididiag_main.cpp
+++ b/src/api/Client/WinRT/user-tools/mididiag/mididiag_main.cpp
@@ -1491,6 +1491,7 @@ bool DoSectionSystemInfo(_In_ bool verbose)
 #include "Feature_Servicing_MIDI2VirtualDeviceRemovalDeadlock.h"
 #include "Feature_Servicing_MIDI2USBSystemRealTimeUmpSize.h"
 #include "Feature_Servicing_MIDI2BsToUMPConvDisallowNOOPs.h"
+#include "Feature_Servicing_MIDI2XProcSendWaitTimeouts.h"
 
 void OutputSingleFeatureEnablement(_In_ bool enabled, _In_ std::wstring const& featureName)
 {
@@ -1537,6 +1538,7 @@ bool DoSectionFeatureEnablement(_In_ bool verbose)
     OutputSingleFeatureEnablement(Feature_Servicing_MIDI2USBSystemRealTimeUmpSize::IsEnabled(), L"MIDI2USBSystemRealTimeUmpSize (fix timing clock coming in as NOOP on MIDI2 driver)");
     OutputSingleFeatureEnablement(Feature_Servicing_MIDI2BsToUMPConvDisallowNOOPs::IsEnabled(), L"MIDI2BsToUMPConvDisallowNOOPs (ensure over-stated MIDI 1 packet size doesn't result in trailing NOOPs)");
     OutputSingleFeatureEnablement(Feature_Servicing_MIDI2VirtualDeviceRemovalDeadlock::IsEnabled(), L"MIDI2VirtualDeviceRemovalDeadlock (fix service hang when a virtual device is shut down)");
+    OutputSingleFeatureEnablement(Feature_Servicing_MIDI2XProcSendWaitTimeouts::IsEnabled(),    L"MIDI2XProcSendWaitTimeouts (stop aborting sends to devices that are slow to accept data)");
 
     
     

--- a/src/api/CollectMidiLogs/providers.wprp
+++ b/src/api/CollectMidiLogs/providers.wprp
@@ -14,6 +14,11 @@
       <BufferSize Value="256" />
       <Buffers Value="3" PercentageOfTotalMemory="true" MaximumBufferSpace="64" />
     </EventCollector>
+    <!-- USB and PnP get their own buffer budget so their volume cannot evict the MIDI events -->
+    <EventCollector Id="UsbPnpCollector" Name="UsbPnpCollector">
+      <BufferSize Value="256" />
+      <Buffers Value="3" PercentageOfTotalMemory="true" MaximumBufferSpace="128" />
+    </EventCollector>
     <SystemProvider Id="SystemProvider">
       <Keywords>
         <Keyword Value="CpuConfig" />
@@ -44,6 +49,9 @@
     <EventProvider Id="TraceLogging/Microsoft.Windows.Midi2.MidiSrv" Name="f42d2441-aac3-5216-0150-3c0f50006b64" Level="5" NonPagedMemory="false" />
     <EventProvider Id="TraceLogging/Microsoft.Windows.Midi2.MidiSrvTransport" Name="c22d26fd-947b-5df1-a0f8-bc62d26d188d" Level="5" NonPagedMemory="false" />
 
+    <!-- Cross-process pipe. This is where send stalls and dropped buffers are reported. -->
+    <EventProvider Id="TraceLogging/Microsoft.Windows.Midi2.MidiXproc" Name="159b4b38-c2b9-58bc-f3cc-dcd31ca44d21" Level="5" NonPagedMemory="false" />
+
     <EventProvider Id="TraceLogging/Microsoft.Windows.Midi2.KSTransport" Name="a8d144fe-be0c-5484-25a9-512d2f6445d5" Level="5" NonPagedMemory="false" />
     <EventProvider Id="TraceLogging/Microsoft.Windows.Midi2.KSAggregateTransport" Name="07e90998-c326-56f8-e99b-20afb12e1b4f" Level="5" NonPagedMemory="false" />
     <EventProvider Id="TraceLogging/Microsoft.Windows.Midi2.DiagnosticsTransport" Name="84856b86-fe14-51a3-96fa-b9683533d40b" Level="5" NonPagedMemory="false" />
@@ -71,6 +79,17 @@
         <Keyword Value="0x7FFFFFFF" />
       </Keywords>
     </EventProvider>
+
+    <!-- Device arrival/removal and USB stack state. Level 4 (Information) deliberately: level 5
+         on the host controller providers logs every transfer and fills the ring in seconds. -->
+    <EventProvider Id="Microsoft-Windows-Kernel-PnP" Name="9c205a39-1250-487d-abd7-e831c6290539" Level="4" NonPagedMemory="true" />
+    <EventProvider Id="Microsoft-Windows-USB-USBHUB3" Name="ac52ad17-cc01-4f85-8df5-4dce4333c99b" Level="4" NonPagedMemory="true" />
+    <EventProvider Id="Microsoft-Windows-USB-UCX" Name="36da592d-e43a-4e28-af6f-4bc57c5a11e8" Level="4" NonPagedMemory="true" />
+    <EventProvider Id="Microsoft-Windows-USB-USBXHCI" Name="30e1d284-5d88-459c-83fd-6345b39b19ec" Level="4" NonPagedMemory="true" />
+    <EventProvider Id="Microsoft-Windows-USB-USBHUB" Name="7426a56b-e2d5-4b30-bdef-b31815c1a74a" Level="4" NonPagedMemory="true" />
+    <EventProvider Id="Microsoft-Windows-USB-USBPORT" Name="c88a4ef5-d048-4013-9408-e04b7db2814a" Level="4" NonPagedMemory="true" />
+
+    <EventProvider Id="Microsoft-Windows-Audio" Name="ae4bd3be-f36f-45b6-8d21-bdd6fb832853" Level="4" NonPagedMemory="false" />
     <Profile Id="midi.Verbose.Memory" LoggingMode="Memory" Name="midi" DetailLevel="Verbose" Description="midi profile">
       <Collectors>
         <SystemCollectorId Value="SystemCollector">
@@ -80,6 +99,7 @@
           <EventProviders>
             <EventProviderId Value="TraceLogging/Microsoft.Windows.Midi2.MidiSrv" />
             <EventProviderId Value="TraceLogging/Microsoft.Windows.Midi2.MidiSrvTransport" />
+            <EventProviderId Value="TraceLogging/Microsoft.Windows.Midi2.MidiXproc" />
             <EventProviderId Value="TraceLogging/Microsoft.Windows.Midi2.KSTransport" />
             <EventProviderId Value="TraceLogging/Microsoft.Windows.Midi2.KSAggregateTransport" />
             <EventProviderId Value="TraceLogging/Microsoft.Windows.Midi2.DiagnosticsTransport" />
@@ -97,11 +117,22 @@
             <EventProviderId Value="TraceLogging/Microsoft.Midi.Console" />
             <EventProviderId Value="TraceLogging/Windows.Devices.Midi2.Api" />
             <EventProviderId Value="TraceLogging/Microsoft.Windows.Midi2.Sdk" />
+            <EventProviderId Value="Microsoft-Windows-Audio" />
           </EventProviders>
         </EventCollectorId>
         <EventCollectorId Value="NonpagedPoolCollector">
           <EventProviders>
             <EventProviderId Value="WPP/usbmidi2.sys" />
+          </EventProviders>
+        </EventCollectorId>
+        <EventCollectorId Value="UsbPnpCollector">
+          <EventProviders>
+            <EventProviderId Value="Microsoft-Windows-Kernel-PnP" />
+            <EventProviderId Value="Microsoft-Windows-USB-USBHUB3" />
+            <EventProviderId Value="Microsoft-Windows-USB-UCX" />
+            <EventProviderId Value="Microsoft-Windows-USB-USBXHCI" />
+            <EventProviderId Value="Microsoft-Windows-USB-USBHUB" />
+            <EventProviderId Value="Microsoft-Windows-USB-USBPORT" />
           </EventProviders>
         </EventCollectorId>
       </Collectors>

--- a/src/api/Inc/Feature_Servicing_MIDI2XProcSendWaitTimeouts.h
+++ b/src/api/Inc/Feature_Servicing_MIDI2XProcSendWaitTimeouts.h
@@ -1,0 +1,18 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License
+// ============================================================================
+// This is part of the Windows MIDI Services App API and should be used
+// in your Windows application via an official binary distribution.
+// Further information: https://aka.ms/midi
+// ============================================================================
+
+#pragma once
+
+class Feature_Servicing_MIDI2XProcSendWaitTimeouts
+{
+public:
+    static bool IsEnabled()
+    {
+        return true;
+    }
+};

--- a/src/api/Inc/MidiDefs.h
+++ b/src/api/Inc/MidiDefs.h
@@ -677,6 +677,12 @@ DEFINE_MIDIDEVPROPKEY(PKEY_MIDI_VirtualMidiEndpointAssociator, 905);     // DEVP
 #define STRING_PKEY_MIDI_VirtualMidiClientEndpointInUse MIDI_STRING_PKEY_GUID MIDI_STRING_PKEY_PID_SEPARATOR L"906"
 DEFINE_MIDIDEVPROPKEY(PKEY_MIDI_VirtualMidiClientEndpointInUse, 906);     // DEVPROP_TYPE_BOOLEAN
 
+// Set on a client-visible endpoint to name the endpoint that its in-use state is published to.
+// Only the service can count connected applications, and only the transport knows which two
+// endpoints are paired, so the transport records the destination here and the service writes it.
+#define STRING_PKEY_MIDI_VirtualMidiInUseReportingTarget MIDI_STRING_PKEY_GUID MIDI_STRING_PKEY_PID_SEPARATOR L"907"
+DEFINE_MIDIDEVPROPKEY(PKEY_MIDI_VirtualMidiInUseReportingTarget, 907);     // DEVPROP_TYPE_STRING
+
 #define STRING_PKEY_MIDI_NetworkMidiLastRemoteHostName MIDI_STRING_PKEY_GUID MIDI_STRING_PKEY_PID_SEPARATOR L"920"
 DEFINE_MIDIDEVPROPKEY(PKEY_MIDI_NetworkMidiLastRemoteHostName, 920);     // DEVPROP_TYPE_STRING
 

--- a/src/api/Libs/MidiXProc/MidiXProc.cpp
+++ b/src/api/Libs/MidiXProc/MidiXProc.cpp
@@ -29,6 +29,7 @@
 #include "ump_iterator.h"
 #include "Feature_Servicing_MIDI2KSOutputWriteHang.h"
 #include "Feature_Servicing_MIDI2XProcBatchedReads.h"
+#include "Feature_Servicing_MIDI2XProcSendWaitTimeouts.h"
 
 // A worker holding an IRP that a driver refuses to release can never finish terminating.
 #define MIDI_XPROC_WORKER_EXIT_TIMEOUT 10000
@@ -49,6 +50,11 @@ class MidiXProcTelemetryProvider : public wil::TraceLoggingProvider
 // timeout waiting for the messages to be received
 // waits for more than 5 seconds cause UI app hang crashes.
 #define MIDI_XPROC_BUFFER_RECEIVED_WAIT 1000
+
+// A single downstream KS write is allowed KSMidiOutDevice::WriteTimeoutBaseMilliseconds plus a
+// per-byte allowance, so the 1 second wait above gives up on sends that are still in flight to a
+// slow but healthy device. Kept below the 5 second UI hang threshold noted above.
+#define MIDI_XPROC_SEND_WAIT_TIMEOUT_EXTENDED 4000
 
 // timeout waiting for the messages to be received
 #define MIDI_XPROC_CALLBACK_RETRY_TIMEOUT 1000
@@ -333,10 +339,17 @@ CMidiXProc::WaitForSendComplete(ULONG startingReadPosition, ULONG BufferWrittenP
             }
         }
 
+        ULONG bufferReceivedWait = MIDI_XPROC_BUFFER_RECEIVED_WAIT;
+
+        if (Feature_Servicing_MIDI2XProcSendWaitTimeouts::IsEnabled())
+        {
+            bufferReceivedWait = MIDI_XPROC_SEND_WAIT_TIMEOUT_EXTENDED;
+        }
+
         do
         {
             // wait for either the other end to read the buffer, termination, or timeout with no messages read
-            DWORD ret = WaitForMultipleObjects(ARRAYSIZE(handles), handles, FALSE, MIDI_XPROC_BUFFER_RECEIVED_WAIT);
+            DWORD ret = WaitForMultipleObjects(ARRAYSIZE(handles), handles, FALSE, bufferReceivedWait);
             if (ret == (WAIT_OBJECT_0 + 1))
             {
                 // this is a manual reset event, so reset the event before reading the updated position so

--- a/src/api/Service/Exe/MidiClientManager.cpp
+++ b/src/api/Service/Exe/MidiClientManager.cpp
@@ -8,6 +8,7 @@
 
 #include "stdafx.h"
 #include "Feature_Servicing_MIDI2VirtualDeviceRemovalDeadlock.h"
+#include "Feature_Servicing_MIDI2VirtualDeviceClientEndpointInUse.h"
 
 using namespace winrt::Windows::Devices::Enumeration;
 
@@ -932,6 +933,85 @@ CMidiClientManager::GetMidiScheduler(
 }
 
 
+// Returns the endpoint that this endpoint's in-use state should be published to, or an empty
+// string if no transport asked for it. Caller must hold m_ClientManagerLock.
+_Use_decl_annotations_
+std::wstring
+CMidiClientManager::GetEndpointInUseReportingTarget(
+    std::wstring const& midiDevice
+)
+{
+    auto devicePipes = m_DevicePipes.equal_range(midiDevice);
+
+    for (auto pipe = devicePipes.first; pipe != devicePipes.second; ++pipe)
+    {
+        auto devicePipe = static_cast<CMidiDevicePipe*>(pipe->second.get());
+
+        if (!devicePipe->InUseReportingTarget().empty())
+        {
+            return devicePipe->InUseReportingTarget();
+        }
+    }
+
+    return L"";
+}
+
+
+// The service's own protocol negotiation connection is a client of the endpoint just like any
+// application, and it is held open for the life of the endpoint, so it has to be excluded here
+// or every endpoint would look permanently busy. Caller must hold m_ClientManagerLock.
+_Use_decl_annotations_
+bool
+CMidiClientManager::EndpointHasApplicationClients(
+    std::wstring const& midiDevice
+)
+{
+    for (auto const& client : m_ClientPipes)
+    {
+        auto clientPipe = static_cast<CMidiClientPipe*>(client.second.get());
+
+        if (clientPipe->SessionId() == __uuidof(IMidiEndpointProtocolManager))
+        {
+            continue;
+        }
+
+        if (clientPipe->MidiDevice() == midiDevice)
+        {
+            return true;
+        }
+    }
+
+    return false;
+}
+
+
+// Reaches PnP, so this must be called with m_ClientManagerLock released.
+//
+// Deliberately scoped to virtual devices. Nothing above this function is virtual-specific: the
+// count is just "client pipes on this endpoint that aren't the protocol manager", and the
+// reporting target is whatever the transport asked for. Making this general would mean swapping
+// the hardcoded property key below for one the transport nominates, and likely publishing a
+// count rather than a bool, so that endpoints could report how many applications are attached.
+_Use_decl_annotations_
+HRESULT
+CMidiClientManager::UpdateEndpointInUseProperty(
+    std::wstring const& endpointInterfaceId,
+    bool const inUse
+)
+{
+    RETURN_HR_IF_NULL(E_POINTER, m_DeviceManager);
+
+    DEVPROP_BOOLEAN devPropInUse = inUse ? DEVPROP_TRUE : DEVPROP_FALSE;
+
+    DEVPROPERTY prop{ { PKEY_MIDI_VirtualMidiClientEndpointInUse, DEVPROP_STORE_SYSTEM, nullptr },
+        DEVPROP_TYPE_BOOLEAN, (ULONG)(sizeof(DEVPROP_BOOLEAN)), &devPropInUse };
+
+    RETURN_IF_FAILED(m_DeviceManager->UpdateEndpointProperties(endpointInterfaceId.c_str(), 1, &prop));
+
+    return S_OK;
+}
+
+
 _Use_decl_annotations_
 HRESULT
 CMidiClientManager::CreateMidiClient(
@@ -1044,6 +1124,10 @@ CMidiClientManager::CreateMidiClient(
         client->ClientHandle = NULL;
         client->DataFormat = MidiDataFormats_Invalid;
     });
+
+    // captured under the lock below, published after it is released
+    std::wstring inUseReportingTarget{ };
+    bool endpointInUse{ false };
 
     {
         auto lock = m_ClientManagerLock.lock_exclusive();
@@ -1222,9 +1306,27 @@ CMidiClientManager::CreateMidiClient(
         }
 
         RETURN_IF_FAILED(m_SessionTracker->AddClientEndpointConnection(sessionId, clientProcessId, midiDevice, client->ClientHandle));
+
+        if (Feature_Servicing_MIDI2VirtualDeviceClientEndpointInUse::IsEnabled())
+        {
+            inUseReportingTarget = GetEndpointInUseReportingTarget(devicePipe->MidiDevice());
+
+            if (!inUseReportingTarget.empty())
+            {
+                endpointInUse = EndpointHasApplicationClients(devicePipe->MidiDevice());
+            }
+        }
     }
 
     cleanupOnFailure.release();
+
+    if (Feature_Servicing_MIDI2VirtualDeviceClientEndpointInUse::IsEnabled())
+    {
+        if (!inUseReportingTarget.empty())
+        {
+            LOG_IF_FAILED(UpdateEndpointInUseProperty(inUseReportingTarget, endpointInUse));
+        }
+    }
 
     TraceLoggingWrite(
         MidiSrvTelemetryProvider::Provider(),
@@ -1411,6 +1513,10 @@ CMidiClientManager::DestroyMidiClientDeferredPipeShutdown(
     // shut them down after the lock has been released
     std::vector<wil::com_ptr_nothrow<CMidiPipe>> pipesToShutdown;
 
+    // captured under the lock below, published after it is released
+    std::wstring inUseReportingTarget{ };
+    bool endpointInUse{ false };
+
     {
         auto lock = m_ClientManagerLock.lock_exclusive();
 
@@ -1424,6 +1530,14 @@ CMidiClientManager::DestroyMidiClientDeferredPipeShutdown(
         {
             wil::com_ptr_nothrow<CMidiClientPipe> midiClientPipe = (CMidiClientPipe*)(client->second.get());
             wil::com_ptr_nothrow<CMidiPipe> clientAsMidiPipe = midiClientPipe.get();
+
+            // the device pipe is erased below once its last client goes, so read this first
+            std::wstring endpointId = client->second->MidiDevice();
+
+            if (Feature_Servicing_MIDI2VirtualDeviceClientEndpointInUse::IsEnabled())
+            {
+                inUseReportingTarget = GetEndpointInUseReportingTarget(endpointId);
+            }
 
             m_SessionTracker->RemoveClientEndpointConnection(midiClientPipe->SessionId(), midiClientPipe->ClientProcessId(), client->second->MidiDevice().c_str(), clientHandle);
 
@@ -1487,10 +1601,26 @@ CMidiClientManager::DestroyMidiClientDeferredPipeShutdown(
             }
 
             m_ClientPipes.erase(client);
+
+            if (Feature_Servicing_MIDI2VirtualDeviceClientEndpointInUse::IsEnabled())
+            {
+                if (!inUseReportingTarget.empty())
+                {
+                    endpointInUse = EndpointHasApplicationClients(endpointId);
+                }
+            }
         }
         else
         {
             RETURN_IF_FAILED(E_INVALIDARG);
+        }
+    }
+
+    if (Feature_Servicing_MIDI2VirtualDeviceClientEndpointInUse::IsEnabled())
+    {
+        if (!inUseReportingTarget.empty())
+        {
+            LOG_IF_FAILED(UpdateEndpointInUseProperty(inUseReportingTarget, endpointInUse));
         }
     }
 

--- a/src/api/Service/Exe/MidiDevicePipe.cpp
+++ b/src/api/Service/Exe/MidiDevicePipe.cpp
@@ -7,6 +7,7 @@
 // ============================================================================
 
 #include "stdafx.h"
+#include "Feature_Servicing_MIDI2VirtualDeviceClientEndpointInUse.h"
 
 using namespace winrt::Windows::Devices::Enumeration;
 
@@ -41,6 +42,7 @@ CMidiDevicePipe::Initialize(
     auto additionalProperties = winrt::single_threaded_vector<winrt::hstring>();
     additionalProperties.Append(STRING_PKEY_MIDI_TransportLayer);
     additionalProperties.Append(STRING_PKEY_MIDI_SupportsMulticlient);
+    additionalProperties.Append(STRING_PKEY_MIDI_VirtualMidiInUseReportingTarget);
 
     auto deviceInfo = DeviceInformation::CreateFromIdAsync(
         device, 
@@ -154,6 +156,25 @@ CMidiDevicePipe::Initialize(
 
     }
     CATCH_LOG();
+
+    if (Feature_Servicing_MIDI2VirtualDeviceClientEndpointInUse::IsEnabled())
+    {
+        try
+        {
+            // presence of this property is how a transport opts an endpoint in to having the
+            // number of connected applications reported
+            if (deviceInfo.Properties().HasKey(STRING_PKEY_MIDI_VirtualMidiInUseReportingTarget))
+            {
+                auto propTarget = deviceInfo.Properties().Lookup(STRING_PKEY_MIDI_VirtualMidiInUseReportingTarget);
+
+                if (propTarget != nullptr)
+                {
+                    m_inUseReportingTarget = winrt::unbox_value<winrt::hstring>(propTarget).c_str();
+                }
+            }
+        }
+        CATCH_LOG();
+    }
 
     TraceLoggingWrite(
         MidiSrvTelemetryProvider::Provider(),

--- a/src/api/Service/Inc/MidiClientManager.h
+++ b/src/api/Service/Inc/MidiClientManager.h
@@ -57,6 +57,19 @@ private:
         _In_ PMIDISRV_CLIENTCREATION_PARAMS,
         _In_ wil::com_ptr_nothrow<CMidiPipe>&);
 
+    // The following three support publishing endpoint in-use state. The first two require
+    // m_ClientManagerLock to be held; the third writes to PnP and must be called without it.
+
+    std::wstring GetEndpointInUseReportingTarget(
+        _In_ std::wstring const&);
+
+    bool EndpointHasApplicationClients(
+        _In_ std::wstring const&);
+
+    HRESULT UpdateEndpointInUseProperty(
+        _In_ std::wstring const&,
+        _In_ bool);
+
     // TODO: These should be made more generic and go by a configuration, rather than have
     // discrete methods for each type of transform. But right now, it's about making the
     // transform process work properly

--- a/src/api/Service/Inc/MidiDevicePipe.h
+++ b/src/api/Service/Inc/MidiDevicePipe.h
@@ -28,6 +28,8 @@ public:
 
     HRESULT SendMidiMessage(_In_ MessageOptionFlags, _In_ PVOID, _In_ UINT, _In_ LONGLONG);
 
+    std::wstring const& InUseReportingTarget() const noexcept { return m_inUseReportingTarget; }
+
 private:
     wil::srwlock m_DevicePipeLock;
     winrt::guid m_TransportGuid{};
@@ -37,6 +39,9 @@ private:
 
     // TODO: This needs to be read from the device properties
     bool m_endpointSupportsMulticlient{ true };
+
+    // empty unless the transport asked for this endpoint's in-use state to be published
+    std::wstring m_inUseReportingTarget{ };
 
 };
 

--- a/src/api/Test/Midi2.Transport.unittests/Midi2SrvTransportTests.cpp
+++ b/src/api/Test/Midi2.Transport.unittests/Midi2SrvTransportTests.cpp
@@ -189,18 +189,22 @@ MidiSrvTransportTests::TestMidiSrvMultiClient
 
         PrintMidiMessage(payload, payloadSize, sizeof(MIDI_MESSAGE), payloadPosition);
 
-        midiMessagesReceived++;
+        // Messages sharing a timestamp arrive coalesced into one callback, so the counts come
+        // from the payload rather than from the number of calls.
+        UINT32 const messagesInPayload = static_cast<UINT32>(payloadSize / sizeof(MIDI_MESSAGE));
+
+        midiMessagesReceived += messagesInPayload;
 
         if (context == context1)
         {
-            midiMessageReceived1++;
+            midiMessageReceived1 += messagesInPayload;
         }
         else if (context == context2)
         {
-            midiMessageReceived2++;
+            midiMessageReceived2 += messagesInPayload;
         }
 
-        if (midiMessagesReceived == expectedMessageCount)
+        if (midiMessagesReceived >= expectedMessageCount)
         {
             allMessagesReceived.SetEvent();
         }
@@ -527,18 +531,22 @@ MidiSrvTransportTests::TestMidiSrvMultiClientBidi
 
         PrintMidiMessage(payload, payloadSize, sizeof(MIDI_MESSAGE), payloadPosition);
 
-        midiMessagesReceived++;
+        // Messages sharing a timestamp arrive coalesced into one callback, so the counts come
+        // from the payload rather than from the number of calls.
+        UINT32 const messagesInPayload = static_cast<UINT32>(payloadSize / sizeof(MIDI_MESSAGE));
+
+        midiMessagesReceived += messagesInPayload;
 
         if (context == context1)
         {
-            midiMessageReceived1++;
+            midiMessageReceived1 += messagesInPayload;
         }
         else if (context == context2)
         {
-            midiMessageReceived2++;
+            midiMessageReceived2 += messagesInPayload;
         }
 
-        if (midiMessagesReceived == expectedMessageCount)
+        if (midiMessagesReceived >= expectedMessageCount)
         {
             allMessagesReceived.SetEvent();
         }
@@ -787,6 +795,10 @@ public:
 
         UINT midiMessagesReceived = 0;
 
+        // Jitter and round trip are sampled once per callback, and a callback can carry several
+        // coalesced messages, so the statistics need their own denominator.
+        UINT midiCallbacksReceived = 0;
+
         RETURN_IF_FAILED(CoCreateInstance(__uuidof(Midi2MidiSrvTransport), nullptr, CLSCTX_ALL, IID_PPV_ARGS(&midiTransport)));
 
         auto cleanupOnFailure = wil::scope_exit([&]() {
@@ -811,16 +823,32 @@ public:
 
         RETURN_IF_FAILED(midiTransport->Activate(__uuidof(IMidiBidirectional), (void**)&midiBidiDevice));
 
-        m_MidiInCallback = [&](PVOID payload, UINT32 , LONGLONG payloadPosition, LONGLONG)
+        m_MidiInCallback = [&](PVOID payload, UINT32 payloadSize, LONGLONG payloadPosition, LONGLONG)
         {
             LARGE_INTEGER qpc{0};
             LONGLONG roundTripLatency{0};
 
-            // filter the callback to only look at the messages sent by this thread
-            if (((transportCreationParams.DataFormat == MidiDataFormats_UMP) && 0 == memcmp(payload, &(testConfig.MidiTestData_32), sizeof(testConfig.MidiTestData_32))) ||
-                ((transportCreationParams.DataFormat == MidiDataFormats_ByteStream) && 0 == memcmp(payload, &(testConfig.MidiTestMessage), sizeof(testConfig.MidiTestMessage))))
+            bool const isUmp = (transportCreationParams.DataFormat == MidiDataFormats_UMP);
+            UINT32 const messageSize = static_cast<UINT32>(isUmp ? sizeof(testConfig.MidiTestData_32) : sizeof(testConfig.MidiTestMessage));
+            void const* const expectedMessage = isUmp ? static_cast<void const*>(&(testConfig.MidiTestData_32)) : static_cast<void const*>(&(testConfig.MidiTestMessage));
+
+            // filter the callback to only look at the messages sent by this thread. Messages sharing
+            // a timestamp arrive coalesced into one callback and every thread shares the endpoint,
+            // so each message in the payload has to be matched on its own.
+            UINT32 matchingMessages = 0;
+            for (UINT32 offset = 0; offset + messageSize <= payloadSize; offset += messageSize)
+            {
+                if (0 == memcmp(static_cast<BYTE const*>(payload) + offset, expectedMessage, messageSize))
+                {
+                    matchingMessages++;
+                }
+            }
+
+            if (matchingMessages > 0)
             {
                 QueryPerformanceCounter(&qpc);
+
+                midiCallbacksReceived++;
         
                 // first, we calculate the jitter statistics for how often the
                 // recieve function was called. Since the messages are sent at a
@@ -845,13 +873,13 @@ public:
                     long double prevAvgReceiveLatency = avgReceiveLatency;
         
                     // running average for the average recieve latency/jitter
-                    avgReceiveLatency = (prevAvgReceiveLatency + (((long double)receiveLatency - prevAvgReceiveLatency) / ((long double)midiMessagesReceived)));
+                    avgReceiveLatency = (prevAvgReceiveLatency + (((long double)receiveLatency - prevAvgReceiveLatency) / ((long double)midiCallbacksReceived)));
         
                     stdevReceiveLatency = stdevReceiveLatency + ((receiveLatency - prevAvgReceiveLatency) * (receiveLatency - avgReceiveLatency));
                 }
                 previousReceive = qpc.QuadPart;
         
-                midiMessagesReceived++;
+                midiMessagesReceived += matchingMessages;
         
                 // now calculate the round trip statistics based upon
                 // the timestamp on the message that was just received relative
@@ -870,16 +898,16 @@ public:
                 long double prevAvgRoundTripLatency = avgRoundTripLatency;
         
                 // running average for the round trip latency
-                avgRoundTripLatency = (prevAvgRoundTripLatency + (((long double) roundTripLatency - prevAvgRoundTripLatency) / (long double) midiMessagesReceived));
+                avgRoundTripLatency = (prevAvgRoundTripLatency + (((long double) roundTripLatency - prevAvgRoundTripLatency) / (long double) midiCallbacksReceived));
         
                 stdevRoundTripLatency = stdevRoundTripLatency + ((roundTripLatency - prevAvgRoundTripLatency) * (roundTripLatency - avgRoundTripLatency));
         
                 // Save the latency for the very first message
-                if (1 == midiMessagesReceived)
+                if (1 == midiCallbacksReceived)
                 {
                     firstRoundTripLatency = roundTripLatency;
                 }
-                else if (midiMessagesReceived == expectedMessageCount)
+                else if (midiMessagesReceived >= expectedMessageCount)
                 {
                     lastReceive = qpc;
                     lastRoundTripLatency = roundTripLatency;
@@ -1015,7 +1043,7 @@ public:
         m_lastRtLatency = 1000. * (lastRoundTripLatency / qpcPerMs);
         m_minRtLatency = 1000. * (minRoundTripLatency / qpcPerMs);
         m_maxRtLatency = 1000. * (maxRoundTripLatency / qpcPerMs);
-        m_stddevRtLatency = 1000. * (sqrt(stdevRoundTripLatency / (long double)midiMessagesReceived) / qpcPerMs);
+        m_stddevRtLatency = 1000. * (sqrt(stdevRoundTripLatency / (long double)midiCallbacksReceived) / qpcPerMs);
     
         m_avgSLatency = 1000. * (avgSendLatency / qpcPerMs);
         m_firstSLatency = 1000. * (firstSendLatency / qpcPerMs);
@@ -1027,7 +1055,7 @@ public:
         m_avgRLatency = 1000. * (avgReceiveLatency / qpcPerMs);
         m_maxRLatency = 1000. * (maxReceiveLatency / qpcPerMs);
         m_minRLatency = 1000. * (minReceiveLatency / qpcPerMs);
-        m_stddevRLatency = 1000. * (sqrt(stdevReceiveLatency / ((long double)midiMessagesReceived - 1.)) / qpcPerMs);
+        m_stddevRLatency = 1000. * (sqrt(stdevReceiveLatency / ((long double)midiCallbacksReceived - 1.)) / qpcPerMs);
 
         LOG_OUTPUT(L"%s - Done, cleaning up", testConfig.SessionName.c_str());
     

--- a/src/api/Test/Midi2.Transport.unittests/Midi2TransportTestsBase.cpp
+++ b/src/api/Test/Midi2.Transport.unittests/Midi2TransportTestsBase.cpp
@@ -209,10 +209,15 @@ void MidiTransportTestsBase::TestMidiTransport(REFIID iid, MidiDataFormats dataF
 
     m_MidiInCallback = [&](PVOID payload, UINT32 payloadSize, LONGLONG payloadPosition, LONGLONG)
     {
-        PrintMidiMessage(payload, payloadSize, (transportCreationParams.DataFormat == MidiDataFormats_UMP)?sizeof(UMP32):sizeof(MIDI_MESSAGE), payloadPosition);
+        UINT32 const messageSize = static_cast<UINT32>((transportCreationParams.DataFormat == MidiDataFormats_UMP) ? sizeof(UMP32) : sizeof(MIDI_MESSAGE));
 
-        midiMessagesReceived++;
-        if (midiMessagesReceived == expectedMessageCount)
+        PrintMidiMessage(payload, payloadSize, messageSize, payloadPosition);
+
+        // Messages sharing a timestamp arrive coalesced into one callback, so the count comes
+        // from the payload rather than from the number of calls.
+        midiMessagesReceived += (payloadSize / messageSize);
+
+        if (midiMessagesReceived >= expectedMessageCount)
         {
             allMessagesReceived.SetEvent();
         }
@@ -510,10 +515,15 @@ void MidiTransportTestsBase::TestMidiTransportBidi(REFIID iid, MidiDataFormats d
 
     m_MidiInCallback = [&](PVOID payload, UINT32 payloadSize, LONGLONG payloadPosition, LONGLONG)
     {
-        PrintMidiMessage(payload, payloadSize, (transportCreationParams.DataFormat == MidiDataFormats_UMP)?sizeof(UMP32):sizeof(MIDI_MESSAGE), payloadPosition);
+        UINT32 const messageSize = static_cast<UINT32>((transportCreationParams.DataFormat == MidiDataFormats_UMP) ? sizeof(UMP32) : sizeof(MIDI_MESSAGE));
 
-        midiMessagesReceived++;
-        if (midiMessagesReceived == expectedMessageCount)
+        PrintMidiMessage(payload, payloadSize, messageSize, payloadPosition);
+
+        // Messages sharing a timestamp arrive coalesced into one callback, so the count comes
+        // from the payload rather than from the number of calls.
+        midiMessagesReceived += (payloadSize / messageSize);
+
+        if (midiMessagesReceived >= expectedMessageCount)
         {
             allMessagesReceived.SetEvent();
         }
@@ -640,6 +650,10 @@ void MidiTransportTestsBase::TestMidiIO_Latency(REFIID iid, MidiDataFormats data
 
     UINT midiMessagesReceived = 0;
 
+    // Jitter and round trip are sampled once per callback, and a callback can carry several
+    // coalesced messages, so the statistics need their own denominator.
+    UINT midiCallbacksReceived = 0;
+
     VERIFY_SUCCEEDED(CoCreateInstance(iid, nullptr, CLSCTX_ALL, IID_PPV_ARGS(&midiTransport)));
 
     auto cleanupOnFailure = wil::scope_exit([&]() {
@@ -664,12 +678,19 @@ void MidiTransportTestsBase::TestMidiIO_Latency(REFIID iid, MidiDataFormats data
 
     VERIFY_SUCCEEDED(midiTransport->Activate(__uuidof(IMidiBidirectional), (void**)&midiBidiDevice));
 
-    m_MidiInCallback = [&](PVOID , UINT32 , LONGLONG payloadPosition, LONGLONG)
+    m_MidiInCallback = [&](PVOID , UINT32 payloadSize, LONGLONG payloadPosition, LONGLONG)
     {
         LARGE_INTEGER qpc{0};
         LONGLONG roundTripLatency{0};
 
         QueryPerformanceCounter(&qpc);
+
+        midiCallbacksReceived++;
+
+        // Messages sharing a timestamp arrive coalesced into one callback, so the count comes
+        // from the payload rather than from the number of calls.
+        UINT32 const messageSize = static_cast<UINT32>((transportCreationParams.DataFormat == MidiDataFormats_UMP) ? sizeof(UMP32) : sizeof(MIDI_MESSAGE));
+        midiMessagesReceived += (payloadSize / messageSize);
 
         // first, we calculate the jitter statistics for how often the
         // recieve function was called. Since the messages are sent at a
@@ -694,13 +715,11 @@ void MidiTransportTestsBase::TestMidiIO_Latency(REFIID iid, MidiDataFormats data
             long double prevAvgReceiveLatency = avgReceiveLatency;
 
             // running average for the average recieve latency/jitter
-            avgReceiveLatency = (prevAvgReceiveLatency + (((long double)receiveLatency - prevAvgReceiveLatency) / ((long double)midiMessagesReceived)));
+            avgReceiveLatency = (prevAvgReceiveLatency + (((long double)receiveLatency - prevAvgReceiveLatency) / ((long double)midiCallbacksReceived)));
 
             stdevReceiveLatency = stdevReceiveLatency + ((receiveLatency - prevAvgReceiveLatency) * (receiveLatency - avgReceiveLatency));
         }
         previousReceive = qpc.QuadPart;
-
-        midiMessagesReceived++;
 
         // now calculate the round trip statistics based upon
         // the timestamp on the message that was just received relative
@@ -719,16 +738,16 @@ void MidiTransportTestsBase::TestMidiIO_Latency(REFIID iid, MidiDataFormats data
         long double prevAvgRoundTripLatency = avgRoundTripLatency;
 
         // running average for the round trip latency
-        avgRoundTripLatency = (prevAvgRoundTripLatency + (((long double) roundTripLatency - prevAvgRoundTripLatency) / (long double) midiMessagesReceived));
+        avgRoundTripLatency = (prevAvgRoundTripLatency + (((long double) roundTripLatency - prevAvgRoundTripLatency) / (long double) midiCallbacksReceived));
 
         stdevRoundTripLatency = stdevRoundTripLatency + ((roundTripLatency - prevAvgRoundTripLatency) * (roundTripLatency - avgRoundTripLatency));
 
         // Save the latency for the very first message
-        if (1 == midiMessagesReceived)
+        if (1 == midiCallbacksReceived)
         {
             firstRoundTripLatency = roundTripLatency;
         }
-        else if (midiMessagesReceived == expectedMessageCount)
+        else if (midiMessagesReceived >= expectedMessageCount)
         {
             lastReceive = qpc;
             lastRoundTripLatency = roundTripLatency;
@@ -856,7 +875,7 @@ void MidiTransportTestsBase::TestMidiIO_Latency(REFIID iid, MidiDataFormats data
     long double lastRtLatency = 1000. * (lastRoundTripLatency / qpcPerMs);
     long double minRtLatency = 1000. * (minRoundTripLatency / qpcPerMs);
     long double maxRtLatency = 1000. * (maxRoundTripLatency / qpcPerMs);
-    long double stddevRtLatency = 1000. * (sqrt(stdevRoundTripLatency / (long double)midiMessagesReceived) / qpcPerMs);
+    long double stddevRtLatency = 1000. * (sqrt(stdevRoundTripLatency / (long double)midiCallbacksReceived) / qpcPerMs);
 
     long double avgSLatency = 1000. * (avgSendLatency / qpcPerMs);
     long double firstSLatency = 1000. * (firstSendLatency / qpcPerMs);
@@ -868,7 +887,7 @@ void MidiTransportTestsBase::TestMidiIO_Latency(REFIID iid, MidiDataFormats data
     long double avgRLatency = 1000. * (avgReceiveLatency / qpcPerMs);
     long double maxRLatency = 1000. * (maxReceiveLatency / qpcPerMs);
     long double minRLatency = 1000. * (minReceiveLatency / qpcPerMs);
-    long double stddevRLatency = 1000. * (sqrt(stdevReceiveLatency / ((long double)midiMessagesReceived - 1.)) / qpcPerMs);
+    long double stddevRLatency = 1000. * (sqrt(stdevReceiveLatency / ((long double)midiCallbacksReceived - 1.)) / qpcPerMs);
 
     LOG_OUTPUT(L"****************************************************************************");
     LOG_OUTPUT(L"Elapsed time from start of send to final receive %g ms", elapsedMs);

--- a/src/api/Transport/VirtualMidiTransport/Midi2.VirtualMidiEndpointManager.cpp
+++ b/src/api/Transport/VirtualMidiTransport/Midi2.VirtualMidiEndpointManager.cpp
@@ -222,46 +222,6 @@ CMidi2VirtualMidiEndpointManager::NegotiateAndRequestMetadata(std::wstring endpo
 
 
 _Use_decl_annotations_
-HRESULT
-CMidi2VirtualMidiEndpointManager::UpdateClientEndpointInUseProperty(
-    std::wstring const& deviceEndpointInterfaceId,
-    bool const inUse)
-{
-    TraceLoggingWrite(
-        MidiVirtualMidiTransportTelemetryProvider::Provider(),
-        MIDI_TRACE_EVENT_INFO,
-        TraceLoggingString(__FUNCTION__, MIDI_TRACE_EVENT_LOCATION_FIELD),
-        TraceLoggingLevel(WINEVENT_LEVEL_INFO),
-        TraceLoggingPointer(this, "this"),
-        TraceLoggingWideString(deviceEndpointInterfaceId.c_str(), MIDI_TRACE_EVENT_DEVICE_SWD_ID_FIELD),
-        TraceLoggingBool(inUse, "in use")
-    );
-
-    // The device side can tear down before the last client does, taking the endpoint with it, so
-    // every one of these is a normal condition rather than an error.
-    if (m_MidiDeviceManager == nullptr || deviceEndpointInterfaceId.empty())
-    {
-        return S_FALSE;
-    }
-
-    DEVPROP_BOOLEAN devPropInUse = inUse ? DEVPROP_TRUE : DEVPROP_FALSE;
-
-    std::vector<DEVPROPERTY> interfaceDevProperties{};
-
-    interfaceDevProperties.push_back(DEVPROPERTY{ {PKEY_MIDI_VirtualMidiClientEndpointInUse, DEVPROP_STORE_SYSTEM, nullptr},
-        DEVPROP_TYPE_BOOLEAN, (ULONG)(sizeof(DEVPROP_BOOLEAN)), &devPropInUse });
-
-    LOG_IF_FAILED(m_MidiDeviceManager->UpdateEndpointProperties(
-        deviceEndpointInterfaceId.c_str(),
-        static_cast<ULONG>(interfaceDevProperties.size()),
-        interfaceDevProperties.data()
-    ));
-
-    return S_OK;
-}
-
-
-_Use_decl_annotations_
 HRESULT 
 CMidi2VirtualMidiEndpointManager::CreateClientVisibleEndpoint(
     MidiVirtualDeviceEndpointEntry& entry
@@ -300,6 +260,14 @@ CMidi2VirtualMidiEndpointManager::CreateClientVisibleEndpoint(
     // this is needed for the loopback endpoints to have a relationship with each other
     interfaceDeviceProperties.push_back(DEVPROPERTY{ {PKEY_MIDI_VirtualMidiEndpointAssociator, DEVPROP_STORE_SYSTEM, nullptr},
         DEVPROP_TYPE_STRING, (ULONG)(sizeof(wchar_t) * (entry.VirtualEndpointAssociationId.length() + 1)), (PVOID)entry.VirtualEndpointAssociationId.c_str() });
+
+    // The service counts the applications connected here, but publishes the result on the
+    // device-side endpoint, which is the one the owning application watches.
+    if (Feature_Servicing_MIDI2VirtualDeviceClientEndpointInUse::IsEnabled())
+    {
+        interfaceDeviceProperties.push_back(DEVPROPERTY{ {PKEY_MIDI_VirtualMidiInUseReportingTarget, DEVPROP_STORE_SYSTEM, nullptr},
+            DEVPROP_TYPE_STRING, (ULONG)(sizeof(wchar_t) * (entry.CreatedDeviceEndpointId.length() + 1)), (PVOID)entry.CreatedDeviceEndpointId.c_str() });
+    }
 
 
     // we specify this here, knowing that the device manager will generate the name table once

--- a/src/api/Transport/VirtualMidiTransport/Midi2.VirtualMidiEndpointManager.h
+++ b/src/api/Transport/VirtualMidiTransport/Midi2.VirtualMidiEndpointManager.h
@@ -35,12 +35,6 @@ public:
 
     HRESULT NegotiateAndRequestMetadata(_In_ std::wstring endpointInterfaceId);
 
-    // Best-effort: the device-side endpoint can already be gone when the last client leaves, so
-    // a failure here is logged rather than propagated.
-    HRESULT UpdateClientEndpointInUseProperty(
-        _In_ std::wstring const& deviceEndpointInterfaceId,
-        _In_ bool const inUse);
-
     HRESULT DeleteClientEndpoint(_In_ std::wstring clientShortInstanceId);
 
     HRESULT DeleteDeviceEndpoint(_In_ std::wstring deviceShortInstanceId);

--- a/src/api/Transport/VirtualMidiTransport/MidiEndpointTable.cpp
+++ b/src/api/Transport/VirtualMidiTransport/MidiEndpointTable.cpp
@@ -97,9 +97,6 @@ MidiEndpointTable::OnClientConnected(
 
         auto associationId = internal::GetSwdPropertyVirtualEndpointAssociationId(clientEndpointInterfaceId);
 
-        // captured under the lock, used after releasing it
-        std::wstring deviceEndpointInterfaceId{ };
-
         if (!associationId.empty())
         {
             {
@@ -119,8 +116,6 @@ MidiEndpointTable::OnClientConnected(
                     RETURN_IF_FAILED(entry.MidiClientBidi->LinkAssociatedCallback(entry.MidiDeviceBidi));
 
                     m_endpoints[associationId] = entry;
-
-                    deviceEndpointInterfaceId = entry.CreatedDeviceEndpointId;
                 }
                 else
                 {
@@ -137,18 +132,6 @@ MidiEndpointTable::OnClientConnected(
                         TraceLoggingWideString(L"Unable to find device table entry", MIDI_TRACE_EVENT_MESSAGE_FIELD),
                         TraceLoggingWideString(clientEndpointInterfaceId.c_str(), MIDI_TRACE_EVENT_DEVICE_SWD_ID_FIELD)
                     );
-                }
-            }
-
-            // Deliberately outside the table lock. This reaches PnP through the device manager,
-            // and holding a lock across that is what wedges a removal callback.
-            if (Feature_Servicing_MIDI2VirtualDeviceClientEndpointInUse::IsEnabled())
-            {
-                auto endpointManager = TransportState::Current().GetEndpointManager();
-
-                if (endpointManager != nullptr && !deviceEndpointInterfaceId.empty())
-                {
-                    LOG_IF_FAILED(endpointManager->UpdateClientEndpointInUseProperty(deviceEndpointInterfaceId, true));
                 }
             }
         }
@@ -266,9 +249,6 @@ MidiEndpointTable::OnClientDisconnectedKeepDeviceLink(
     {
         std::wstring associationId = internal::GetSwdPropertyVirtualEndpointAssociationId(clientEndpointInterfaceId);
 
-        // captured under the lock, used after releasing it
-        std::wstring deviceEndpointInterfaceId{ };
-
         if (!associationId.empty())
         {
             {
@@ -291,8 +271,6 @@ MidiEndpointTable::OnClientDisconnectedKeepDeviceLink(
                     }
 
                     m_endpoints[associationId] = entry;
-
-                    deviceEndpointInterfaceId = entry.CreatedDeviceEndpointId;
                 }
                 else
                 {
@@ -309,18 +287,6 @@ MidiEndpointTable::OnClientDisconnectedKeepDeviceLink(
                     );
 
                     return S_OK;
-                }
-            }
-
-            // Deliberately outside the table lock, and best-effort: the endpoint may already be
-            // deleted if the device side went first.
-            if (Feature_Servicing_MIDI2VirtualDeviceClientEndpointInUse::IsEnabled())
-            {
-                auto endpointManager = TransportState::Current().GetEndpointManager();
-
-                if (endpointManager != nullptr && !deviceEndpointInterfaceId.empty())
-                {
-                    LOG_IF_FAILED(endpointManager->UpdateClientEndpointInUseProperty(deviceEndpointInterfaceId, false));
                 }
             }
 


### PR DESCRIPTION
This pull request introduces several improvements and new features to the MIDI Services codebase, focusing on enhanced diagnostics, feature toggling, and more robust virtual device state reporting. The main changes include new feature flags, improved logging capabilities, and updates to virtual device in-use state management.

**Diagnostics and Logging Enhancements:**
- Added new event collectors and providers in `providers.wprp` to capture more detailed logs, especially for USB/PnP events and cross-process MIDI communication. This helps prevent MIDI event eviction due to high USB/PnP event volume and enables better troubleshooting for send stalls and dropped buffers. [[1]](diffhunk://#diff-bab31885311ed81f190dbe6d457e9ebd63291f8a1bb78b1ece4bd0d758d3c5fcR17-R21) [[2]](diffhunk://#diff-bab31885311ed81f190dbe6d457e9ebd63291f8a1bb78b1ece4bd0d758d3c5fcR52-R54) [[3]](diffhunk://#diff-bab31885311ed81f190dbe6d457e9ebd63291f8a1bb78b1ece4bd0d758d3c5fcR82-R92) [[4]](diffhunk://#diff-bab31885311ed81f190dbe6d457e9ebd63291f8a1bb78b1ece4bd0d758d3c5fcR102) [[5]](diffhunk://#diff-bab31885311ed81f190dbe6d457e9ebd63291f8a1bb78b1ece4bd0d758d3c5fcR120-R137)

**Feature Flags and Conditional Behavior:**
- Introduced the `Feature_Servicing_MIDI2XProcSendWaitTimeouts` feature flag, allowing the MIDI cross-process send wait timeout to be extended for slow devices, reducing premature aborts of data sends. [[1]](diffhunk://#diff-a0a0f6fb99bda503eb28913f35e845662625178790a2d09ba7f719fbbe905e26R1-R18) [[2]](diffhunk://#diff-716d07ec57192be1eb5c08b1c524e875db2aec787e53e0acd0822195aac67d75R32) [[3]](diffhunk://#diff-716d07ec57192be1eb5c08b1c524e875db2aec787e53e0acd0822195aac67d75R54-R58) [[4]](diffhunk://#diff-716d07ec57192be1eb5c08b1c524e875db2aec787e53e0acd0822195aac67d75R342-R352) [[5]](diffhunk://#diff-0d21c24c94b71ff41ffd5f175e912eba59bfd13543f5886652e0a667d53830ffR1494) [[6]](diffhunk://#diff-0d21c24c94b71ff41ffd5f175e912eba59bfd13543f5886652e0a667d53830ffR1541)
- Integrated the new feature flag into diagnostic tools and the cross-process logic, making the extended timeout visible and testable.

**Virtual Device In-Use State Reporting:**
- Added a new device property key, `PKEY_MIDI_VirtualMidiInUseReportingTarget`, to allow transports to specify where in-use state should be published.
- Enhanced `CMidiClientManager` to track and update the in-use state of virtual MIDI endpoints, including new methods for determining the reporting target and whether endpoints have application clients, and logic to update the property only when the relevant feature flag is enabled. [[1]](diffhunk://#diff-11cdca191f708728aa9c2182bccb110c41aad879acdf8fc3a2e7bd3bca7f333fR11) [[2]](diffhunk://#diff-11cdca191f708728aa9c2182bccb110c41aad879acdf8fc3a2e7bd3bca7f333fR936-R1014) [[3]](diffhunk://#diff-11cdca191f708728aa9c2182bccb110c41aad879acdf8fc3a2e7bd3bca7f333fR1128-R1131) [[4]](diffhunk://#diff-11cdca191f708728aa9c2182bccb110c41aad879acdf8fc3a2e7bd3bca7f333fR1309-R1330) [[5]](diffhunk://#diff-11cdca191f708728aa9c2182bccb110c41aad879acdf8fc3a2e7bd3bca7f333fR1516-R1519)

**Build and Packaging Updates:**
- Updated the NuGet package version for `Windows.Devices.Midi2` and cleaned up obsolete comments in the `.nuspec` file. [[1]](diffhunk://#diff-143d047abc86f47a84f20d50b09a906e7f8eb4d6f9c08eba2f30cb97e5231f85L5-R5) [[2]](diffhunk://#diff-143d047abc86f47a84f20d50b09a906e7f8eb4d6f9c08eba2f30cb97e5231f85L21-L23)
- Improved project file (`.vcxproj`) organization by associating header/source files with their corresponding IDL files, aiding maintainability. [[1]](diffhunk://#diff-db022fee0566d53db4c46f081c42092ca96961ec89138ea23b2ebf59fbaa9a6dL542-R556) [[2]](diffhunk://#diff-db022fee0566d53db4c46f081c42092ca96961ec89138ea23b2ebf59fbaa9a6dL914-R938)

These changes collectively improve diagnostics, configurability, and the reliability of MIDI virtual device state reporting, making the system more robust and easier to debug.