### PR TITLE
WinMM device removal perf tests, Docs work, and an enum fix

### DIFF
--- a/build/tests/winmm-lock/midi-lock-probe.ps1
+++ b/build/tests/winmm-lock/midi-lock-probe.ps1
@@ -1,0 +1,234 @@
+# Measures whether CMidiPorts::m_Lock contention is observable from a WinMM client.
+#
+#   - a "sender" thread holds an open MIDI OUT port and calls midiOutShortMsg in a loop,
+#     timing every individual call (this path takes m_Lock via GetOpenedPort)
+#   - a "watcher" thread polls midiInGetNumDevs / midiOutGetNumDevs and timestamps every change
+#
+# Plug / unplug a MIDI device while it runs. Any device-change stall on the send path shows up
+# as a latency spike lining up with a device count change.
+#
+# Usage:  powershell -File midi-lock-probe.ps1 [-Seconds 60] [-OutDevice <index>] [-ListOnly]
+
+param(
+    [int]    $Seconds   = 60,
+    [int]    $OutDevice = -1,
+    [switch] $ListOnly
+)
+
+$ErrorActionPreference = 'Stop'
+
+Add-Type -TypeDefinition @'
+using System;
+using System.Collections.Generic;
+using System.Runtime.InteropServices;
+using System.Threading;
+
+public static class MidiProbe
+{
+    [DllImport("winmm.dll")] public static extern uint midiOutGetNumDevs();
+    [DllImport("winmm.dll")] public static extern uint midiInGetNumDevs();
+    [DllImport("winmm.dll", CharSet = CharSet.Unicode)]
+    public static extern uint midiOutGetDevCapsW(UIntPtr id, ref MIDIOUTCAPS caps, uint cbSize);
+    [DllImport("winmm.dll")]
+    public static extern uint midiOutOpen(out IntPtr h, uint id, IntPtr cb, IntPtr inst, uint flags);
+    [DllImport("winmm.dll")] public static extern uint midiOutShortMsg(IntPtr h, uint msg);
+    [DllImport("winmm.dll")] public static extern uint midiOutClose(IntPtr h);
+    [DllImport("winmm.dll")] public static extern uint timeBeginPeriod(uint p);
+    [DllImport("winmm.dll")] public static extern uint timeEndPeriod(uint p);
+
+    [DllImport("kernel32.dll")] public static extern bool QueryPerformanceCounter(out long v);
+    [DllImport("kernel32.dll")] public static extern bool QueryPerformanceFrequency(out long v);
+
+    [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)]
+    public struct MIDIOUTCAPS
+    {
+        public ushort wMid, wPid;
+        public uint vDriverVersion;
+        [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 32)] public string szPname;
+        public ushort wTechnology, wVoices, wNotes, wChannelMask;
+        public uint dwSupport;
+    }
+
+    public static long Freq;
+    public static long Start;
+    public static DateTime StartWall;
+
+    public static double Ms(long ticks) { return ticks * 1000.0 / Freq; }
+    public static long Now() { long v; QueryPerformanceCounter(out v); return v; }
+
+    // ETL timestamps are absolute, so every reported offset also needs a wall-clock equivalent.
+    public static string Wall(long offsetTicks)
+    {
+        return StartWall.AddMilliseconds(Ms(offsetTicks)).ToString("HH:mm:ss.fff");
+    }
+
+    // sender results
+    public static List<long>   SendTicks  = new List<long>();   // duration of each midiOutShortMsg
+    public static List<long>   SendAt     = new List<long>();   // when each call started
+    public static int          SendErrors = 0;
+
+    // watcher results
+    public static List<string> Changes = new List<string>();
+
+    public static volatile bool Stop = false;
+
+    static Thread _sender, _watcher;
+
+    public static void StartThreads(int outDevice)
+    {
+        Stop = false;
+        StartWall = DateTime.Now;
+        Start = Now();
+
+        _sender  = new Thread(Sender);
+        _watcher = new Thread(Watcher);
+        _sender.IsBackground = true;
+        _watcher.IsBackground = true;
+        _sender.Start(outDevice);
+        _watcher.Start();
+    }
+
+    public static void StopThreads()
+    {
+        Stop = true;
+        if (_sender  != null) _sender.Join(3000);
+        if (_watcher != null) _watcher.Join(3000);
+    }
+
+    public static string ListDevices()
+    {
+        var sb = new System.Text.StringBuilder();
+        uint n = midiOutGetNumDevs();
+        sb.AppendLine("MIDI OUT devices: " + n);
+        for (uint i = 0; i < n; i++)
+        {
+            var c = new MIDIOUTCAPS();
+            if (midiOutGetDevCapsW((UIntPtr)i, ref c, (uint)Marshal.SizeOf(typeof(MIDIOUTCAPS))) == 0)
+                sb.AppendLine("  [" + i + "] " + c.szPname);
+            else
+                sb.AppendLine("  [" + i + "] <caps failed>");
+        }
+        sb.AppendLine("MIDI IN devices: " + midiInGetNumDevs());
+        return sb.ToString();
+    }
+
+    public static void Sender(object arg)
+    {
+        Thread.CurrentThread.Priority = ThreadPriority.Highest;
+
+        IntPtr h;
+        uint id = (uint)(int)arg;
+
+        if (midiOutOpen(out h, id, IntPtr.Zero, IntPtr.Zero, 0) != 0)
+        {
+            SendErrors = -1;
+            return;
+        }
+
+        try
+        {
+            long nextDue = Now();
+            long interval = Freq / 500;   // aim for a send every 2 ms
+
+            while (!Stop)
+            {
+                while (Now() < nextDue && !Stop) { }
+                nextDue += interval;
+
+                long a = Now();
+                uint r = midiOutShortMsg(h, 0xFE);   // Active Sensing: single byte, makes no sound
+                long b = Now();
+
+                SendTicks.Add(b - a);
+                SendAt.Add(a - Start);
+
+                if (r != 0) SendErrors++;
+            }
+        }
+        finally { midiOutClose(h); }
+    }
+
+    public static void Watcher()
+    {
+        uint lastIn = midiInGetNumDevs();
+        uint lastOut = midiOutGetNumDevs();
+        Changes.Add(string.Format("{0,10:F1}  baseline  in={1} out={2}", 0.0, lastIn, lastOut));
+
+        while (!Stop)
+        {
+            long a = Now();
+            uint i = midiInGetNumDevs();
+            uint o = midiOutGetNumDevs();
+            long b = Now();
+
+            if (i != lastIn || o != lastOut)
+            {
+                Changes.Add(string.Format("{0,10:F1} ms  {1}  CHANGE  in={2} out={3}   (getNumDevs pair took {4:F2} ms)",
+                                          Ms(a - Start), Wall(a - Start), i, o, Ms(b - a)));
+                lastIn = i; lastOut = o;
+            }
+
+            // Kept slow on purpose: this thread takes the same lock as the sender.
+            Thread.Sleep(20);
+        }
+    }
+}
+'@
+
+[MidiProbe]::QueryPerformanceFrequency([ref]$null) | Out-Null
+$freq = 0L
+[MidiProbe]::QueryPerformanceFrequency([ref]$freq) | Out-Null
+[MidiProbe]::Freq = $freq
+
+Write-Host ([MidiProbe]::ListDevices())
+
+if ($ListOnly) { return }
+
+if ($OutDevice -lt 0) {
+    if ([MidiProbe]::midiOutGetNumDevs() -eq 0) { throw "No MIDI output devices. Create a loopback first." }
+    $OutDevice = 0
+}
+
+Write-Host "Sending to OUT device [$OutDevice] for $Seconds seconds."
+Write-Host "PLUG AND UNPLUG a DIFFERENT MIDI device a few times now.`n"
+
+[MidiProbe]::timeBeginPeriod(1) | Out-Null
+[MidiProbe]::StartThreads($OutDevice)
+
+for ($s = $Seconds; $s -gt 0; $s--) {
+    Start-Sleep -Seconds 1
+    if ($s % 10 -eq 0) { Write-Host "  $s s remaining..." }
+}
+
+[MidiProbe]::StopThreads()
+[MidiProbe]::timeEndPeriod(1) | Out-Null
+
+$ticks = [MidiProbe]::SendTicks
+$at    = [MidiProbe]::SendAt
+
+if ($ticks.Count -eq 0) { throw "No sends recorded (midiOutOpen failed?). SendErrors=$([MidiProbe]::SendErrors)" }
+
+$ms = New-Object 'double[]' $ticks.Count
+for ($i = 0; $i -lt $ticks.Count; $i++) { $ms[$i] = [MidiProbe]::Ms($ticks[$i]) }
+$sorted = [double[]]$ms.Clone(); [Array]::Sort($sorted)
+
+function Pct($a, $p) { $a[[Math]::Min($a.Length - 1, [int][Math]::Floor($a.Length * $p))] }
+
+Write-Host "`n================ midiOutShortMsg call latency ================"
+Write-Host ("  calls        : {0}" -f $ms.Count)
+Write-Host ("  send errors  : {0}" -f [MidiProbe]::SendErrors)
+Write-Host ("  median       : {0:F4} ms" -f (Pct $sorted 0.50))
+Write-Host ("  p99          : {0:F4} ms" -f (Pct $sorted 0.99))
+Write-Host ("  p99.9        : {0:F4} ms" -f (Pct $sorted 0.999))
+Write-Host ("  max          : {0:F4} ms" -f $sorted[$sorted.Length - 1])
+
+Write-Host "`n  slowest 15 calls:"
+Write-Host "      offset        wall clock        duration"
+$idx = 0..($ms.Count - 1) | Sort-Object { - $ms[$_] } | Select-Object -First 15
+foreach ($i in $idx) {
+    Write-Host ("    {0,10:F1} ms   {1}   {2,9:F3} ms" -f [MidiProbe]::Ms($at[$i]), [MidiProbe]::Wall($at[$i]), $ms[$i])
+}
+
+Write-Host "`n================ device count changes ================"
+[MidiProbe]::Changes | ForEach-Object { Write-Host "  $_" }
+Write-Host ""

