### PR TITLE
Fix MIDI-OX SysEx Failure and add a monitor button to the Network MIDI Setup app

### DIFF
--- a/src/in-box/Client/WinMM/MidiSrvPort.cpp
+++ b/src/in-box/Client/WinMM/MidiSrvPort.cpp
@@ -5,6 +5,7 @@
 
 #include <Feature_Servicing_MIDI2BsToUMPConv.h>
 #include <Feature_Servicing_MIDI2WinMMShortMessageNoSendWait.h>
+#include <Feature_Servicing_MIDI2WinMMCompleteLongBufferOnFailure.h>
 
 #define CALC_TICKS(pos) ((DWORD) (((pos) * 1000.0) / m_qpcFrequency))
 
@@ -198,7 +199,14 @@ CMidiPort::ModMessage(UINT msg, DWORD_PTR param1, DWORD_PTR param2)
     switch(msg)
     {
         case MODM_LONGDATA:
-            RETURN_IF_FAILED(SendLongMessage(reinterpret_cast<MIDIHDR*>(param1)));
+            if (Feature_Servicing_MIDI2WinMMCompleteLongBufferOnFailure::IsEnabled())
+            {
+                RETURN_IF_FAILED(SendLongMessageCompletingBuffer(reinterpret_cast<MIDIHDR*>(param1)));
+            }
+            else
+            {
+                RETURN_IF_FAILED(SendLongMessage(reinterpret_cast<MIDIHDR*>(param1)));
+            }
             break;
         case MODM_DATA:
             RETURN_IF_FAILED(SendMidiMessage(static_cast<UINT32>(param1)));
@@ -1020,6 +1028,79 @@ CMidiPort::SendLongMessage(LPMIDIHDR buffer)
     WinmmClientCallback(MOM_DONE, (DWORD_PTR) buffer, 0);
     return S_OK;
 }
+
+// Start add with Feature_Servicing_MIDI2WinMMCompleteLongBufferOnFailure
+_Use_decl_annotations_
+HRESULT
+CMidiPort::SendLongMessageCompletingBuffer(LPMIDIHDR buffer)
+{
+    TraceLoggingWrite(
+        WdmAud2TelemetryProvider::Provider(),
+        MIDI_TRACE_EVENT_VERBOSE,
+        TraceLoggingString(__FUNCTION__, MIDI_TRACE_EVENT_LOCATION_FIELD),
+        TraceLoggingLevel(WINEVENT_LEVEL_INFO),
+        TraceLoggingPointer(this, "this"),
+        TraceLoggingWideString(L"Start", MIDI_TRACE_EVENT_MESSAGE_FIELD),
+        TraceLoggingPointer(buffer, "buffer"));
+
+    auto exitCallback = wil::scope_exit([&]()
+    {
+        TraceLoggingWrite(
+            WdmAud2TelemetryProvider::Provider(),
+            MIDI_TRACE_EVENT_VERBOSE,
+            TraceLoggingString(__FUNCTION__, MIDI_TRACE_EVENT_LOCATION_FIELD),
+            TraceLoggingLevel(WINEVENT_LEVEL_INFO),
+            TraceLoggingPointer(this, "this"),
+            TraceLoggingWideString(L"End", MIDI_TRACE_EVENT_MESSAGE_FIELD),
+            TraceLoggingPointer(buffer, "buffer"));
+    });
+
+    HRESULT sendResult = S_OK;
+
+    {
+        auto lock = m_Lock.lock();
+
+        // This should be on an initialized midi out port
+        RETURN_HR_IF(E_INVALIDARG, nullptr == m_MidisrvTransport);
+
+        // The buffer provided must be valid
+        RETURN_HR_IF(E_INVALIDARG, nullptr == buffer);
+        RETURN_HR_IF(HRESULT_FROM_MMRESULT(MMSYSERR_INVALFLAG), !(buffer->dwFlags & MHDR_PREPARED));
+
+        buffer->dwFlags &= (~MHDR_DONE);
+        buffer->dwFlags |= MHDR_INQUEUE;
+
+        UINT32 bytesSent = 0;
+        do
+        {
+            UINT32 bytesToSend = min(MAXIMUM_LOOPED_BYTESTREAM_DATASIZE, buffer->dwBufferLength - bytesSent);
+            // For legacy compatibility purposes, always wait for the message send to complete
+            sendResult = m_MidisrvTransport->SendMidiMessage(MessageOptionFlags_WaitForSendComplete, buffer->lpData + bytesSent, bytesToSend, 0);
+            if (FAILED(sendResult))
+            {
+                LOG_IF_FAILED(sendResult);
+                break;
+            }
+
+            bytesSent += bytesToSend;
+        }
+        while (bytesSent < buffer->dwBufferLength);
+    }
+
+    // A buffer we have taken is always given back, even when the send failed. Apps have no
+    // other way to reclaim one, and many treat MHDR_DONE as the only signal that a buffer
+    // has returned to their pool, so keeping it strands that buffer for the life of the port.
+    buffer->dwFlags &= (~MHDR_INQUEUE);
+    buffer->dwFlags |= MHDR_DONE;
+
+    // client callback indicating this buffer is completed.
+    WinmmClientCallback(MOM_DONE, (DWORD_PTR) buffer, 0);
+
+    RETURN_IF_FAILED(sendResult);
+
+    return S_OK;
+}
+// End add with Feature_Servicing_MIDI2WinMMCompleteLongBufferOnFailure
 
 _Use_decl_annotations_
 void

