### PR TITLE
Fix midiInClose / midiInReset problem after surprise removal of device

### DIFF
--- a/build/replace_wdmaud2_x86.bat
+++ b/build/replace_wdmaud2_x86.bat
@@ -1,0 +1,19 @@
+@echo off
+echo This is for copying build artifacts into the system for testing. 
+echo This will only replace the github-built Windows service and components
+echo If you are using the in-box service or dism-deployed service, this will not work.
+echo This must be run as administrator.
+echo.
+echo This is the 32-bit driver used by 32-bit winmm apps like MIDI-OX. It is a separate
+echo binary from the one in System32, so replacing that one does not cover these apps.
+
+set buildoutput="%midi_repo_root%src\in-box\VSFiles\Win32\Release"
+
+echo.
+echo Close any running 32-bit MIDI apps first. midisrv does not load this file, so
+echo stopping the service does not release it - the apps holding it do.
+pause
+
+%midi_repo_root%build\sfpcopy %buildoutput%\wdmaud2.drv %windir%\SysWOW64\wdmaud2.drv
+
+pause

--- a/src/in-box/Client/WinMM/MidiSrvPorts.cpp
+++ b/src/in-box/Client/WinMM/MidiSrvPorts.cpp
@@ -9,6 +9,7 @@
 #include "Feature_Servicing_MIDI2NumDevsPerf.h"
 #include "Feature_Servicing_MIDI2LegacyControl.h"
 #include "Feature_Servicing_MIDI2WinMMPortHandleSlotWidth.h"
+#include "Feature_Servicing_MIDI2WinMMCleanupAfterDeviceRemoval.h"
 
 using unique_hdevinfo = wil::unique_any_handle_invalid<decltype(&::SetupDiDestroyDeviceInfoList), ::SetupDiDestroyDeviceInfoList>;
 
@@ -294,7 +295,14 @@ CMidiPorts::MidMessage(UINT deviceID, UINT msg, DWORD_PTR user, DWORD_PTR param1
             hr = GetDeviceInterface(MidiFlowIn, deviceID, msg, param1, param2);
             break;
         default:
-            hr = ForwardMidMessage(msg, (MidiPortHandle) user, param1, param2);
+            if (Feature_Servicing_MIDI2WinMMCleanupAfterDeviceRemoval::IsEnabled())
+            {
+                hr = ForwardMidMessageAllowingCleanup(msg, (MidiPortHandle) user, param1, param2);
+            }
+            else
+            {
+                hr = ForwardMidMessage(msg, (MidiPortHandle) user, param1, param2);
+            }
     }
 
     return MMRESULT_FROM_HRESULT(hr);
@@ -1288,6 +1296,39 @@ CMidiPorts::ForwardMidMessage(UINT msg, MidiPortHandle portHandle, DWORD_PTR par
     RETURN_IF_FAILED(port->MidMessage(msg, param1, param2));
     return S_OK;
 }
+
+// Start add with Feature_Servicing_MIDI2WinMMCleanupAfterDeviceRemoval
+_Use_decl_annotations_
+HRESULT
+CMidiPorts::ForwardMidMessageAllowingCleanup(UINT msg, MidiPortHandle portHandle, DWORD_PTR param1, DWORD_PTR param2)
+{
+    TraceLoggingWrite(WdmAud2TelemetryProvider::Provider(),
+        MIDI_TRACE_EVENT_VERBOSE,
+        TraceLoggingString(__FUNCTION__, MIDI_TRACE_EVENT_LOCATION_FIELD),
+        TraceLoggingLevel(WINEVENT_LEVEL_INFO),
+        TraceLoggingPointer(this, "this"),
+        TraceLoggingValue(msg, "msg"),
+        TraceLoggingValue(portHandle, "MidiPortHandle"),
+        TraceLoggingValue(param1, "param1"),
+        TraceLoggingValue(param2, "param2"));
+
+    // Stop and reset are the documented way for a client to get its queued input buffers back,
+    // and neither one touches the device. Refusing them once the device is gone leaves close
+    // permanently answering MIDIERR_STILLPLAYING, so the port and its service connection are
+    // stranded until the process exits.
+    if (MIDM_STOP == msg || MIDM_RESET == msg)
+    {
+        wil::com_ptr_nothrow<CMidiPort> port;
+
+        RETURN_IF_FAILED(GetOpenedPort(MidiFlowIn, portHandle, port));
+        RETURN_IF_FAILED(port->MidMessage(msg, param1, param2));
+
+        return S_OK;
+    }
+
+    return ForwardMidMessage(msg, portHandle, param1, param2);
+}
+// End add with Feature_Servicing_MIDI2WinMMCleanupAfterDeviceRemoval
 
 _Use_decl_annotations_
 HRESULT