--- a/build/tests/winmm-lock/midi-removal-correctness-test.ps1
+++ b/build/tests/winmm-lock/midi-removal-correctness-test.ps1
@@ -1,0 +1,141 @@
+# Correctness check for Feature_Servicing_MIDI2WinMMInterfaceRemovalPerf.
+#
+# The fix stops re-walking PnP on interface removal and instead erases the departed interface from
+# the cached map. This verifies that produces the same visible state a full refresh did: after a
+# create/remove cycle the enumerable port table must return EXACTLY to its starting contents.
+#
+# Usage:  powershell -File midi-removal-correctness-test.ps1 [-Cycles 3]
+
+param(
+    [int]    $Cycles  = 3,
+    [string] $MidiExe = 'midi'
+)
+
+$ErrorActionPreference = 'Stop'
+
+Add-Type -TypeDefinition @'
+using System;
+using System.Collections.Generic;
+using System.Runtime.InteropServices;
+
+public static class PortTable
+{
+    [DllImport("winmm.dll")] public static extern uint midiOutGetNumDevs();
+    [DllImport("winmm.dll")] public static extern uint midiInGetNumDevs();
+    [DllImport("winmm.dll", CharSet = CharSet.Unicode)]
+    public static extern uint midiOutGetDevCapsW(UIntPtr id, ref MIDIOUTCAPS c, uint sz);
+    [DllImport("winmm.dll", CharSet = CharSet.Unicode)]
+    public static extern uint midiInGetDevCapsW(UIntPtr id, ref MIDIINCAPS c, uint sz);
+
+    [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)]
+    public struct MIDIOUTCAPS
+    {
+        public ushort wMid, wPid; public uint vDriverVersion;
+        [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 32)] public string szPname;
+        public ushort wTechnology, wVoices, wNotes, wChannelMask; public uint dwSupport;
+    }
+
+    [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)]
+    public struct MIDIINCAPS
+    {
+        public ushort wMid, wPid; public uint vDriverVersion;
+        [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 32)] public string szPname;
+        public uint dwSupport;
+    }
+
+    // "index|name" for every index where GetDevCaps succeeds, plus the reported device count.
+    public static string Snapshot()
+    {
+        var sb = new System.Text.StringBuilder();
+
+        uint no = midiOutGetNumDevs();
+        sb.Append("OUTCOUNT=").Append(no).Append('\n');
+        for (uint i = 0; i < no; i++)
+        {
+            var c = new MIDIOUTCAPS();
+            if (midiOutGetDevCapsW((UIntPtr)i, ref c, (uint)Marshal.SizeOf(typeof(MIDIOUTCAPS))) == 0)
+                sb.Append("OUT ").Append(i).Append('|').Append(c.szPname).Append('\n');
+        }
+
+        uint ni = midiInGetNumDevs();
+        sb.Append("INCOUNT=").Append(ni).Append('\n');
+        for (uint i = 0; i < ni; i++)
+        {
+            var c = new MIDIINCAPS();
+            if (midiInGetDevCapsW((UIntPtr)i, ref c, (uint)Marshal.SizeOf(typeof(MIDIINCAPS))) == 0)
+                sb.Append("IN ").Append(i).Append('|').Append(c.szPname).Append('\n');
+        }
+
+        return sb.ToString();
+    }
+}
+'@
+
+$reAssoc = [regex]'Association\s*Id[^0-9a-fA-F]*([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12})'
+
+function Show-Diff($before, $after, $label) {
+    $b = $before -split "`n"
+    $a = $after  -split "`n"
+    $onlyBefore = @($b | Where-Object { $_ -and $a -notcontains $_ })
+    $onlyAfter  = @($a | Where-Object { $_ -and $b -notcontains $_ })
+    Write-Host "    $label"
+    foreach ($x in $onlyBefore) { Write-Host "      lost:  $x" -ForegroundColor Red }
+    foreach ($x in $onlyAfter)  { Write-Host "      new:   $x" -ForegroundColor Yellow }
+}
+
+$baseline = [PortTable]::Snapshot()
+$baseCount = ($baseline -split "`n" | Where-Object { $_ -match '^(OUT|IN) ' }).Count
+Write-Host "Baseline: $baseCount enumerable ports"
+Write-Host ($baseline -split "`n" | Where-Object { $_ -match 'COUNT' }) -Separator '  '
+Write-Host ""
+
+$failures = 0
+$createdIds = @()
+
+try {
+    for ($c = 1; $c -le $Cycles; $c++) {
+        Write-Host "cycle $c/$Cycles"
+
+        $out = & $MidiExe loopback create --name-a "CorrectnessA$c" --name-b "CorrectnessB$c" 2>&1 | Out-String
+        $m = $reAssoc.Match($out)
+        if (-not $m.Success) { Write-Warning "  could not parse association id"; continue }
+        $assoc = '{' + $m.Groups[1].Value + '}'
+        $createdIds += $assoc
+        Start-Sleep -Milliseconds 2500
+
+        $afterCreate = [PortTable]::Snapshot()
+        $addedOut = @(($afterCreate -split "`n") | Where-Object { $_ -match "^OUT .*Correctness" })
+        $addedIn  = @(($afterCreate -split "`n") | Where-Object { $_ -match "^IN .*Correctness" })
+        Write-Host ("  after create: +{0} out, +{1} in" -f $addedOut.Count, $addedIn.Count)
+        if ($addedOut.Count -ne 2 -or $addedIn.Count -ne 2) {
+            Write-Host "    UNEXPECTED port count after create" -ForegroundColor Red
+            $failures++
+        }
+
+        & $MidiExe loopback remove --association-id $assoc 2>&1 | Out-Null
+        $createdIds = @($createdIds | Where-Object { $_ -ne $assoc })
+        Start-Sleep -Milliseconds 2500
+
+        $afterRemove = [PortTable]::Snapshot()
+
+        if ($afterRemove -eq $baseline) {
+            Write-Host "  after remove: port table identical to baseline" -ForegroundColor Green
+        }
+        else {
+            Write-Host "  after remove: PORT TABLE DIFFERS FROM BASELINE" -ForegroundColor Red
+            Show-Diff $baseline $afterRemove "differences:"
+            $failures++
+        }
+    }
+}
+finally {
+    foreach ($id in $createdIds) { & $MidiExe loopback remove --association-id $id 2>&1 | Out-Null }
+}
+
+Write-Host ""
+if ($failures -eq 0) {
+    Write-Host "PASS - port table returned exactly to baseline after every create/remove cycle." -ForegroundColor Green
+} else {
+    Write-Host "FAIL - $failures cycle(s) left the port table wrong." -ForegroundColor Red
+}
+Write-Host ""