--- a/src/in-box/Client/WinMM/MidiSrvPort.h
+++ b/src/in-box/Client/WinMM/MidiSrvPort.h
@@ -56,6 +56,9 @@ private:
 
     HRESULT SendMidiMessage(_In_ UINT32 midiMessage);
     HRESULT SendLongMessage(_In_ LPMIDIHDR buffer);
+    // Start add with Feature_Servicing_MIDI2WinMMCompleteLongBufferOnFailure
+    HRESULT SendLongMessageCompletingBuffer(_In_ LPMIDIHDR buffer);
+    // End add with Feature_Servicing_MIDI2WinMMCompleteLongBufferOnFailure
 
     HRESULT CompleteLongBuffer(_In_ UINT message, _In_ LONGLONG position);
     

--- a/src/in-box/Client/WinMM/MidiSrvPorts.cpp
+++ b/src/in-box/Client/WinMM/MidiSrvPorts.cpp
@@ -8,6 +8,7 @@
 #include "Feature_Servicing_MIDI2DevCaps2.h"
 #include "Feature_Servicing_MIDI2NumDevsPerf.h"
 #include "Feature_Servicing_MIDI2LegacyControl.h"
+#include "Feature_Servicing_MIDI2WinMMPortHandleSlotWidth.h"
 
 using unique_hdevinfo = wil::unique_any_handle_invalid<decltype(&::SetupDiDestroyDeviceInfoList), ::SetupDiDestroyDeviceInfoList>;
 
