### PR TITLE
Feature_Servicing_MIDI2WinMMInterfaceRemovalPerf

### DIFF
--- a/src/in-box/Client/WinMM/MidiSrvPorts.cpp
+++ b/src/in-box/Client/WinMM/MidiSrvPorts.cpp
@@ -10,6 +10,7 @@
 #include "Feature_Servicing_MIDI2LegacyControl.h"
 #include "Feature_Servicing_MIDI2WinMMPortHandleSlotWidth.h"
 #include "Feature_Servicing_MIDI2WinMMCleanupAfterDeviceRemoval.h"
+#include "Feature_Servicing_MIDI2WinMMInterfaceRemovalPerf.h"
 
 using unique_hdevinfo = wil::unique_any_handle_invalid<decltype(&::SetupDiDestroyDeviceInfoList), ::SetupDiDestroyDeviceInfoList>;
 
@@ -97,7 +98,14 @@ CMidiPorts::MidiInterfaceChange
             // else it's already present so noop.
             if (!IsArrival)
             {
-                RETURN_IF_FAILED(RefreshPortsForFlow(Flow));
+                if (Feature_Servicing_MIDI2WinMMInterfaceRemovalPerf::IsEnabled())
+                {
+                    RETURN_IF_FAILED(RemovePortForInterface(Flow, notifiedInterface));
+                }
+                else
+                {
+                    RETURN_IF_FAILED(RefreshPortsForFlow(Flow));
+                }
 
                 for (auto const& [portHandle, openPort] : m_OpenPorts)
                 {
@@ -988,6 +996,38 @@ CMidiPorts::RefreshPortsForFlow(MidiFlow flow)
 
     return S_OK;
 }
+
+// Start add with Feature_Servicing_MIDI2WinMMInterfaceRemovalPerf
+_Use_decl_annotations_
+HRESULT
+CMidiPorts::RemovePortForInterface(MidiFlow flow, std::wstring const& interfaceId)
+{
+    TraceLoggingWrite(WdmAud2TelemetryProvider::Provider(),
+        MIDI_TRACE_EVENT_INFO,
+        TraceLoggingString(__FUNCTION__, MIDI_TRACE_EVENT_LOCATION_FIELD),
+        TraceLoggingLevel(WINEVENT_LEVEL_INFO),
+        TraceLoggingPointer(this, "this"),
+        TraceLoggingValue((int)flow, "MidiFlow"));
+
+    RETURN_HR_IF(E_INVALIDARG, flow != MidiFlowIn && flow != MidiFlowOut);
+
+    auto& ports = m_MidiPortInfo[flow];
+
+    for (auto it = ports.begin(); it != ports.end(); it++)
+    {
+        if (it->second.InterfaceId == interfaceId)
+        {
+            ports.erase(it);
+            break;
+        }
+    }
+
+    // The count is the highest port number in use, and the map is ordered by port number.
+    m_MidiPortCount[flow] = ports.empty() ? 0 : ports.rbegin()->first;
+
+    return S_OK;
+}
+// End add with Feature_Servicing_MIDI2WinMMInterfaceRemovalPerf
 
 
 _Use_decl_annotations_

--- a/src/in-box/Client/WinMM/MidiSrvPorts.h
+++ b/src/in-box/Client/WinMM/MidiSrvPorts.h
@@ -45,6 +45,9 @@ private:
     HRESULT GetMidiDeviceCount(_In_ MidiFlow flow, _In_ UINT32& count);
     // End remove with Feature_Servicing_MIDI2NumDevsPerf
     HRESULT RefreshPortsForFlow(_In_ MidiFlow flow);
+    // Start add with Feature_Servicing_MIDI2WinMMInterfaceRemovalPerf
+    HRESULT RemovePortForInterface(_In_ MidiFlow flow, _In_ std::wstring const& interfaceId);
+    // End add with Feature_Servicing_MIDI2WinMMInterfaceRemovalPerf
     HRESULT GetDevCaps(_In_ MidiFlow flow, _In_ UINT portNumber, _In_ DWORD_PTR midiCaps);
     HRESULT GetDevCaps(_In_ MidiFlow flow, _In_ UINT portNumber, _In_ DWORD_PTR midiCaps, _In_ DWORD_PTR midiCapsSize);
     HRESULT Open(_In_ MidiFlow flow, _In_ UINT portNumber, _In_ const MIDIOPENDESC* midiOpenDesc, _In_ DWORD_PTR flags, _In_ MidiPortHandle* openedPort);

--- a/src/in-box/Inc/Feature_Servicing_MIDI2WinMMInterfaceRemovalPerf.h
+++ b/src/in-box/Inc/Feature_Servicing_MIDI2WinMMInterfaceRemovalPerf.h
@@ -1,0 +1,18 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License
+// ============================================================================
+// This is part of the Windows MIDI Services App API and should be used
+// in your Windows application via an official binary distribution.
+// Further information: https://aka.ms/midi
+// ============================================================================
+
+#pragma once
+
+class Feature_Servicing_MIDI2WinMMInterfaceRemovalPerf
+{
+public:
+    static bool IsEnabled()
+    {
+        return true;
+    }
+};


### PR DESCRIPTION
This pull request introduces a new feature flag, `Feature_Servicing_MIDI2WinMMInterfaceRemovalPerf`, which enables a more targeted and performant removal of MIDI ports by interface ID when a device is removed. The main logic now conditionally uses this new removal approach based on the feature flag, and the supporting method is implemented in the codebase.

**Feature flag introduction and conditional logic:**

* Added a new feature flag class `Feature_Servicing_MIDI2WinMMInterfaceRemovalPerf` in `Feature_Servicing_MIDI2WinMMInterfaceRemovalPerf.h` to control whether the optimized interface removal path is enabled.
* Updated `MidiSrvPorts.cpp` to include the new feature flag header.
* Modified `CMidiPorts::MidiInterfaceChange` to check the feature flag and use the new `RemovePortForInterface` method if enabled, otherwise fall back to the existing `RefreshPortsForFlow` logic.

**New removal method implementation:**

* Added `CMidiPorts::RemovePortForInterface`, which efficiently removes a MIDI port by its interface ID and updates the port count accordingly.
* Declared the new `RemovePortForInterface` method in the `CMidiPorts` class definition in `MidiSrvPorts.h`.