--- a/build/tests/winmm-lock/midi-removal-stall-test.ps1
+++ b/build/tests/winmm-lock/midi-removal-stall-test.ps1
@@ -1,0 +1,236 @@
+# Regression test for Feature_Servicing_MIDI2WinMMInterfaceRemovalPerf.
+#
+# CMidiPorts::MidiInterfaceChange used to call RefreshPortsForFlow (a full SetupDi walk) once per
+# departing interface, holding m_Lock across the burst. Every reader - including midiOutShortMsg
+# via GetOpenedPort, and midiInGetNumDevs which does nothing but read a cached int - blocked
+# behind it. Measured 14-25 ms on every removal before the fix.
+#
+# Creates and removes a loopback pair to fire the same interface-removal path as a hot unplug,
+# so no hardware is needed.
+#
+# Usage:  powershell -File midi-removal-stall-test.ps1 [-Cycles 5] [-FailAboveMs 5]
+
+param(
+    [int]    $Cycles      = 5,
+    [double] $FailAboveMs = 1.0,
+    [string] $MidiExe     = 'midi'
+)
+
+$ErrorActionPreference = 'Stop'
+$namePrefix = 'KIRRemovalTest'
+
+Add-Type -TypeDefinition @'
+using System;
+using System.Collections.Generic;
+using System.Runtime.InteropServices;
+using System.Threading;
+
+public static class StallProbe
+{
+    [DllImport("winmm.dll")] public static extern uint midiOutGetNumDevs();
+    [DllImport("winmm.dll")] public static extern uint midiInGetNumDevs();
+    [DllImport("winmm.dll", CharSet = CharSet.Unicode)]
+    public static extern uint midiOutGetDevCapsW(UIntPtr id, ref MIDIOUTCAPS caps, uint cbSize);
+    [DllImport("winmm.dll")]
+    public static extern uint midiOutOpen(out IntPtr h, uint id, IntPtr cb, IntPtr inst, uint flags);
+    [DllImport("winmm.dll")] public static extern uint midiOutShortMsg(IntPtr h, uint msg);
+    [DllImport("winmm.dll")] public static extern uint midiOutClose(IntPtr h);
+    [DllImport("winmm.dll")] public static extern uint timeBeginPeriod(uint p);
+    [DllImport("winmm.dll")] public static extern uint timeEndPeriod(uint p);
+    [DllImport("kernel32.dll")] public static extern bool QueryPerformanceCounter(out long v);
+    [DllImport("kernel32.dll")] public static extern bool QueryPerformanceFrequency(out long v);
+
+    [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)]
+    public struct MIDIOUTCAPS
+    {
+        public ushort wMid, wPid;
+        public uint vDriverVersion;
+        [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 32)] public string szPname;
+        public ushort wTechnology, wVoices, wNotes, wChannelMask;
+        public uint dwSupport;
+    }
+
+    public static long Freq, Start;
+    public static DateTime StartWall;
+    public static double Ms(long t) { return t * 1000.0 / Freq; }
+    public static long Now() { long v; QueryPerformanceCounter(out v); return v; }
+    public static DateTime Wall(long off) { return StartWall.AddMilliseconds(Ms(off)); }
+
+    public class Sample { public long At; public double Dur; public uint In, Out; }
+
+    public static List<Sample> Polls = new List<Sample>();   // getNumDevs pair timings
+    public static List<Sample> Sends = new List<Sample>();   // midiOutShortMsg timings
+    public static int SendErrors = 0;
+    public static volatile bool Stop = false;
+
+    static Thread _sender, _watcher;
+
+    public static int FindOutDeviceByName(string needle)
+    {
+        uint n = midiOutGetNumDevs();
+        for (uint i = 0; i < n; i++)
+        {
+            var c = new MIDIOUTCAPS();
+            if (midiOutGetDevCapsW((UIntPtr)i, ref c, (uint)Marshal.SizeOf(typeof(MIDIOUTCAPS))) == 0)
+                if (c.szPname != null && c.szPname.IndexOf(needle, StringComparison.OrdinalIgnoreCase) >= 0)
+                    return (int)i;
+        }
+        return -1;
+    }
+
+    public static void StartThreads(int outDevice)
+    {
+        QueryPerformanceFrequency(out Freq);
+        Stop = false;
+        StartWall = DateTime.Now;
+        Start = Now();
+        _sender = new Thread(Sender) { IsBackground = true };
+        _watcher = new Thread(Watcher) { IsBackground = true };
+        _sender.Start(outDevice);
+        _watcher.Start();
+    }
+
+    public static void StopThreads()
+    {
+        Stop = true;
+        if (_sender != null) _sender.Join(3000);
+        if (_watcher != null) _watcher.Join(3000);
+    }
+
+    static void Sender(object arg)
+    {
+        Thread.CurrentThread.Priority = ThreadPriority.Highest;
+        IntPtr h;
+        if (midiOutOpen(out h, (uint)(int)arg, IntPtr.Zero, IntPtr.Zero, 0) != 0) { SendErrors = -1; return; }
+        try
+        {
+            long next = Now(), interval = Freq / 500;
+            while (!Stop)
+            {
+                while (Now() < next && !Stop) { }
+                next += interval;
+                long a = Now();
+                uint r = midiOutShortMsg(h, 0xFE);   // Active Sensing: single byte, silent
+                long b = Now();
+                Sends.Add(new Sample { At = a - Start, Dur = Ms(b - a) });
+                if (r != 0) SendErrors++;
+            }
+        }
+        finally { midiOutClose(h); }
+    }
+
+    static void Watcher()
+    {
+        while (!Stop)
+        {
+            long a = Now();
+            uint i = midiInGetNumDevs();
+            uint o = midiOutGetNumDevs();
+            long b = Now();
+            Polls.Add(new Sample { At = a - Start, Dur = Ms(b - a), In = i, Out = o });
+            Thread.Sleep(5);
+        }
+    }
+}
+'@
+
+# The console prints a boxed table and the guid is unbraced, so anchor on the label. The endpoint
+# ids printed above it contain the interface class guid, which a naive guid match would grab.
+$reAssoc = [regex]'Association\s*Id[^0-9a-fA-F]*([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12})'
+
+$createdIds = @()
+
+$outIndex = [StallProbe]::FindOutDeviceByName('Basic App Loopback')
+if ($outIndex -lt 0) { $outIndex = [StallProbe]::FindOutDeviceByName('App Loopback') }
+if ($outIndex -lt 0) { throw "No loopback MIDI output found to send to. Create one, or edit this script." }
+
+Write-Host "Sending to MIDI OUT index $outIndex"
+Write-Host "Running $Cycles create/remove cycles.`n"
+
+[StallProbe]::timeBeginPeriod(1) | Out-Null
+[StallProbe]::StartThreads($outIndex)
+
+$removals = @()
+$creates  = @()
+try {
+    for ($c = 1; $c -le $Cycles; $c++) {
+        $a = "$namePrefix A $c"
+        $b = "$namePrefix B $c"
+
+        $tCreate = [StallProbe]::Now() - [StallProbe]::Start
+        $out = & $MidiExe loopback create --name-a $a --name-b $b 2>&1 | Out-String
+        $creates += $tCreate
+        $m = $reAssoc.Match($out)
+        if (-not $m.Success) {
+            Write-Warning "cycle ${c}: could not parse association id"
+            continue
+        }
+        $assoc = '{' + $m.Groups[1].Value + '}'
+        $createdIds += $assoc
+        Start-Sleep -Milliseconds 2500
+
+        $tRemove = [StallProbe]::Now() - [StallProbe]::Start
+        & $MidiExe loopback remove --association-id $assoc 2>&1 | Out-Null
+        $removals += $tRemove
+        $createdIds = @($createdIds | Where-Object { $_ -ne $assoc })
+        Write-Host ("  cycle {0}/{1}  created and removed {2}" -f $c, $Cycles, $assoc)
+
+        Start-Sleep -Milliseconds 2500
+    }
+}
+finally {
+    [StallProbe]::StopThreads()
+    [StallProbe]::timeEndPeriod(1) | Out-Null
+    foreach ($id in $createdIds) { & $MidiExe loopback remove --association-id $id 2>&1 | Out-Null }
+}
+
+$polls = [StallProbe]::Polls
+$sends = [StallProbe]::Sends
+if ($polls.Count -eq 0 -or $sends.Count -eq 0) { throw "no samples collected" }
+
+# The fix targets removal only, so bucket create and removal separately - arrival still refreshes.
+function InWindow($at, $marks) {
+    foreach ($m in $marks) {
+        $d = [StallProbe]::Ms($at - $m)
+        if ($d -ge -50 -and $d -le 1500) { return $true }
+    }
+    return $false
+}
+
+$pollRemoval = @($polls | Where-Object { InWindow $_.At $removals })
+$pollCreate  = @($polls | Where-Object { (InWindow $_.At $creates) -and -not (InWindow $_.At $removals) })
+$pollIdle    = @($polls | Where-Object { -not (InWindow $_.At $removals) -and -not (InWindow $_.At $creates) })
+$sendRemoval = @($sends | Where-Object { InWindow $_.At $removals })
+
+function Report($set, $label) {
+    if ($set.Count -eq 0) { Write-Host ("  {0,-36} (no samples)" -f $label); return 0 }
+    $s = ($set | ForEach-Object { $_.Dur }) | Sort-Object
+    $max = $s[$s.Count - 1]
+    Write-Host ("  {0,-36} n={1,-6} median={2,7:F3} ms   max={3,9:F3} ms" -f $label, $set.Count, $s[[int]($s.Count/2)], $max)
+    return $max
+}
+
+Write-Host "`n================ results ================"
+$null           = Report $pollIdle    "getNumDevs pair, idle"
+$null           = Report $pollCreate  "getNumDevs pair, during create"
+$maxPollRemoval = Report $pollRemoval "getNumDevs pair, during REMOVAL"
+$null           = Report $sendRemoval "midiOutShortMsg, during REMOVAL"
+Write-Host ("  send errors: {0}" -f [StallProbe]::SendErrors)
+
+Write-Host "`n  slowest 10 getNumDevs pairs in removal windows:"
+$pollRemoval | Sort-Object Dur -Descending | Select-Object -First 10 | ForEach-Object {
+    Write-Host ("    {0}   {1,8:F3} ms   in={2} out={3}" -f [StallProbe]::Wall($_.At).ToString('HH:mm:ss.fff'), $_.Dur, $_.In, $_.Out)
+}
+
+Write-Host ""
+if ($removals.Count -eq 0) {
+    Write-Host "INCONCLUSIVE - no removals were performed." -ForegroundColor Yellow
+}
+elseif ($maxPollRemoval -gt $FailAboveMs) {
+    Write-Host ("FAIL  - getNumDevs stalled up to {0:F3} ms during removal (limit {1:F1} ms)." -f $maxPollRemoval, $FailAboveMs) -ForegroundColor Red
+    Write-Host "        midiInGetNumDevs only takes the lock and reads a cached int, so this is lock wait."
+}
+else {
+    Write-Host ("PASS  - getNumDevs max {0:F3} ms during removal, under the {1:F1} ms limit." -f $maxPollRemoval, $FailAboveMs) -ForegroundColor Green
+}
+Write-Host ""