--- a/src/in-box/Client/WinMM/MidiSrvPorts.h
+++ b/src/in-box/Client/WinMM/MidiSrvPorts.h
@@ -53,6 +53,9 @@ private:
     // End add with Feature_Servicing_MIDI2WinMMPortHandleSlotWidth
     HRESULT Close(_In_ MidiFlow flow, _In_ MidiPortHandle portHandle);
     HRESULT ForwardMidMessage(_In_ UINT msg, _In_ MidiPortHandle portHandle, _In_ DWORD_PTR param1, _In_ DWORD_PTR param2);
+    // Start add with Feature_Servicing_MIDI2WinMMCleanupAfterDeviceRemoval
+    HRESULT ForwardMidMessageAllowingCleanup(_In_ UINT msg, _In_ MidiPortHandle portHandle, _In_ DWORD_PTR param1, _In_ DWORD_PTR param2);
+    // End add with Feature_Servicing_MIDI2WinMMCleanupAfterDeviceRemoval
     HRESULT ForwardModMessage(_In_ UINT msg, _In_ MidiPortHandle portHandle, _In_ DWORD_PTR param1, _In_ DWORD_PTR param2);
 
     HRESULT GetOpenedPort(_In_ MidiFlow flow, _In_ MidiPortHandle portHandle, _In_ wil::com_ptr_nothrow<CMidiPort> &port);

--- a/src/in-box/Inc/Feature_Servicing_MIDI2WinMMCleanupAfterDeviceRemoval.h
+++ b/src/in-box/Inc/Feature_Servicing_MIDI2WinMMCleanupAfterDeviceRemoval.h
@@ -1,0 +1,18 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License
+// ============================================================================
+// This is part of the Windows MIDI Services App API and should be used
+// in your Windows application via an official binary distribution.
+// Further information: https://aka.ms/midi
+// ============================================================================
+
+#pragma once
+
+class Feature_Servicing_MIDI2WinMMCleanupAfterDeviceRemoval
+{
+public:
+    static bool IsEnabled()
+    {
+        return true;
+    }
+};


### PR DESCRIPTION
This pull request introduces a new feature flag, `Feature_Servicing_MIDI2WinMMCleanupAfterDeviceRemoval`, and updates the WinMM MIDI client to improve cleanup behavior after device removal. The main change ensures that certain MIDI messages (`STOP` and `RESET`) are still processed for cleanup purposes, even if the device is no longer present, preventing ports from being stranded.

Feature flag introduction:

* Added the new feature flag class `Feature_Servicing_MIDI2WinMMCleanupAfterDeviceRemoval` in `Feature_Servicing_MIDI2WinMMCleanupAfterDeviceRemoval.h`, which currently always returns enabled.
* Included the new feature header in `MidiSrvPorts.cpp`.

WinMM cleanup logic improvements:

* Added the method `ForwardMidMessageAllowingCleanup` to `CMidiPorts` in both the header and implementation. This method allows `STOP` and `RESET` messages to be processed even after device removal, enabling proper cleanup of queued input buffers. [[1]](diffhunk://#diff-a9dda1d541a548f0e6f4cc24afa21570a98c3363a44f7c8b2361a0e99475cbd5R56-R58) [[2]](diffhunk://#diff-698ca2113cacaa4961e9bc9bb1d9722dc2f9c58f5685fa2e48c41c37ae946ba2R1300-R1332)
* Updated the `MidMessage` function to use the new cleanup-aware forwarding method when the feature flag is enabled.