@@ -15,7 +16,9 @@ using unique_hdevinfo = wil::unique_any_handle_invalid<decltype(&::SetupDiDestro
 EXTERN_C IMAGE_DOS_HEADER __ImageBase;
 #define HINST_WDMAUD2 ((HINSTANCE)&__ImageBase)
 
-DWORD CMEventCallback
+// PCM_NOTIFY_CALLBACK is __stdcall, which only matters on x86, where the default
+// convention would otherwise make this project fail to build.
+DWORD CALLBACK CMEventCallback
 (
     HCMNOTIFICATION,
     PVOID Context,
@@ -269,7 +272,14 @@ CMidiPorts::MidMessage(UINT deviceID, UINT msg, DWORD_PTR user, DWORD_PTR param1
             hr = GetDevCaps(MidiFlowIn, deviceID, param1, param2);
             break;
         case MIDM_OPEN:
-            hr = Open(MidiFlowIn, deviceID, (MIDIOPENDESC *) param1, param2, (MidiPortHandle*) user);
+            if (Feature_Servicing_MIDI2WinMMPortHandleSlotWidth::IsEnabled())
+            {
+                hr = OpenIntoPointerSizedSlot(MidiFlowIn, deviceID, (MIDIOPENDESC *) param1, param2, (DWORD_PTR*) user);
+            }
+            else
+            {
+                hr = Open(MidiFlowIn, deviceID, (MIDIOPENDESC *) param1, param2, (MidiPortHandle*) user);
+            }
             break;
         case MIDM_CLOSE:
             // Forward the message to the open port, if one exists, giving the port an opportunity to
@@ -332,7 +342,14 @@ CMidiPorts::ModMessage(UINT deviceID, UINT msg, DWORD_PTR user, DWORD_PTR param1
             hr = GetDevCaps(MidiFlowOut, deviceID, param1, param2);
             break;
         case MODM_OPEN:
-            hr = Open(MidiFlowOut, deviceID, (MIDIOPENDESC *) param1, param2, (MidiPortHandle*) user);
+            if (Feature_Servicing_MIDI2WinMMPortHandleSlotWidth::IsEnabled())
+            {
+                hr = OpenIntoPointerSizedSlot(MidiFlowOut, deviceID, (MIDIOPENDESC *) param1, param2, (DWORD_PTR*) user);
+            }
+            else
+            {
+                hr = Open(MidiFlowOut, deviceID, (MIDIOPENDESC *) param1, param2, (MidiPortHandle*) user);
+            }
             break;
         case MODM_CLOSE:
             // Forward the message to the open port, if one exists, giving the port an opportunity to
@@ -1144,6 +1161,25 @@ CMidiPorts::Open(MidiFlow flow, UINT portNumber, const MIDIOPENDESC* midiOpenDes
 
     return S_OK;
 }
+
+// Start add with Feature_Servicing_MIDI2WinMMPortHandleSlotWidth
+_Use_decl_annotations_
+HRESULT
+CMidiPorts::OpenIntoPointerSizedSlot(MidiFlow flow, UINT portNumber, const MIDIOPENDESC* midiOpenDesc, DWORD_PTR flags, DWORD_PTR* openedPort)
+{
+    RETURN_HR_IF(E_POINTER, nullptr == openedPort);
+
+    // winmm hands us a DWORD_PTR sized slot inside its own handle, so the handle is taken in a
+    // local of our own width and narrowed on the way out rather than written over the slot.
+    MidiPortHandle localPortHandle{ 0 };
+
+    RETURN_IF_FAILED(Open(flow, portNumber, midiOpenDesc, flags, &localPortHandle));
+
+    *openedPort = static_cast<DWORD_PTR>(localPortHandle);
+
+    return S_OK;
+}
+// End add with Feature_Servicing_MIDI2WinMMPortHandleSlotWidth
 
 _Use_decl_annotations_
 HRESULT

--- a/src/in-box/Client/WinMM/MidiSrvPorts.h
+++ b/src/in-box/Client/WinMM/MidiSrvPorts.h
@@ -48,6 +48,9 @@ private:
     HRESULT GetDevCaps(_In_ MidiFlow flow, _In_ UINT portNumber, _In_ DWORD_PTR midiCaps);
     HRESULT GetDevCaps(_In_ MidiFlow flow, _In_ UINT portNumber, _In_ DWORD_PTR midiCaps, _In_ DWORD_PTR midiCapsSize);
     HRESULT Open(_In_ MidiFlow flow, _In_ UINT portNumber, _In_ const MIDIOPENDESC* midiOpenDesc, _In_ DWORD_PTR flags, _In_ MidiPortHandle* openedPort);
+    // Start add with Feature_Servicing_MIDI2WinMMPortHandleSlotWidth
+    HRESULT OpenIntoPointerSizedSlot(_In_ MidiFlow flow, _In_ UINT portNumber, _In_ const MIDIOPENDESC* midiOpenDesc, _In_ DWORD_PTR flags, _In_ DWORD_PTR* openedPort);
+    // End add with Feature_Servicing_MIDI2WinMMPortHandleSlotWidth
     HRESULT Close(_In_ MidiFlow flow, _In_ MidiPortHandle portHandle);
     HRESULT ForwardMidMessage(_In_ UINT msg, _In_ MidiPortHandle portHandle, _In_ DWORD_PTR param1, _In_ DWORD_PTR param2);
     HRESULT ForwardModMessage(_In_ UINT msg, _In_ MidiPortHandle portHandle, _In_ DWORD_PTR param1, _In_ DWORD_PTR param2);

--- a/src/in-box/Inc/Feature_Servicing_MIDI2WinMMCompleteLongBufferOnFailure.h
+++ b/src/in-box/Inc/Feature_Servicing_MIDI2WinMMCompleteLongBufferOnFailure.h
@@ -1,0 +1,18 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License
+// ============================================================================
+// This is part of the Windows MIDI Services App API and should be used
+// in your Windows application via an official binary distribution.
+// Further information: https://aka.ms/midi
+// ============================================================================
+
+#pragma once
+
+class Feature_Servicing_MIDI2WinMMCompleteLongBufferOnFailure
+{
+public:
+    static bool IsEnabled()
+    {
+        return true;
+    }
+};

--- a/src/in-box/Inc/Feature_Servicing_MIDI2WinMMPortHandleSlotWidth.h
+++ b/src/in-box/Inc/Feature_Servicing_MIDI2WinMMPortHandleSlotWidth.h
@@ -1,0 +1,18 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License
+// ============================================================================
+// This is part of the Windows MIDI Services App API and should be used
+// in your Windows application via an official binary distribution.
+// Further information: https://aka.ms/midi
+// ============================================================================
+
+#pragma once
+
+class Feature_Servicing_MIDI2WinMMPortHandleSlotWidth
+{
+public:
+    static bool IsEnabled()
+    {
+        return true;
+    }
+};

--- a/src/in-box/user-tools/network-midi-setup/MainWindow.xaml
+++ b/src/in-box/user-tools/network-midi-setup/MainWindow.xaml
@@ -427,16 +427,32 @@
                                                            TextWrapping="Wrap"
                                                            Visibility="{x:Bind EndpointDeviceIdVisibility, Mode=OneWay}"
                                                            Style="{ThemeResource CaptionTextBlockStyle}" />
-                                                <Button x:Uid="CopyEndpointDeviceIdButton"
-                                                        Grid.Row="2" Grid.Column="2"
-                                                        Padding="6,2,6,2"
-                                                        VerticalAlignment="Top"
-                                                        Background="Transparent"
-                                                        BorderThickness="0"
-                                                        Visibility="{x:Bind EndpointDeviceIdVisibility, Mode=OneWay}"
-                                                        Click="OnCopyEndpointDeviceIdClick">
-                                                    <FontIcon Glyph="&#xE8C8;" FontSize="14" />
-                                                </Button>
+                                                <!-- These sit against the id rather than at the far right of the row.
+                                                     A network endpoint is bidirectional, so Monitor needs no test for
+                                                     whether the device sends anything: it always can. -->
+                                                <StackPanel Grid.Row="2" Grid.Column="2"
+                                                            Orientation="Horizontal"
+                                                            Spacing="4"
+                                                            VerticalAlignment="Top"
+                                                            Visibility="{x:Bind EndpointDeviceIdVisibility, Mode=OneWay}">
+                                                    <Button x:Uid="CopyEndpointDeviceIdButton"
+                                                            Padding="6,2,6,2"
+                                                            Background="Transparent"
+                                                            BorderThickness="0"
+                                                            Click="OnCopyEndpointDeviceIdClick">
+                                                        <FontIcon Glyph="&#xE8C8;" FontSize="14" />
+                                                    </Button>
+                                                    <Button x:Uid="MonitorEndpointButton"
+                                                            Padding="6,2,6,2"
+                                                            Background="Transparent"
+                                                            BorderThickness="0"
+                                                            Click="OnMonitorRemoteHostClick">
+                                                        <StackPanel Orientation="Horizontal" Spacing="6">
+                                                            <FontIcon Glyph="&#xE9D9;" FontSize="14" />
+                                                            <TextBlock x:Uid="MonitorEndpointButtonText" Text="Monitor" />
+                                                        </StackPanel>
+                                                    </Button>
+                                                </StackPanel>
 
                                                 <TextBlock x:Uid="RemoteHostNotAdvertisedText"
                                                            Grid.Row="3" Grid.Column="0" Grid.ColumnSpan="3"
@@ -740,6 +756,16 @@
                                                                         Orientation="Horizontal"
                                                                         Spacing="8"
                                                                         VerticalAlignment="Center">
+                                                                <Button x:Uid="MonitorEndpointButton"
+                                                                        Background="Transparent"
+                                                                        BorderThickness="0"
+                                                                        Visibility="{x:Bind MonitorVisibility, Mode=OneWay}"
+                                                                        Click="OnMonitorHostConnectionClick">
+                                                                    <StackPanel Orientation="Horizontal" Spacing="6">
+                                                                        <FontIcon Glyph="&#xE9D9;" FontSize="14" />
+                                                                        <TextBlock x:Uid="MonitorEndpointButtonText" Text="Monitor" />
+                                                                    </StackPanel>
+                                                                </Button>
                                                                 <Button x:Uid="DisconnectRemoteClientButton"
                                                                         Content="Disconnect"
                                                                         Click="OnDisconnectRemoteClientClick" />

--- a/src/in-box/user-tools/network-midi-setup/MainWindow.xaml.cpp
+++ b/src/in-box/user-tools/network-midi-setup/MainWindow.xaml.cpp
@@ -1676,6 +1676,7 @@ namespace winrt::midinetworksetup::implementation
                                         FormatCount(connection.TotalCountNetworkPacketsReceived()),
                                         FormatCount(connection.RetransmitCount())) :
                                     winrt::hstring{},
+                                connection.EndpointDeviceId(),
                                 connection.CurrentLatencyTicks(),
                                 connection.IsSessionActive(),
                                 connection.IsPendingApproval());

--- a/src/in-box/user-tools/network-midi-setup/MainWindow.xaml.h
+++ b/src/in-box/user-tools/network-midi-setup/MainWindow.xaml.h
@@ -49,6 +49,8 @@ namespace winrt::midinetworksetup::implementation
         winrt::fire_and_forget OnBrowseForImageClick(foundation::IInspectable const& sender, xaml::RoutedEventArgs const& args);
         void OnRemoveImageClick(foundation::IInspectable const& sender, xaml::RoutedEventArgs const& args);
         void OnCopyEndpointDeviceIdClick(foundation::IInspectable const& sender, xaml::RoutedEventArgs const& args);
+        void OnMonitorRemoteHostClick(foundation::IInspectable const& sender, xaml::RoutedEventArgs const& args);
+        void OnMonitorHostConnectionClick(foundation::IInspectable const& sender, xaml::RoutedEventArgs const& args);
         winrt::fire_and_forget OnDisconnectRemoteHostClick(foundation::IInspectable const& sender, xaml::RoutedEventArgs const& args);
 
         void OnManualConnectFieldChanged(foundation::IInspectable const& sender, controls::TextChangedEventArgs const& args);

--- a/src/in-box/user-tools/network-midi-setup/MainWindowActions.cpp
+++ b/src/in-box/user-tools/network-midi-setup/MainWindowActions.cpp
@@ -276,6 +276,46 @@ namespace winrt::midinetworksetup::implementation
     }
 
     _Use_decl_annotations_
+    void MainWindow::OnMonitorRemoteHostClick(foundation::IInspectable const& sender, xaml::RoutedEventArgs const&)
+    {
+        try
+        {
+            auto item = ItemOf<midinetworksetup::RemoteHostItem>(sender);
+
+            if (item == nullptr || item.EndpointDeviceId().empty())
+            {
+                return;
+            }
+
+            if (!midiapp::LaunchMonitorForEndpoint(item.EndpointDeviceId()))
+            {
+                SetRemoteStatus(res::GetString(L"StatusMonitorNotAvailable"));
+            }
+        }
+        MIDI_NETSETUP_CATCH_AND_LOG(L"Unable to open the MIDI monitor for a remote device.")
+    }
+
+    _Use_decl_annotations_
+    void MainWindow::OnMonitorHostConnectionClick(foundation::IInspectable const& sender, xaml::RoutedEventArgs const&)
+    {
+        try
+        {
+            auto item = ItemOf<midinetworksetup::HostConnectionItem>(sender);
+
+            if (item == nullptr || item.EndpointDeviceId().empty())
+            {
+                return;
+            }
+
+            if (!midiapp::LaunchMonitorForEndpoint(item.EndpointDeviceId()))
+            {
+                SetLocalStatus(res::GetString(L"StatusMonitorNotAvailable"));
+            }
+        }
+        MIDI_NETSETUP_CATCH_AND_LOG(L"Unable to open the MIDI monitor for a connected client.")
+    }
+
+    _Use_decl_annotations_
     void MainWindow::OnCopyEndpointDeviceIdClick(foundation::IInspectable const& sender, xaml::RoutedEventArgs const&)
     {
         auto item = ItemOf<midinetworksetup::RemoteHostItem>(sender);

--- a/src/in-box/user-tools/network-midi-setup/NetworkItems.h
+++ b/src/in-box/user-tools/network-midi-setup/NetworkItems.h
@@ -565,8 +565,18 @@ namespace winrt::midinetworksetup::implementation
         winrt::hstring AddressText() const noexcept { return m_addressText; }
         winrt::hstring StatusText() const noexcept { return m_statusText; }
         winrt::hstring StatisticsText() const noexcept { return m_statisticsText; }
+        winrt::hstring EndpointDeviceId() const noexcept { return m_endpointDeviceId; }
 
         bool IsPendingApproval() const noexcept { return m_isPendingApproval; }
+
+        // A network endpoint is bidirectional, so there is always something to watch once one
+        // exists. It only exists while the session is up.
+        winrt::Microsoft::UI::Xaml::Visibility MonitorVisibility() const noexcept
+        {
+            return m_endpointDeviceId.empty() ?
+                winrt::Microsoft::UI::Xaml::Visibility::Collapsed :
+                winrt::Microsoft::UI::Xaml::Visibility::Visible;
+        }
 
         winrt::Microsoft::UI::Xaml::Visibility ConnectedBadgeVisibility() const noexcept
         {
@@ -612,6 +622,7 @@ namespace winrt::midinetworksetup::implementation
             _In_ winrt::hstring const& addressText,
             _In_ winrt::hstring const& statusText,
             _In_ winrt::hstring const& statisticsText,
+            _In_ winrt::hstring const& endpointDeviceId,
             _In_ uint64_t const latencyTicks,
             _In_ bool const isSessionActive,
             _In_ bool const isPendingApproval) noexcept
@@ -621,6 +632,11 @@ namespace winrt::midinetworksetup::implementation
             UpdateField(m_statusText, statusText, L"StatusText");
             UpdateField(m_statisticsText, statisticsText, L"StatisticsText");
             UpdateField(m_isPendingApproval, isPendingApproval, L"IsPendingApproval");
+
+            if (UpdateField(m_endpointDeviceId, endpointDeviceId, L"EndpointDeviceId"))
+            {
+                RaisePropertyChanged(L"MonitorVisibility");
+            }
 
             if (UpdateField(m_isSessionActive, isSessionActive, L"IsSessionActive"))
             {
@@ -648,6 +664,7 @@ namespace winrt::midinetworksetup::implementation
         winrt::hstring m_addressText{};
         winrt::hstring m_statusText{};
         winrt::hstring m_statisticsText{};
+        winrt::hstring m_endpointDeviceId{};
 
         LatencyHistory m_latency{};
 

--- a/src/in-box/user-tools/network-midi-setup/NetworkItems.idl
+++ b/src/in-box/user-tools/network-midi-setup/NetworkItems.idl
@@ -116,8 +116,13 @@ namespace midinetworksetup
         String StatusText{ get; };
         String StatisticsText{ get; };
 
+        // empty until the session is up and the host has created an endpoint for this client
+        String EndpointDeviceId{ get; };
+
         Boolean IsPendingApproval{ get; };
         Boolean IsBusy;
+
+        Microsoft.UI.Xaml.Visibility MonitorVisibility{ get; };
 
         // matches the remote host rows: round trip latency over a rolling window
         Microsoft.UI.Xaml.Visibility ConnectedBadgeVisibility{ get; };

--- a/src/in-box/user-tools/network-midi-setup/Strings/en-US/Resources.resw
+++ b/src/in-box/user-tools/network-midi-setup/Strings/en-US/Resources.resw
@@ -368,6 +368,18 @@
   <data name="CopyEndpointDeviceIdButton.[using:Microsoft.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
     <value>Copy the MIDI Endpoint id</value>
   </data>
+  <data name="MonitorEndpointButtonText.Text" xml:space="preserve">
+    <value>Monitor</value>
+  </data>
+  <data name="MonitorEndpointButton.[using:Microsoft.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
+    <value>Watch this endpoint in the MIDI monitor</value>
+  </data>
+  <data name="MonitorEndpointButton.[using:Microsoft.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
+    <value>Watch the messages this device sends, using the MIDI monitor</value>
+  </data>
+  <data name="StatusMonitorNotAvailable" xml:space="preserve">
+    <value>The MIDI monitor could not be started. It may not be installed.</value>
+  </data>
   <data name="EndpointDeviceIdCopied" xml:space="preserve">
     <value>The MIDI Endpoint id was copied to the clipboard.</value>
   </data>

--- a/src/in-box/user-tools/network-midi-setup/midinetworksetup.vcxproj
+++ b/src/in-box/user-tools/network-midi-setup/midinetworksetup.vcxproj
@@ -146,6 +146,7 @@
     <ClInclude Include="..\midi-app-shared\MidiAppSettings.h" />
     <ClInclude Include="..\midi-app-shared\WindowChrome.h" />
     <ClInclude Include="..\midi-app-shared\MidiEndpointHelpers.h" />
+    <ClInclude Include="..\midi-app-shared\MonitorLauncher.h" />
     <ClInclude Include="..\midi-app-shared\AppearanceFlyout.h" />
   </ItemGroup>
   <ItemGroup>
@@ -174,6 +175,7 @@
     <ClCompile Include="..\midi-app-shared\MidiAppSettings.cpp" />
     <ClCompile Include="..\midi-app-shared\WindowChrome.cpp" />
     <ClCompile Include="..\midi-app-shared\MidiEndpointHelpers.cpp" />
+    <ClCompile Include="..\midi-app-shared\MonitorLauncher.cpp" />
     <ClCompile Include="..\midi-app-shared\AppearanceFlyout.cpp" />
     <ClCompile Include="$(GeneratedFilesDir)module.g.cpp" />
   </ItemGroup>

--- a/src/in-box/user-tools/network-midi-setup/pch.h
+++ b/src/in-box/user-tools/network-midi-setup/pch.h
@@ -120,6 +120,7 @@ namespace appshared = ::winrt::MidiAppShared;
 
 #include "WindowChrome.h"
 #include "MidiEndpointHelpers.h"
+#include "MonitorLauncher.h"
 #include "AppearanceFlyout.h"
 
 // XAML generated type info activates these shared types by name, so their declarations have to


### PR DESCRIPTION
This pull request introduces two main feature flags to the MIDI Services codebase: one to improve handling of long MIDI output buffers on failure, and another to address port handle sizing for compatibility. Additionally, the network MIDI setup tool gains a new "Monitor" button for endpoints, enabling users to launch a monitor for remote MIDI devices or connections directly from the UI. Below are the most important changes grouped by theme:

**Feature Flag: Complete Long Buffer on Failure**

* Added new feature flag `Feature_Servicing_MIDI2WinMMCompleteLongBufferOnFailure` (always enabled for now) to control improved handling of long MIDI output buffers. When enabled, failed sends will still complete and return the buffer to the client, preventing buffer leaks and improving compatibility with legacy applications. This includes a new method `SendLongMessageCompletingBuffer` in `CMidiPort` and logic in `ModMessage` to select the appropriate send method. [[1]](diffhunk://#diff-9aaf899c44dfa362b9c37dfe2943f475ea0d6f662741fc1612b74c66c34dbb53R1-R18) [[2]](diffhunk://#diff-ed95ffb07c0e5fc0c669bf7307528cf0dfccdd549158129a308db85b9bb3ff6bR8) [[3]](diffhunk://#diff-ed95ffb07c0e5fc0c669bf7307528cf0dfccdd549158129a308db85b9bb3ff6bR202-R209) [[4]](diffhunk://#diff-ed95ffb07c0e5fc0c669bf7307528cf0dfccdd549158129a308db85b9bb3ff6bR1032-R1104) [[5]](diffhunk://#diff-1e1e2b5b22b531bcc56ee5552eea00b9fab690ce4858fd10f8302dfb8336d1d4R59-R61)

**Feature Flag: Port Handle Slot Width**

* Introduced `Feature_Servicing_MIDI2WinMMPortHandleSlotWidth` (always enabled for now) to ensure port handles are correctly sized for the slot provided by winmm, improving cross-architecture compatibility. This includes a new method `OpenIntoPointerSizedSlot` in `CMidiPorts` and updated logic in `MidMessage` and `ModMessage` to use this method when the flag is enabled. [[1]](diffhunk://#diff-b3a132b71fe91e8dd6f4fd9325d48af56bf692f742c6dcc00da678671a13284dR1-R18) [[2]](diffhunk://#diff-698ca2113cacaa4961e9bc9bb1d9722dc2f9c58f5685fa2e48c41c37ae946ba2R11-R21) [[3]](diffhunk://#diff-698ca2113cacaa4961e9bc9bb1d9722dc2f9c58f5685fa2e48c41c37ae946ba2R275-R282) [[4]](diffhunk://#diff-698ca2113cacaa4961e9bc9bb1d9722dc2f9c58f5685fa2e48c41c37ae946ba2R345-R352) [[5]](diffhunk://#diff-698ca2113cacaa4961e9bc9bb1d9722dc2f9c58f5685fa2e48c41c37ae946ba2R1165-R1183) [[6]](diffhunk://#diff-a9dda1d541a548f0e6f4cc24afa21570a98c3363a44f7c8b2361a0e99475cbd5R51-R53)

**Network MIDI Setup Tool: Monitor Button**

* Added a "Monitor" button to the network MIDI setup UI for both endpoint and host connection rows, allowing users to launch a MIDI monitor for the selected remote device or connection. This includes new UI elements in `MainWindow.xaml`, new click handlers in `MainWindow.xaml.h` and `MainWindowActions.cpp`, and logic to determine visibility based on endpoint availability. [[1]](diffhunk://#diff-faf0f81407806d81bfc1b3656c39476abb490a041a5e1c6642c915949382bd79R430-R455) [[2]](diffhunk://#diff-faf0f81407806d81bfc1b3656c39476abb490a041a5e1c6642c915949382bd79R759-R768) [[3]](diffhunk://#diff-c05ff99aa6781d09b0678af2e70755810c180d9c01dd287b4755ca6cc1cacd12R52-R53) [[4]](diffhunk://#diff-59506c26a2eb61073426e69f1c413aa6feb8ee999588eb02f9e8018eea0dd8f1R278-R317) [[5]](diffhunk://#diff-ae959b884205f14d1fba429a6d80bf30c958c95a70d4a3fb11f3a2b5f5128c5fR568-R580) [[6]](diffhunk://#diff-ae959b884205f14d1fba429a6d80bf30c958c95a70d4a3fb11f3a2b5f5128c5fR625) [[7]](diffhunk://#diff-aeba9a2f246a439d4cfb95845d8ef26c4be312f90d449cb5cb8218fae8ef4cd3R1679)

These changes improve buffer management robustness, cross-platform compatibility, and user experience in monitoring networked MIDI devices.