--- a/build/tests/winmm-lock/midi-walk-cost.ps1
+++ b/build/tests/winmm-lock/midi-walk-cost.ps1
@@ -1,0 +1,194 @@
+# Times the SetupDi walk that CMidiPorts::RefreshPortsForFlow performs while holding m_Lock.
+# Pure client-side PnP cost - no service involvement - so this IS the lock hold duration.
+#
+# Usage:  powershell -File midi-walk-cost.ps1 [-Iterations 20]
+
+param(
+    [int] $Iterations = 20,
+    [int] $MonitorSeconds = 0
+)
+
+$ErrorActionPreference = 'Stop'
+
+Add-Type -TypeDefinition @'
+using System;
+using System.Runtime.InteropServices;
+
+public static class WalkCost
+{
+    const uint DIGCF_PRESENT = 0x02, DIGCF_DEVICEINTERFACE = 0x10;
+
+    [StructLayout(LayoutKind.Sequential)]
+    struct SP_DEVINFO_DATA { public uint cbSize; public Guid ClassGuid; public uint DevInst; public IntPtr Reserved; }
+
+    [StructLayout(LayoutKind.Sequential)]
+    struct SP_DEVICE_INTERFACE_DATA { public uint cbSize; public Guid InterfaceClassGuid; public uint Flags; public IntPtr Reserved; }
+
+    [StructLayout(LayoutKind.Sequential)]
+    struct DEVPROPKEY { public Guid fmtid; public uint pid; }
+
+    [DllImport("setupapi.dll", CharSet = CharSet.Unicode, SetLastError = true)]
+    static extern IntPtr SetupDiGetClassDevsW(ref Guid cls, IntPtr enumerator, IntPtr hwnd, uint flags);
+    [DllImport("setupapi.dll", SetLastError = true)]
+    static extern bool SetupDiEnumDeviceInfo(IntPtr h, uint i, ref SP_DEVINFO_DATA d);
+    [DllImport("setupapi.dll", SetLastError = true)]
+    static extern bool SetupDiEnumDeviceInterfaces(IntPtr h, ref SP_DEVINFO_DATA d, ref Guid cls, uint i, ref SP_DEVICE_INTERFACE_DATA id);
+    [DllImport("setupapi.dll", CharSet = CharSet.Unicode, SetLastError = true)]
+    static extern bool SetupDiGetDeviceInterfaceDetailW(IntPtr h, ref SP_DEVICE_INTERFACE_DATA id, IntPtr detail, uint size, out uint req, IntPtr info);
+    [DllImport("setupapi.dll", CharSet = CharSet.Unicode, SetLastError = true)]
+    static extern bool SetupDiGetDeviceInterfacePropertyW(IntPtr h, ref SP_DEVICE_INTERFACE_DATA id, ref DEVPROPKEY key, out uint type, byte[] buf, uint size, out uint req, uint flags);
+    [DllImport("setupapi.dll")]
+    static extern bool SetupDiDestroyDeviceInfoList(IntPtr h);
+
+    [DllImport("kernel32.dll")] static extern bool QueryPerformanceCounter(out long v);
+    [DllImport("kernel32.dll")] static extern bool QueryPerformanceFrequency(out long v);
+
+    static Guid MidiOut = new Guid("6dc23320-ab33-4ce4-80d4-bbb3ebbf2814");
+    static Guid MidiIn  = new Guid("504be32c-ccf6-4d2c-b73f-6f8b3747e22b");
+    static Guid MidiPkey = new Guid("3f114a6a-11fa-4bd0-9d2c-6b7780cd80ad");
+    static Guid IfacePkey = new Guid("026e516e-b814-414b-83cd-856d6fef4822");
+
+    public static int LastInterfaceCount;
+
+    // Mirrors RefreshPortsForFlow: class enumeration, interface detail, then the same four
+    // per-interface property reads.
+    public static double WalkMs(bool output)
+    {
+        Guid cls = output ? MidiOut : MidiIn;
+        long freq; QueryPerformanceFrequency(out freq);
+        long a; QueryPerformanceCounter(out a);
+
+        int interfaces = 0;
+        IntPtr h = SetupDiGetClassDevsW(ref cls, IntPtr.Zero, IntPtr.Zero, DIGCF_DEVICEINTERFACE | DIGCF_PRESENT);
+
+        if (h != IntPtr.Zero && h != (IntPtr)(-1))
+        {
+            var dev = new SP_DEVINFO_DATA(); dev.cbSize = (uint)Marshal.SizeOf(typeof(SP_DEVINFO_DATA));
+            var buf = new byte[2048];
+
+            for (uint di = 0; SetupDiEnumDeviceInfo(h, di, ref dev); di++)
+            {
+                var iface = new SP_DEVICE_INTERFACE_DATA();
+                iface.cbSize = (uint)Marshal.SizeOf(typeof(SP_DEVICE_INTERFACE_DATA));
+
+                for (uint ii = 0; SetupDiEnumDeviceInterfaces(h, ref dev, ref cls, ii, ref iface); ii++)
+                {
+                    interfaces++;
+
+                    uint req;
+                    SetupDiGetDeviceInterfaceDetailW(h, ref iface, IntPtr.Zero, 0, out req, IntPtr.Zero);
+                    IntPtr detail = Marshal.AllocHGlobal((int)Math.Max(req, 8));
+                    Marshal.WriteInt32(detail, IntPtr.Size == 8 ? 8 : 6);
+                    SetupDiGetDeviceInterfaceDetailW(h, ref iface, detail, req, out req, IntPtr.Zero);
+                    Marshal.FreeHGlobal(detail);
+
+                    uint t, r;
+                    var k = new DEVPROPKEY();
+
+                    k.fmtid = MidiPkey;  k.pid = 17;   // PKEY_MIDI_ServiceAssignedPortNumber
+                    SetupDiGetDeviceInterfacePropertyW(h, ref iface, ref k, out t, buf, 4, out r, 0);
+
+                    k.fmtid = IfacePkey; k.pid = 2;    // DEVPKEY_DeviceInterface_FriendlyName
+                    SetupDiGetDeviceInterfacePropertyW(h, ref iface, ref k, out t, buf, 64, out r, 0);
+
+                    k.fmtid = MidiPkey;  k.pid = 19;   // PKEY_MIDI_DriverDeviceInterface
+                    SetupDiGetDeviceInterfacePropertyW(h, ref iface, ref k, out t, buf, 520, out r, 0);
+
+                    k.fmtid = MidiPkey;  k.pid = 56;   // PKEY_MIDI_KsComponentId
+                    SetupDiGetDeviceInterfacePropertyW(h, ref iface, ref k, out t, buf, 64, out r, 0);
+                }
+            }
+
+            SetupDiDestroyDeviceInfoList(h);
+        }
+
+        long b; QueryPerformanceCounter(out b);
+        LastInterfaceCount = interfaces;
+        return (b - a) * 1000.0 / freq;
+    }
+}
+'@
+
+if ($MonitorSeconds -gt 0) {
+
+    [WalkCost]::WalkMs($true) | Out-Null   # warm
+
+    Write-Host "Walking DEVINTERFACE_MIDI_OUTPUT every ~20 ms for $MonitorSeconds seconds."
+    Write-Host "PLUG AND UNPLUG a MIDI device a few times now.`n"
+
+    $samples = New-Object System.Collections.ArrayList
+    $deadline = (Get-Date).AddSeconds($MonitorSeconds)
+    $nextTick = $MonitorSeconds
+
+    while ((Get-Date) -lt $deadline) {
+        $when = [DateTime]::Now
+        $ms   = [WalkCost]::WalkMs($true)
+        [void]$samples.Add([pscustomobject]@{ When = $when; Ms = $ms; Count = [WalkCost]::LastInterfaceCount })
+
+        $left = [int]($deadline - (Get-Date)).TotalSeconds
+        if ($left -le ($nextTick - 10)) { $nextTick = $left; Write-Host "  $left s remaining..." }
+
+        Start-Sleep -Milliseconds 20
+    }
+
+    $all = $samples.Ms | Sort-Object
+    $med = $all[[int]($all.Count/2)]
+
+    # "Storm" = any walk within 1.5 s of an interface-count change.
+    $changeTimes = @()
+    for ($i = 1; $i -lt $samples.Count; $i++) {
+        if ($samples[$i].Count -ne $samples[$i-1].Count) { $changeTimes += $samples[$i].When }
+    }
+
+    $storm = @($samples | Where-Object { $t = $_.When; ($changeTimes | Where-Object { [Math]::Abs(($t - $_).TotalSeconds) -le 1.5 }).Count -gt 0 })
+    $quiet = @($samples | Where-Object { $t = $_.When; ($changeTimes | Where-Object { [Math]::Abs(($t - $_).TotalSeconds) -le 1.5 }).Count -eq 0 })
+
+    function Stat($set, $label) {
+        if ($set.Count -eq 0) { Write-Host ("  {0,-22} (none)" -f $label); return }
+        $s = $set.Ms | Sort-Object
+        Write-Host ("  {0,-22} n={1,-6} median={2,7:F3} ms   p95={3,7:F3} ms   max={4,8:F3} ms" -f `
+            $label, $set.Count, $s[[int]($s.Count/2)], $s[[int]($s.Count*0.95)], $s[$s.Count-1])
+    }
+
+    Write-Host "`n================ RefreshPortsForFlow-equivalent walk cost ================"
+    Stat $samples "all walks"
+    Stat $quiet   "quiet"
+    Stat $storm   "within 1.5s of change"
+
+    Write-Host "`n  interface count changes:"
+    if ($changeTimes.Count -eq 0) { Write-Host "    (none seen - was a device actually plugged?)" }
+    for ($i = 1; $i -lt $samples.Count; $i++) {
+        if ($samples[$i].Count -ne $samples[$i-1].Count) {
+            Write-Host ("    {0}   {1} -> {2} interfaces   (this walk took {3:F3} ms)" -f `
+                $samples[$i].When.ToString('HH:mm:ss.fff'), $samples[$i-1].Count, $samples[$i].Count, $samples[$i].Ms)
+        }
+    }
+
+    Write-Host "`n  slowest 20 walks:"
+    Write-Host "      wall clock       duration    interfaces   vs quiet median"
+    $samples | Sort-Object Ms -Descending | Select-Object -First 20 | ForEach-Object {
+        Write-Host ("    {0}   {1,8:F3} ms   {2,6}       {3,6:F1}x" -f `
+            $_.When.ToString('HH:mm:ss.fff'), $_.Ms, $_.Count, ($_.Ms / $med))
+    }
+    Write-Host ""
+    return
+}
+
+foreach ($flow in @($true, $false)) {
+    $name = if ($flow) { 'MIDI OUT (DEVINTERFACE_MIDI_OUTPUT)' } else { 'MIDI IN  (DEVINTERFACE_MIDI_INPUT)' }
+
+    [WalkCost]::WalkMs($flow) | Out-Null   # warm the caches, as a running driver would be
+    $times = 1..$Iterations | ForEach-Object { [WalkCost]::WalkMs($flow) }
+    $n = [WalkCost]::LastInterfaceCount
+    $sorted = [double[]]$times; [Array]::Sort($sorted)
+
+    Write-Host "`n=== $name ==="
+    Write-Host ("  interfaces walked : {0}" -f $n)
+    Write-Host ("  min               : {0:F3} ms" -f $sorted[0])
+    Write-Host ("  median            : {0:F3} ms" -f $sorted[[int]($sorted.Length/2)])
+    Write-Host ("  max               : {0:F3} ms" -f $sorted[$sorted.Length-1])
+    if ($n -gt 0) {
+        Write-Host ("  per interface     : {0:F3} ms  (median)" -f ($sorted[[int]($sorted.Length/2)] / $n))
+    }
+}
+Write-Host ""

--- a/docs/_layouts/sdk_reference_page.html
+++ b/docs/_layouts/sdk_reference_page.html
@@ -64,12 +64,13 @@ layout: default
                                     {% if iface_name contains "Windows.Foundation" %}
                                     {%   assign iface_url = "https://learn.microsoft.com/uwp/api/" | append: iface_name %}
                                     {%   assign iface_short_name = iface_name | remove: "Windows.Foundation." %}
-                                    {% elsif iface_name contains "Microsoft.Windows.Devices.Midi2" %}
+                                    {% elsif iface_name contains "Windows.Devices.Midi2" %}
                                     {%   assign root_folder = "/sdk-reference/" %}
                                     {%   assign sub_folder = iface_name | remove: "Windows.Devices.Midi2." | replace: ".", "/" %}
                                     {%   assign iface_url = root_folder | append: sub_folder | append: "/" | relative_url %}
                                     {%   assign iface_short_name = iface_name | split: "." | last %}
                                     {% else %}
+                                    {%   assign iface_url = "" %}
                                     {%   assign iface_short_name = iface_name %}
                                     {% endif %}
 

--- a/docs/kb/best-practices.md
+++ b/docs/kb/best-practices.md
@@ -23,13 +23,25 @@ The most flexible, but least performant approach, is to use the `IMidiMessage` i
 
 For C++ and C++-like languages, we've added the COM extensions for fast allocation-free send and receive of messages. All the normal WinRT types are used for Session and Connection. But when you want to send and receive messages, and can ensure the data integrity of the messages being sent (most cross-platform apps already have code to do this), the COM Extensions are the way to go. There is a C++ example in the repo and examples in the documentation.
 
+### Splitting large messages across transmissions
+
+There is a limit to how many MIDI words may be sent in a single call. That limit is available through `GetSupportedMaxMidiWordsPerTransmission`, on both the connection and the COM extension interface. If a single call contains more words than the limit allows, the whole call is rejected and nothing is sent. Because the rejection is all-or-nothing, no data has reached the device, so retrying with a smaller buffer is safe.
+
+System Exclusive is where this comes up. A SysEx7 UMP carries only six data bytes, so a 64 KB bulk dump is around 10,900 UMPs, far beyond what a single transmission can hold. Firmware updaters, patch librarians, and bulk dump tools all need to split their data and send it as a series of transmissions.
+
+Query the limit for each connection rather than hard-coding it, split only on message boundaries so that no UMP ever spans two transmissions, and stop sending as soon as one transmission fails. Any chunks already accepted have reached the device, so decide in advance how your app recovers from a partial transfer. For System Exclusive, that normally means abandoning the transfer and starting it over.
+
+If you are building a cross-platform framework or a language projection on top of this API, handle the splitting inside your own layer. Applications written against your abstraction usually cannot reach `GetSupportedMaxMidiWordsPerTransmission`, so leaving the job to them means they will hard-code a limit which is not guaranteed to remain correct.
+
+For the rules and sample code, see [`MidiEndpointConnection`]({{ site.baseurl }}/sdk-reference/MidiEndpointConnection) and [the COM Extensions]({{ site.baseurl }}/sdk-reference/MidiEndpointConnection_COM-Extensions).
+
 ## Displaying connections to your app users
 
 Most apps need to display device and endpoint connection information to their users. Here are some details related to that.
 
 ### Use the `MidiEndpointDeviceWatcher` to respond to device changes
 
-MIDI devices come and go based on connecting/disconnecting USB cables, or new network endpoints coming online. In addition, properties like Function Blocks and Endpoint Name are subject to change at any time. Use the `Microsoft::Windows::Devices::Midi2::MidiEndpointDeviceWatcher` class on a background thread to monitor these endpoints, and receive notifications when anything changes. This is a much more robust approach vs simply enumerating a snapshot of devices up-front.
+MIDI devices come and go based on connecting/disconnecting USB cables, or new network endpoints coming online. In addition, properties like Function Blocks and Endpoint Name are subject to change at any time. Use the `Windows::Devices::Midi2::Enumeration::MidiEndpointDeviceWatcher` class on a background thread to monitor these endpoints, and receive notifications when anything changes. This is a much more robust approach vs simply enumerating a snapshot of devices up-front.
 
 There's no API or service reason to require a customer to reboot or reload/restart a MIDI DAW or other application to see newly added endpoints when using Windows MIDI Services.
 

--- a/docs/kb/data-translation.md
+++ b/docs/kb/data-translation.md
@@ -31,7 +31,7 @@ The MIDI messages defined in the MIDI 2.0 UMP specifications, excluding the MIDI
 
 Windows MIDI Services supports both MIDI 1.0 and MIDI 2.0 devices.
 
-| Device | Driver | Microsoft.Windows.Devices.Midi2 | WinMM/WinRT MIDI 1.0 APIs |
+| Device | Driver | Windows.Devices.Midi2 | WinMM/WinRT MIDI 1.0 APIs |
 | ------------------- | --------------------- | -------------------------- | ------------------------ |
 | USB MIDI 1.0 Device | MIDI 2.0 Class Driver | To/From MIDI 1.0 in UMP by driver | To/from MIDI 1.0 byte data format by service |
 | USB MIDI 1.0 Device | Older MIDI 1.0 Class Driver | To/From MIDI 1.0 in UMP by service | To/from MIDI 1.0 byte data format by service |
@@ -46,7 +46,7 @@ Incoming messages are translated between protocol and data format only when nece
 
 WinMM and WinRT MIDI 1.0 will always receive correct MIDI 1.0 channel voice messages, no matter what the endpoint has.
 
-Microsoft.Windows.Devices.Midi2 will provide the UMP version of what it is provided. It does not upscale MIDI 1.0 channel voice messages to MIDI 2.0 channel voice messages. The client may use open source libraries to handle that if needed.
+Windows.Devices.Midi2 will provide the UMP version of what it is provided. It does not upscale MIDI 1.0 channel voice messages to MIDI 2.0 channel voice messages. The client may use open source libraries to handle that if needed.
 
 ### Translation between Message type 2 (MIDI 1.0 Channel Voice) and Message type 4 (MIDI 2.0 Channel Voice)
 

--- a/docs/sdk-reference/MidiEndpointConnection.md
+++ b/docs/sdk-reference/MidiEndpointConnection.md
@@ -97,6 +97,62 @@ This function sends each packet one at a time, because each packet has its own t
 > # Tip 
 > To learn more about how collections are handled in WinRT, and how they may convert to constructs like `std::vector`, see the [Collections with C++/WinRT](https://learn.microsoft.com/windows/uwp/cpp-and-winrt-apis/collections) page in our documentation.
 
+## Sending More Data Than Fits in a Single Transmission
+
+If a call contains more words than `GetSupportedMaxMidiWordsPerTransmission` allows, the entire call is rejected and **nothing is sent**. The result is `MidiSendMessageResults.Failed` combined with `MidiSendMessageResults.TransmissionWordCountExceeded`. Because the rejection is all-or-nothing, no data has reached the device, and it is safe to retry with a smaller buffer.
+
+Some payloads exceed the limit by their very nature. A System Exclusive message carries six data bytes per 64-bit SysEx7 UMP, so a 64 KB bulk dump becomes roughly 10,900 UMPs, or about 21,800 MIDI words. That will never fit in a single transmission, and so must be split by the sending code.
+
+When splitting a large buffer:
+
+1. Call `GetSupportedMaxMidiWordsPerTransmission` on the same connection you are sending to. Do not hard-code the value, and do not assume it is the same for every endpoint or for every release.
+2. Split only on message boundaries. A single UMP shall never span two transmissions.
+3. Stop as soon as a transmission fails. Continuing to send the remaining chunks after a failure only makes the device's state harder to recover.
+4. Decide in advance how to handle a partial transfer. Once an earlier chunk has been accepted, those messages have already reached the device. For System Exclusive in particular, a partially delivered message normally means the transfer has to be abandoned and restarted from the beginning.
+
+```cpp
+// Send a large buffer as a series of transmissions, without splitting any UMP.
+const uint32_t maxWords = connection.GetSupportedMaxMidiWordsPerTransmission();
+
+uint32_t offset{ 0 };
+
+while (offset < totalWords)
+{
+    // Gather whole messages until the next one would not fit
+    uint32_t chunkWords{ 0 };
+
+    while (offset + chunkWords < totalWords)
+    {
+        auto packetType = MidiMessageHelper::GetPacketTypeFromMessageFirstWord(words[offset + chunkWords]);
+
+        if (packetType == MidiPacketType::UnknownOrInvalid) return;
+
+        // the MidiPacketType value is also the message length in MIDI words
+        const uint32_t messageWords = static_cast<uint32_t>(packetType);
+
+        if (chunkWords + messageWords > maxWords) break;
+
+        chunkWords += messageWords;
+    }
+
+    if (chunkWords == 0) return;
+
+    auto sendResult = connection.SendMultipleMessagesWordArray(
+        MidiClock::TimestampConstantSendImmediately(), offset, chunkWords, words);
+
+    if (MidiEndpointConnection::SendMessageFailed(sendResult))
+    {
+        // Any earlier chunks have already reached the device. Do not send the rest.
+        break;
+    }
+
+    offset += chunkWords;
+}
+```
+
+> # Note for framework and language projection authors
+> If you are wrapping this API for another language or app framework, perform this splitting inside your wrapper instead of requiring the applications built on it to do so. Those applications usually have no way to reach `GetSupportedMaxMidiWordsPerTransmission` through your abstraction, so if they must split the data themselves, they will hard-code a limit which is not guaranteed to stay correct.
+
 
 ## Events
 

--- a/docs/sdk-reference/MidiEndpointConnection_COM-Extensions.md
+++ b/docs/sdk-reference/MidiEndpointConnection_COM-Extensions.md
@@ -83,6 +83,60 @@ interface IMidiEndpointConnectionRaw : IUnknown
 | `SetMessagesReceivedCallback` | Register a callback handler for receiving a buffer of one or more incoming messages. Currently, this is the only way to receive more than one message in a single function call. When the connection has a callback handler attached, it will not fire any message received events, nor will it process any message listeners. |
 | `RemoveMessagesReceivedCallback` | Unregister the callback. This must be done before closing and destroying the connection. |
 
+### Sending more data than fits in a single transmission
+
+`SendMidiMessagesRaw` does not validate the buffer for you. If `wordCount` is greater than `GetSupportedMaxMidiWordsPerTransmission`, the call fails, returns a failure `HRESULT`, and **nothing is sent**. Because the rejection is all-or-nothing, no data has reached the device, and it is safe to retry with a smaller buffer.
+
+This comes up most often with System Exclusive. A SysEx7 UMP carries six data bytes, so a 64 KB bulk dump is roughly 10,900 UMPs, or about 21,800 MIDI words. That will never fit in a single transmission, and so must be split by the sending code.
+
+When splitting a large buffer:
+
+1. Call `GetSupportedMaxMidiWordsPerTransmission` once per connection and keep it with your connection state. Do not hard-code the value, and do not assume it is the same for every endpoint or for every release.
+2. Split only on message boundaries. A single UMP shall never span two transmissions. The message type in the high four bits of the first word of each UMP determines that message's length, and `ValidateBufferHasOnlyCompleteUmps` will confirm that the range you are about to send contains only whole messages.
+3. Stop as soon as a transmission returns a failure `HRESULT`. Continuing to send the remaining chunks after a failure only makes the device's state harder to recover.
+4. Decide in advance how to handle a partial transfer. Once an earlier chunk has been accepted, those messages have already reached the device. For System Exclusive in particular, a partially delivered message normally means the transfer has to be abandoned and restarted from the beginning.
+
+```cpp
+UINT32 maxWords = connectionRaw->GetSupportedMaxMidiWordsPerTransmission();
+
+uint32_t offset{ 0 };
+
+while (offset < totalWords)
+{
+    // Gather whole messages until the next one would not fit
+    uint32_t chunkWords{ 0 };
+
+    while (offset + chunkWords < totalWords)
+    {
+        auto packetType = MidiMessageHelper::GetPacketTypeFromMessageFirstWord(words[offset + chunkWords]);
+
+        if (packetType == MidiPacketType::UnknownOrInvalid) return;
+
+        // the MidiPacketType value is also the message length in MIDI words
+        const uint32_t messageWords = static_cast<uint32_t>(packetType);
+
+        if (chunkWords + messageWords > maxWords) break;
+
+        chunkWords += messageWords;
+    }
+
+    if (chunkWords == 0) return;
+
+    if (!connectionRaw->ValidateBufferHasOnlyCompleteUmps(chunkWords, words + offset)) return;
+
+    if (FAILED(connectionRaw->SendMidiMessagesRaw(
+        MidiClock::TimestampConstantSendImmediately(), chunkWords, words + offset)))
+    {
+        // Any earlier chunks have already reached the device. Do not send the rest.
+        break;
+    }
+
+    offset += chunkWords;
+}
+```
+
+If you are writing a cross-platform framework or a language projection on top of this API, do this splitting inside your own layer rather than requiring the applications built on it to do so. Those applications generally cannot reach `GetSupportedMaxMidiWordsPerTransmission` through your abstraction, so if they have to split the data themselves, they will hard-code a limit which is not guaranteed to stay correct.
+
 ## IMidiEndpointConnectionMessagesReceivedCallback
 
 A single callback type may optionally handle incoming messages from multiple `MidiEndpointConnection` instances. From an SDK standpoint, there is no inherent advantage or disadvantage to having multiple handlers or a single handler as long as your code is thread-safe.

--- a/docs/sdk-reference/MidiSendMessageResultsEnum.md
+++ b/docs/sdk-reference/MidiSendMessageResultsEnum.md
@@ -25,7 +25,6 @@ These values are flags, and may be combined
 | `DataIndexOutOfRange` | `0x00400000` | Reading a full message would result in overrunning the provided array, collection, or buffer. |
 | `TimestampOutOfRange` | `0x00800000` | The provided timestamp is too far in the future to be scheduled. |
 | `TransmissionWordCountExceeded` | `0x01000000` | The number of MIDI words in the transmission exceeded the maximum supported count. |
-| `MessageListPartiallyProcessed` | `0x00F00000` | The message list was only partially processed. Not all messages were sent. |
 
 ## Example
 

--- a/src/in-box/Client/WinRT/core/MidiSendMessageResultsEnum.idl
+++ b/src/in-box/Client/WinRT/core/MidiSendMessageResultsEnum.idl
@@ -30,8 +30,6 @@ namespace Windows.Devices.Midi2
         TimestampOutOfRange =               0x00800000,
         TransmissionWordCountExceeded =     0x01000000,
 
-        MessageListPartiallyProcessed =     0x00F00000,
-
-        /*Other = 0x01000000,*/
+    //    MessageListPartiallyProcessed =     0x02000000,
     };
 }

--- a/src/in-box/Client/WinRT/core/MidiSendMessageResultsEnum_h_p.h
+++ b/src/in-box/Client/WinRT/core/MidiSendMessageResultsEnum_h_p.h
@@ -82,8 +82,7 @@ enum __x_ABI_CWindows_CDevices_CMidi2_CMidiSendMessageResults
         MidiSendMessageResults_InvalidMessageOther	= 0x200000,
         MidiSendMessageResults_DataIndexOutOfRange	= 0x400000,
         MidiSendMessageResults_TimestampOutOfRange	= 0x800000,
-        MidiSendMessageResults_TransmissionWordCountExceeded	= 0x1000000,
-        MidiSendMessageResults_MessageListPartiallyProcessed	= 0xf00000
+        MidiSendMessageResults_TransmissionWordCountExceeded	= 0x1000000
     } ;
 
 


### PR DESCRIPTION
This pull request adds three new PowerShell regression and correctness test scripts for the WinMM MIDI lock and device removal behaviors. These scripts are designed to measure lock contention, verify correct device table restoration after interface removal, and detect stalls during device removal operations. They provide automated ways to validate recent fixes and ensure performance and correctness in MIDI device handling.

**New test scripts for WinMM MIDI device handling:**

* **Lock contention and latency measurement:**
  - Added `midi-lock-probe.ps1`, which measures whether contention on `CMidiPorts::m_Lock` is observable from a WinMM client by timing `midiOutShortMsg` calls and correlating latency spikes with device count changes. This helps detect if device changes cause stalls for MIDI clients.

* **Device removal performance regression testing:**
  - Added `midi-removal-stall-test.ps1`, a regression test for the device removal performance fix. It measures the time taken by `midiInGetNumDevs` and `midiOutShortMsg` during loopback device removal cycles to ensure that the lock is not held for excessive durations.

* **Device removal correctness verification:**
  - Added `midi-removal-correctness-test.ps1`, which verifies that after MIDI device create/remove cycles, the enumerable port table returns exactly to its baseline state, ensuring that the new removal logic produces correct observable results.