### PR TITLE
Sept 2026 work

### DIFF
--- a/.github/skills/midi-contributing/SKILL.md
+++ b/.github/skills/midi-contributing/SKILL.md
@@ -1,0 +1,209 @@
+---
+name: midi-contributing
+description: >
+  Write, review or submit a code change to Windows MIDI Services (microsoft/MIDI).
+
+  USE FOR: implementing a fix or feature in this repository; deciding whether a change needs a
+  servicing gate (KIR); reviewing a diff or a pull request; adding or changing user-visible
+  strings; adding a transport, tool, test or sample; preparing a change for submission.
+
+  DO NOT USE FOR: scoping or filing a defect before it is understood (use midi-bug-reports);
+  documentation-only edits under docs/ that touch no code; using the shipped SDK in your own app.
+---
+
+# Contributing code to Windows MIDI Services
+
+This code runs inside a Windows service, inside a kernel-mode-adjacent driver stack, and inside
+every music app on the machine. A crash here takes out MIDI for the whole PC, and much of it
+ships in Windows, where a bad change has to be serviced rather than simply patched.
+
+Read [CONTRIBUTING.md](../../../CONTRIBUTING.md) for process, licensing and the CLA.
+This skill is about the change itself.
+
+## Before you write anything
+
+1. **Find out whether the code you are about to touch ships in Windows.** That single fact
+   determines whether you need a servicing gate, and it is the most commonly missed requirement in
+   this repository. See [references/kir-servicing.md](references/kir-servicing.md).
+2. **Do not change public API surface without asking first.** The `Windows.Devices.Midi2` WinRT
+   API ships in box and shipping applications have taken a dependency on it. Adding a method,
+   changing a signature, renaming a parameter or renumbering an enum can break an already-shipped
+   application. Propose it in the issue or PR and let the maintainers decide.
+3. **New external dependencies must be declared explicitly** and must be available as a vcpkg
+   port, because the internal build system that signs and ships this code requires it. For JSON,
+   the only supported library is `Windows.Data.Json`.
+4. **Match the surrounding code.** This repository has strong local conventions per project
+   (naming, tracing, error codes, resource ids). Copy the neighboring file rather than importing a
+   style from elsewhere.
+
+## The five rules that get broken most often
+
+### 1. Changes to shipping code must be wrapped in a servicing gate (KIR)
+
+Any change to code that has already shipped in Windows must be selectable at run time, so it can
+be rolled back in servicing without rebuilding. The trigger is the **location of the file**, not
+the size of the diff: a one-line fix in `midisrv` still needs a gate.
+
+Only two things decide whether the gating is right:
+
+1. **With the gate disabled, the behavior and the code is exactly what shipped.**
+2. **The result still reads sensibly to a human.**
+
+Where the branch goes follows from those, and depends on the shape of the change:
+
+| The change | Where the gate goes |
+|---|---|
+| Changes a function's signature | The call site. There is no other option — a signature cannot be conditional. |
+| Would need several `if (Feature_Servicing_...)` branches inside one function | Add a net-new function beside the old one and branch once at the call site |
+| A small piece of code inside an existing function | Branch in place, inside the function. That is fine. |
+| Rewrites how a whole class behaves | Build a net-new class beside the old one and choose between them in the factory that constructs it |
+
+The call-site form, where that is the right choice:
+
+```cpp
+if (Feature_Servicing_MIDI2VirtualDeviceRemovalDeadlock::IsEnabled())
+{
+    RETURN_IF_FAILED(table->OnDeviceDisconnectedAlwaysTeardown(m_endpointId));
+}
+else
+{
+    RETURN_IF_FAILED(table->OnDeviceDisconnected(m_endpointId));
+}
+```
+
+Whichever form you pick: never combine another condition with the gate check in one `if` — nest
+instead. Never rename an existing function; add a net-new one beside it, or the rollback path
+disappears. The `else` branch must be the original code, unchanged, byte-for-byte, except for the new indent inside the braces.
+
+Full rules, the shipping/not-shipping list, test gating and how to prove the gate works:
+[references/kir-servicing.md](references/kir-servicing.md).
+
+### 2. SAL-annotate every function parameter
+
+Every named parameter on every function declaration gets a SAL annotation: `_In_`, `_In_opt_`,
+`_Out_`, `_Out_opt_`, `_Inout_`, `_In_reads_(n)`, `_Out_writes_(n)` and so on. This is what lets
+static analysis find the buffer and null-pointer defects that reviewers will not.
+
+When a function is declared in a header and defined in a `.cpp`, the **definition uses
+`_Use_decl_annotations_` and bare parameters** — do not repeat the annotations:
+
+```cpp
+// MidiEndpointTable.h
+HRESULT OnDeviceDisconnectedAlwaysTeardown(_In_ std::wstring const deviceEndpointInterfaceId) noexcept;
+
+// MidiEndpointTable.cpp
+_Use_decl_annotations_
+HRESULT MidiEndpointTable::OnDeviceDisconnectedAlwaysTeardown(std::wstring const deviceEndpointInterfaceId) noexcept
+{
+```
+
+For a function defined inline in the header, annotate the parameters there directly. Annotate COM
+method declarations too, including inside `STDMETHOD(...)`. Lambda parameters are not annotated.
+
+### 3. en-US spelling everywhere, including identifiers
+
+en-GB spellings are defects, not style preferences — in UI strings, `.resw` and `.rc` values,
+`#define` and variable names, comments, documentation and commit messages alike. The forms that
+actually get through are the `-our`, `-ise`/`-isation`, `-re`, `-ce` and doubled-`l` groups; the
+full do-not-write table is in the instruction file linked below.
+
+```powershell
+pwsh -File build\check_en_us_spelling.ps1 -Path <file or folder>
+```
+
+Run it before handing work back; it exits non-zero on a hit and understands `SNAKE_CASE` and
+`camelCase`, so it catches API-shaped identifiers that a plain word search misses. Rules and the
+word list:
+[.github/instructions/en-us-spelling.instructions.md](../../instructions/en-us-spelling.instructions.md).
+
+### 4. User-facing strings live in resource files
+
+Never hardcode a string a human will read. The project is localized, and a literal in code cannot
+be translated.
+
+| Project type | Where the strings go | How to read them |
+|---|---|---|
+| WinUI 3 tools | `Strings\en-US\Resources.resw`, keyed by `x:Uid` | `x:Uid` in XAML, `StringResources::GetString` / `FormatString` in code |
+| Console tools, service, transports | `resource.h` (`IDS_*`) + `Resources.rc` `STRINGTABLE` | `internal::ResourceGetWString(IDS_X)` / `ResourceGetHString` |
+
+- Format with `std::format`-style `{0}` `{1}` placeholders, not `%1`. Keep any trailing space
+  inside the resource string.
+- A `.resw` key prefix matching an `x:Uid` is not enough: every localizable property needs its own
+  key (`MyBox.Header`, `MyBox.PlaceholderText`, ...), or the literal in the XAML ships
+  untranslatable.
+- Renaming a resource key means changing it on **both** sides. A one-sided rename compiles and
+  then fails at run time with a missing (empty) string. If a string renders blank, the id is
+  missing from the `.rc`/`.resw`, not from your logic.
+- Do **not** localize machine-parseable output: `mididiag` field and section labels, field values,
+  device ids, and anything an app or script parses stay as constants.
+- Adding entries to a `.rc` or `.resw` needs no servicing gate — resources are inert data. The
+  code that *reads* them is the change, and in shipping code that does need one.
+- Do **not** localize messages in a Trace Logging statement
+
+### 5. Review your own change for the failure classes that hurt here
+
+Before submitting, walk your diff against this list. Every one of these has caused a real,
+customer-visible defect in this project.
+
+- **Use after free** — a `[this]` capture in an event handler, a coroutine parameter taken by
+  reference, or a callback invoked after the owner was torn down.
+- **Time of check to time of use** — a lock released between validating state and acting on it; a
+  path validated and then re-opened; a "still pending?" check that is not part of the same
+  atomic transition.
+- **Escaping exceptions** — an exception leaving an `HRESULT`-returning function, a thread body, a
+  `noexcept` function or a `fire_and_forget` coroutine terminates the process. In `midisrv` that
+  is every MIDI app on the machine.
+- **A module missing `<wil\cppwinrt.h>`** — WIL does not recognize `winrt::hresult_error`, treats
+  it as unrecoverable and **fail-fasts**, so every `CATCH_LOG()` and `CATCH_RETURN()` in the binary
+  becomes a crash site instead of a handler. Any module using both WIL and C++/WinRT needs the
+  include in its precompiled header, first among the WIL includes.
+- **Locks** — SRW locks are not recursive in any combination, including taking shared after
+  exclusive on the same thread. Never call out (callback, COM, network, WinRT async) while holding
+  a lock. Keep one global lock order.
+- **Blocking inside an event handler or callback** — calling `.get()` on a WinRT async operation
+  from a device watcher, DevQuery or socket callback holds a system callback thread. The watcher
+  can be aborted for exceeding its notification budget and then goes permanently and silently
+  blind; on an STA the same call trips a blocking-wait check or deadlocks outright. Queue the work
+  to your own worker and return in microseconds.
+- **Untrusted input** — the configuration file is writable by a standard user and the service runs
+  as `LOCAL SERVICE`. Treat config JSON, device-supplied names and network packets as hostile.
+- **Silent failure** — a `catch` that returns a default, a fallback that logs nothing, a wrong-type
+  JSON value that quietly disappears. A defect you cannot see in a trace is worse than a crash.
+
+The concrete patterns, the idioms that look correct and are not, and what to grep for:
+[references/code-safety-review.md](references/code-safety-review.md).
+
+## Verify before you hand it back
+
+A change is not done because it compiles. In order:
+
+1. It builds for **every** platform and configuration the project supports, not just x64 Release.
+2. The relevant test suites pass, **and you rebuilt the tests**, not only the code under test.
+3. The binary you tested is the binary you built — check timestamps or hashes, do not assume.
+4. If you gated the change, you proved the gate by turning it off, rebuilding and re-running.
+5. `build\check_en_us_spelling.ps1` is clean over what you touched.
+6. `git status` is clean of incidental files, and `git diff` shows only what you meant to change.
+
+Build commands, test runners, the stale-binary traps and how to prove a deployment is live:
+[references/build-and-verify.md](references/build-and-verify.md).
+
+## What to say in the pull request
+
+- Which files ship in Windows, and the servicing gate name covering them — or why none is needed.
+- What you built and what you ran, including platforms and configurations, and the pass counts.
+- **What you did not verify.** Missing hardware, an elevated step you could not perform, a
+  platform you could not build. An honest gap is more useful than a confident summary.
+- Any new external dependency, any change to public API surface, and any new file that has to be
+  installed or registered.
+- Tag AI-generated analysis as **"AI Generated Content"**, as the issue forms require.
+
+## Things not to do
+
+- Do not add features, refactors or "improvements" beyond the change being asked for. Churn in
+  shipping code costs a servicing gate for no benefit.
+- Do not fix a defect you have not reproduced. Scope it first with the
+  **midi-bug-reports** skill.
+- Do not delete or rename shipped API members to fix them. Public surface is additive only.
+- Do not put message payload data in retail tracing. Pointers, byte counts, device ids and names
+  are fine; the contents of a MIDI message are a privacy violation outside `_DEBUG`.
+- Do not add tracing to the per-message hot path.

--- a/.github/skills/midi-contributing/references/build-and-verify.md
+++ b/.github/skills/midi-contributing/references/build-and-verify.md
@@ -1,0 +1,140 @@
+# Building, testing and verifying a change
+
+## Solutions
+
+| Solution | What it builds |
+|---|---|
+| `src/in-box/Midi2.sln` | The service, transports, transforms, WinMM client, shared libraries and their tests |
+| `src/in-box/Midi2-AppSDK.sln` | The `Windows.Devices.Midi2` WinRT SDK, the console, the GUI tools and the SDK tests |
+| `src/in-box/Drivers/USBMIDI2/Driver/USBMidi2.sln` | The USB MIDI 2.0 class driver |
+| `src/installers/*.sln` | The installers and bundles |
+
+## Building a single project
+
+```powershell
+& $msbuild <project>.vcxproj /t:Build /p:Configuration=Release /p:Platform=x64 `
+    "/p:SolutionDir=<repo>\src\in-box\\" /v:minimal /nologo
+```
+
+- **`SolutionDir` is required**, including the trailing double backslash, or the build fails with
+  `C1083: Cannot open include file: 'MidiDefs.h'`. This applies to managed projects that reference
+  a native project too.
+- Solution-level `/t:ProjectName` does not work on these solutions. Build the project file.
+- **Static libraries are not rebuilt by their dependents.** Build the library first, then everything
+  that links it. Changing a shared static library means rebuilding the service, several transports
+  and the WinMM driver.
+- Filter output with `": error C|: fatal error|: error MSB|: error LNK"`. Do not grep bare `error`
+  — several source files have `Error` in their names and flood the match.
+- Redirect long builds to a log file; the output is large enough to be truncated inline.
+- When `/WX` promotes a warning, the first error MSBuild prints is often not the useful one. Read
+  the full `.log` under the project's intermediate directory.
+
+### Build failures that are not your change
+
+| Symptom | Cause | Fix |
+|---|---|---|
+| `MSB6003 ... .tlog being used by another process` | Orphaned MSBuild nodes from an interrupted build | Stop the MSBuild processes, rebuild with `/nodeReuse:false`. Do not background long solution builds. |
+| `MIDL2011: unresolved type declaration Microsoft.UI.Xaml.*` | A deleted `obj\` took `project.assets.json` with it, so package targets never imported | `msbuild <sln> /t:Restore`, then build |
+| `C1301: error accessing program database ... .ipdb, invalid format` | Stale incremental link database | Delete the `.ipdb`/`.iobj` and rebuild |
+| `LNK1104: cannot open file ....dll` | Transient file lock | Re-run the build |
+| `C2259: cannot instantiate abstract class` after an IDL edit | Stale generated header, or a trailing `const` MIDL discarded | Compare header and `.idl` timestamps; rebuild the IDL project per platform |
+
+## Running tests
+
+Tests are TAEF:
+
+```
+"C:\Program Files (x86)\Windows Kits\10\Testing\Runtimes\TAEF\x64\TE.exe" <test>.dll /logOutput:Low
+```
+
+- `/logOutput:High` to see `Log::Comment` output.
+- `/select:` and `/name:` filters get mangled by PowerShell quoting. Put them in a temporary `.cmd`
+  file. Repeating `/name:` does not union the filters — the last one wins.
+- **Run both sets.** Service and transport suites live under `src/in-box/VSFiles/<plat>/<cfg>/`;
+  SDK suites live under `src/in-box/vsfiles-sdk/out/tests/<plat>/<cfg>/`. A change validated
+  against only one set has shipped a break in the other.
+
+### Rebuild the tests, not just the code under test
+
+The SDK binary is resolved from the test folder, and that copy is refreshed **only when a test
+project is built**. Building the SDK alone leaves the tests running the old SDK, so the results are
+meaningless and look like "my fix did nothing".
+
+If every `Midi2.WinRTClient.*` suite fails with `Class not registered [0x80040154]`, that means
+*rebuild the tests*, not "registration is broken on this machine".
+
+After building, confirm the two copies match:
+
+```powershell
+(Get-FileHash $sdkBuildOutput).Hash -eq (Get-FileHash $sdkCopyInTestFolder).Hash   # must be True
+```
+
+The same class of stale-binary trap applies to tools that consume the SDK. An
+`InvalidCastException` from an SDK call means the projection was regenerated against a newer
+metadata file than the DLL sitting next to the executable.
+
+## Writing tests
+
+- **Never let a test pick an arbitrary MIDI device.** Target a loopback endpoint by id. "First in
+  the list" has landed on a real instrument mid-firmware-update.
+- **Clean up anything written to the running service.** A configuration payload goes to the live
+  service, not to a file, and survives until restart. Use a `wil::scope_exit` per test *and* sweep
+  the same ids again in class cleanup, because a skipped or blocked test never runs its own
+  cleanup.
+- **Watch cross-test coupling.** A test that leaves a timing value at its floor gives every later
+  test an unusually aggressive background scanner.
+- **Count what you mean to count.** Callbacks are not messages: the cross-process reader coalesces
+  queued messages that share a timestamp into one callback with a larger payload, so counting
+  callbacks under-counts. Derive the count from the payload size and make the completion trigger
+  `>=`, not `==`.
+- **Do not call `uninit_apartment` in a test.** The test host already initialized the apartment;
+  tearing it down breaks every later test in the process.
+- **Implement `QueryInterface` properly even in test objects.** Returning `S_OK` for everything
+  claims `IMarshal` and `IAgileObject` and never writes the out pointer.
+- **Assert the specific error code**, not just failure — see the discriminating-test note in
+  [kir-servicing.md](kir-servicing.md).
+- **Benchmark Release, never Debug.** The same list operation measured 4,731 ms in Debug and 232 ms
+  in Release. Do not design around a Debug number.
+
+### Test failures that are environmental
+
+- Repeated test runs accumulate deactivated software device nodes. Thousands of them make raw
+  device enumeration take seconds and time out watcher tests. Count the stale nodes and split live
+  from deactivated before blaming a change. `build\remove_deactivated_midi_devices.ps1` cleans them
+  up; run it more than once.
+- Endpoint enumeration speed depends on which build of the service is installed. Poll for a
+  non-empty list rather than sleeping for a fixed interval.
+
+## Deploying to test against the running service
+
+Deployment needs elevation. Most binaries go to `System32`; **some transports load from
+`C:\Program Files\Windows MIDI Services\Service\` instead**, and there are separate helper scripts
+under `build\` for those. A stale copy of one of them makes the service answer
+"Unrecognized command." to any newer verb.
+
+Confirm the real load path from the CLSID's `InprocServer32` registry value rather than assuming
+`System32`, and hash- or timestamp-check the deployed file before believing any test result.
+
+## Verifying a service-crash fix
+
+"The tests passed" is not sufficient — the RPC returns before the service dies, so tests report
+success while the service is crashing underneath them.
+
+Capture the service process id before and after, plus a fault count since a timestamp mark, and
+check the Application event log's **faulting module** field.
+
+## Before you hand the change back
+
+```powershell
+pwsh -File build\check_en_us_spelling.ps1 -Path <files or folders you touched>
+git status
+git diff
+```
+
+- Running any build target rewrites a tracked generated version header with today's date. Check for
+  it in `git status` and revert it, or it rides along in your diff.
+- Review the diff. It is what catches an edit that landed at the wrong offset, and it is cheap.
+- Confirm the built binary is **newer than the source you changed** before interpreting any test
+  result. A passing test against a four-minute-old executable has proved nothing.
+- State plainly what you could not verify: a platform you did not build, an elevated step you could
+  not run, hardware you do not have.

--- a/.github/skills/midi-contributing/references/code-safety-review.md
+++ b/.github/skills/midi-contributing/references/code-safety-review.md
@@ -1,0 +1,237 @@
+# Reviewing your own change: the failure classes that hurt here
+
+Walk your diff against this list before you submit. Each item below has produced a real,
+customer-visible defect in this project — a dead service, a lost firmware update, a silent MIDI
+port, or an app that will not start.
+
+## 1. Escaping exceptions kill the process
+
+In `midisrv` that means every MIDI application on the machine stops working, and the service
+often cannot even be stopped afterward because the wedged threads block `SERVICE_CONTROL_STOP`.
+
+Four places an exception is fatal, and all four appear in this repository's history:
+
+- **An `HRESULT`-returning function that calls throwing code.** Callers use `RETURN_IF_FAILED` /
+  `LOG_IF_FAILED` and are entitled to rely on the signature. Wrap the body in `try` +
+  `CATCH_RETURN()`. C++/WinRT throws far more readily than it looks: a constructor rejecting a
+  malformed string throws `E_INVALIDARG` from deep inside a generated header.
+- **A thread body.** `std::thread` and `std::jthread` call `std::terminate` on an escaping
+  exception. `LOG_IF_FAILED(Worker())` in the lambda catches HRESULTs, **not exceptions**, and a
+  worker started with `std::bind_front(&Class::Worker, this)` has no wrapper at all.
+- **A `noexcept` function.**
+- **A `fire_and_forget` coroutine.** Its promise type calls `winrt::terminate()`. The process dies
+  with nothing logged.
+
+**Put the `try` inside the worker loop, not around the whole function.** A function-level guard
+converts "the service crashes loudly" into "the worker thread dies silently and nothing is ever
+created again", which is worse. Log and continue per iteration; keep a function-level guard only
+as a last resort.
+
+**Do not treat "this function contains a catch" as guarded.** Compare the position of the first
+throwing call against the position of the first handler — a handler *below* the throwing call
+protects nothing.
+
+### `<wil/cppwinrt.h>` is mandatory in any module using both WIL and C++/WinRT
+
+`winrt::hresult_error` does not derive from `std::exception`. Without `<wil/cppwinrt.h>`, WIL does
+not recognize it, treats it as unrecoverable, and **fail-fasts**. Every `CATCH_LOG()`,
+`CATCH_RETURN()` and `LOG_CAUGHT_EXCEPTION()` in the module becomes a crash site — the exact
+opposite of what the defensive catch was for.
+
+- Include it in `pch.h`/`stdafx.h`, first among the WIL includes. Include order relative to
+  C++/WinRT does not fix it; the header is opt-in and installs the translator.
+- This repository writes the include with a backslash: `#include <wil\cppwinrt.h>`. Grepping for
+  `wil/cppwinrt.h` returns nothing and looks like the include is absent.
+
+### Recognizing `0xC0000409`
+
+Faulting module `ucrtbase.dll` means `abort()`/`terminate` — an exception escaped a thread body or
+a `noexcept` function. Faulting module = your own binary or WIL means a WIL fail-fast — usually
+the missing `<wil/cppwinrt.h>`. Split those two first, before theorizing.
+
+## 2. Lifetime and use after free
+
+- **Coroutine parameters must be taken by value.** A reference parameter is not stored in the
+  coroutine frame, so after the first `co_await` it dangles. This is worst in XAML event handlers,
+  where the framework releases the args the moment the handler returns at its first suspend point.
+  This shipped as an access violation in a released preview.
+- **Event handlers must capture `weak_from_this()`** and re-check a shutdown flag on entry.
+  Revoking a token does **not** drain handlers already in flight.
+- **A watcher or browser you do not own needs its stop to drain.** Cancel, then spin on an
+  in-flight counter, and only then clear the handlers.
+- **`[this]` captures are mostly fine** — synchronous callbacks and `jthread` members that join in
+  their destructor are safe. Classify them rather than converting them all; the ones that matter
+  are event tokens and callbacks into objects owned elsewhere.
+- **After moving a member between a base and a derived class, sweep for a redeclared member.** C++
+  shadows silently: the base initializes its copy, the derived code reads its own empty one, and
+  the forwarding chain looks correct at every step.
+- Releasing a callback and tearing down an endpoint often **re-enters synchronously** through the
+  bidirectional stream's `Shutdown`. Release the callback before deleting the endpoint.
+
+## 3. Concurrency, locks and TOCTOU
+
+- **SRW locks are not recursive in any combination.** Taking shared after exclusive on the same
+  thread deadlocks exactly like exclusive after exclusive. "Shared is safe because it does not
+  mutate" is wrong.
+- **Never call out while holding a lock** — no callbacks, no COM, no network, no WinRT async, no
+  blocking wait. Copy what you need under the lock (a `com_ptr` addref keeps the callee alive),
+  release, then call. Almost every deadlock in this project's history is this one mistake.
+- **Keep one global lock order** and do not invert it anywhere. Measure nesting by **brace depth**,
+  not proximity: two adjacent scoped blocks are sequential, not nested, and a proximity scan
+  produces mostly false positives.
+- **Nothing on a socket receive callback, a device-watcher callback or a PnP notification callback
+  may block on the service.** Queue the work to a background worker and return in microseconds.
+  Creating or deleting an endpoint raises PnP notifications that re-enter the same locks.
+- **TOCTOU:** a "still pending?" check and the action it guards must be one atomic transition under
+  one lock acquisition. Building a connection takes seconds; if the user can remove the definition
+  in that window, the object gets registered anyway and becomes invisible and unreachable while
+  holding a socket and an endpoint. The fix is an `AddIfStillPending`-style operation, not a
+  re-check.
+- **Insert and erase must use the same normalized key.** An insert that normalizes and an erase
+  that does not is a silent no-op leaving a stale entry that blocks re-creation forever.
+- **A new thread must call `winrt::init_apartment()`**, or its COM and WinRT calls fail with
+  `CO_E_NOTINITIALIZED` and the work silently stops happening.
+- **Declare `jthread` members last** in the class (reverse-order destruction) and join them
+  explicitly in `Shutdown`, with a `get_id() != std::this_thread::get_id()` self-join guard.
+- **Clear an "in progress" flag on every exit path.** A refresh loop that hands the flag to a
+  dispatcher lambda leaks it whenever the dispatcher is null or the enqueue fails, and the page
+  silently stops refreshing forever.
+
+### Never `.get()` a WinRT async operation from a callback or a UI thread
+
+Blocking a thread you do not own is not just slow. The failures are qualitatively different from
+"the call took a while", and all three have happened here.
+
+- **In a device watcher or DevQuery callback**, the blocking call holds a system callback thread.
+  A watcher that exceeds its notification budget is put into `DeviceWatcherStatus::Aborted` by the
+  system, and an aborted watcher goes **permanently and silently blind** — it never reports another
+  arrival or removal, and it never reports `Stopped` either, so a stop poll waiting for `Stopped`
+  hangs. The visible symptom is a device that is never re-enumerated until the service restarts,
+  which looks exactly like a driver defect and is not. Recovering needs an explicit
+  restart-if-aborted path with backoff; the real fix is to push the work onto a worker thread and
+  return from the callback in microseconds.
+- **On an STA UI thread**, it trips `winrt::impl::check_sta_blocking_wait` (a debug assert dialog),
+  and nested calls such as creating an endpoint connection can hang forever, because the apartment
+  cannot service the nested call while it is blocked.
+- **Wrapping it in a helper that does `co_await winrt::resume_background()` first does not fix
+  it.** C++/WinRT's `wait_get` calls `check_sta_blocking_wait()` unconditionally, before it even
+  looks at `Status()`, so converting a raw `.get()` into such a helper moves the assert one frame
+  deeper and changes nothing. Wait via `Completed()` plus an event, then `GetResults()` (which
+  rethrows on failure exactly like `get()`), and skip the wait entirely when the operation has
+  already completed. Do not use `CoWaitForMultipleHandles` — it pumps, which reintroduces the
+  reentrancy you were avoiding.
+
+In UI code, prefer not needing the call at all: a watcher's enumerated-devices collection already
+hands you the objects, so you rarely have to look one up by id.
+
+## 4. Untrusted input
+
+The configuration file is writable by a standard user, and the service runs as `LOCAL SERVICE`.
+Device-supplied names, network packets and configuration values are all hostile input.
+
+- **WinRT JSON "default" accessors only cover a missing key, not a wrong type.**
+  `GetNamedString(name, L"")` and `GetNamedObject(name, nullptr)` **throw** when the name is
+  present and holds another type. Check `HasKey` plus `ValueType()` first.
+- **`entry.try_as<json::JsonObject>()` always returns `nullptr`.** Iterating a `JsonArray` yields
+  `IJsonValue` and iterating a `JsonObject` yields `IKeyValuePair`; neither queries to
+  `JsonObject`. There is no compile error and no exception, so every element is silently skipped
+  and the configuration reads as empty. Use:
+  ```cpp
+  if (entry == nullptr || entry.ValueType() != json::JsonValueType::Object) { continue; }
+  auto const obj = entry.GetObject();
+  ```
+  (`IJsonValue::GetObject()` collides with the `GetObject` macro from `wingdi.h`; check
+  `ValueType()` and then call the one-argument `GetNamedObject(name)` on the parent instead.)
+- **Never parse an untrusted string straight into a GUID.** `winrt::guid{ hstring }` throws, and
+  `internal::StringToGuid` returns an **uninitialized** GUID on failure. Use
+  `internal::TryParseGuidString`. One malformed entry inside a loop wrapped in a single
+  `catch (...)` hides every entry after it.
+- **Any new configuration field that becomes a path, a file name or a credential name** is what
+  turns configuration tampering into privilege escalation. Those are the fields to scrutinize.
+  A user-writable directory can be redirected with a junction — junctions have never needed
+  admin — so verify the final path, do not trust it.
+- **Validate the declared length of network payloads against the datagram up front**, and never let
+  a handler read past its own payload. Resynchronize by skipping unconsumed payload after each
+  command.
+- **Anything that can produce a storm of replies must be rate limited**, with a fixed-size table
+  rather than a map keyed by an attacker-chosen value.
+- **Reject out-of-spec input rather than absorbing it.** Tolerating malformed device identity is
+  what poisoned USB MIDI 1.0 naming for two decades.
+
+## 5. Strings, buffers and identifiers
+
+- **UMP name and identifier limits are UTF-8 byte counts, not UTF-16 code units.** Never measure
+  them with `wstring::length()` or `hstring::size()`. Use the helpers in
+  `src/in-box/Inc/wstring_util.h`: `Utf8ByteCount`, `ExceedsUtf8ByteCount`,
+  `TruncateToUtf8ByteCount`.
+- **Truncating UTF-8 correctly:** inspect the **first dropped byte** and walk back only while
+  *that* is a continuation byte. Resizing to the cap and then popping trailing continuation bytes
+  destroys a character that ends exactly on the cap.
+- **Do not round a byte cap down to a word boundary** unless the wire format requires it. Two
+  spec-sized identity fields were silently clipped by two bytes that way, so a remote device saw
+  the advertised identity and the in-session identity as two different devices.
+- **A boundary test must assert that the maximum value survives intact**, not merely that the
+  result does not exceed the maximum. A truncating bug passes `length <= max`.
+- **Software device instance ids** allow only ASCII alphanumerics plus `-` and `_`, max 200
+  characters, normalized to uppercase. Use `internal::RemoveInvalidSWDUniqueIdCharacters`.
+- **Verify where a fix belongs before writing it.** A plausibly named helper is not evidence that
+  it is on the code path — grep for its callers first. A fix placed in a dead function passes
+  review and changes nothing.
+
+## 6. Silent failure and observability
+
+- **Trace in the type-check branch, not in the `catch`.** A key present with the wrong type falling
+  back to a default with nothing logged is how a mistyped `"enabled": "yes"` produced a silently
+  disabled host. Absence of a key stays silent, because absence is normal.
+- **A `catch` that returns a default is fine only if the interesting case was traced before it.**
+- **An empty trace means the code never ran.** Look at loading, registration and ACLs before
+  looking at what the code does once loaded.
+- **Absence of an event may mean the provider was never in the profile.** Check the `.wprp` before
+  concluding anything from missing events. There is more than one `.wprp` in this repository.
+- **Message payload data may only be traced under `_DEBUG`** — it is a privacy violation in retail.
+  Pointers, byte counts, device ids and names are fine.
+- **Keep tracing out of the per-message hot path.**
+- **A partial list is a failure mode.** An enumeration loop whose per-item work can throw needs the
+  `try` *inside* the loop, or one bad item silently truncates everything after it.
+
+## 7. COM, WinRT and IDL
+
+- **`S_FALSE` is not failure.** `RETURN_IF_FAILED` does not catch it. Some interfaces return
+  `S_FALSE` without setting their out parameter; check `hr == S_FALSE || out == nullptr`
+  explicitly.
+- **MIDL silently discards a trailing `const` on a method.** If the implementation declares the
+  method `const`, it is a different signature, does not override the pure virtual, and the class
+  stays abstract. The real error, `C2259`, is buried behind a `C4373` warning promoted by `/WX` —
+  read the full build log, not the first error MSBuild prints.
+- **Parameter `const` is preserved, and pointee `const` is the meaningful form.** `UINT32 const*
+  buffer` promises the callee will not modify the buffer. `UINT32* const` only makes the pointer
+  const, is not part of the function type, and tells a caller nothing.
+- **The generated header for a hand-written IDL does not always regenerate**, and never for
+  platforms you did not build. Compare timestamps against the `.idl` before believing a mismatch,
+  and rebuild the IDL project once per platform and configuration.
+- **An IDL change must be mirrored everywhere it is duplicated**: the `.idl`, any committed MIDL
+  output that is checked into git, and the published reference documentation page — including the
+  numeric values in enum tables. Wrong numbers in shipped docs are worse than missing ones.
+- **A runtime class with a constructor or statics must be registered** in the OS manifest, or it
+  fails at run time with "Class not registered". Enums are not activatable and need no entry.
+- **A transport needs three registrations**, not one: the file, the COM in-process server CLSID,
+  and the `Transport Plugins\<Name>` registry key. The service discovers transports by enumerating
+  that key, so a transport with only the first two ships and never loads.
+
+## How to audit a diff mechanically
+
+- **Verify your instrument before trusting a negative result.** Run any detector script against a
+  file known to contain the defect first. A scan that reports zero findings because it is broken
+  looks exactly like a clean codebase. This has produced wrong conclusions here more than once.
+- **`git diff -w` is the right check after a pass that reindents bodies** (wrapping functions in
+  `try`, for example). Plain `--stat` shows thousands of changed lines and proves nothing;
+  whitespace-insensitive diff collapses it, and "zero removed lines" is direct proof that no code
+  was lost or truncated.
+- **Never build an edit from transformed terminal output.** Take edit text from the file, not from
+  something you printed through a formatter — phantom indentation and substituted characters have
+  corrupted whitespace-sensitive files here.
+- **One edit per pass, re-reading the file each time.** Collecting all offsets up front and
+  applying them in a batch produces overlapping ranges and truncated identifiers, and it still
+  compiles.
+- **Read the result of any scripted edit** rather than trusting the script's own success output,
+  then build.

--- a/.github/skills/midi-contributing/references/kir-servicing.md
+++ b/.github/skills/midi-contributing/references/kir-servicing.md
@@ -1,0 +1,194 @@
+# Servicing gates (KIR) for shipping code
+
+A **KIR** ("known issue rollback") gate makes a behavior change selectable at run time, so that if
+the change causes a regression in the field it can be turned back off through servicing without
+shipping new binaries. Windows MIDI Services ships in Windows, so any change to code that has
+already shipped needs one.
+
+## Check this before you edit, not after
+
+The trigger is the **location of the file**, not the size or risk of the diff. A one-line fix in
+`midisrv` is a shipping change. So is swapping a hardcoded English literal for a resource string,
+even though the en-US output is byte-identical — what matters is that the changed code lives in
+shipping code, not how visible the behavior change is. Do not reason about severity to talk
+yourself out of a gate.
+
+## Is this code shipping?
+
+Shipping in Windows today, so a gate is required:
+
+| Area | Path |
+|---|---|
+| The service | `src/in-box/Service/` |
+| Shared libraries | `src/in-box/Libs/*` |
+| Shared headers | `src/in-box/Inc/*` |
+| Drivers | `src/in-box/Drivers/*` |
+| Message transforms | `src/in-box/Transform/*` |
+| KS, KS Aggregate, Loopback, Virtual, Diagnostics transports | `src/in-box/Transport/{KSTransport,KSAggregateTransport,LoopbackMidiTransport,VirtualMidiTransport,DiagnosticsTransport}` |
+| WinMM client | `src/in-box/Client/WinMM/` |
+
+Not shipping in Windows today, so no gate is needed:
+
+- The `Windows.Devices.Midi2` WinRT SDK (`src/in-box/Client/WinRT/core`)
+- Transports still in preview — confirm the current list before relying on this
+- User tools under `src/in-box/user-tools/`
+- Everything under `src/in-box/Test/`, samples, `build/` and `docs/`
+
+**This list moves.** Transports graduate into Windows release by release. If you are not certain
+whether the file you are changing has shipped, ask in the issue or PR rather than guessing — the
+cost of an unnecessary gate is small, and the cost of a missing one is a change that cannot be
+rolled back.
+
+### The nuance that catches people
+
+When you add a **net-new function to a shipping library** and gate the choice at the call sites,
+gate **every** call site — including call sites in projects that do not ship. What is being gated
+is the behavior of the shared function, not the caller. Turning the gate off then restores the old
+behavior uniformly everywhere.
+
+## What the gating has to achieve
+
+There are only two requirements, and every other rule below exists to serve them:
+
+1. **With the gate disabled, the code behaves exactly as it shipped.**
+2. **The result still has a structure a human can read.**
+
+Anything that satisfies both is acceptable gating. Anything that satisfies only the first is a
+maintenance problem, and anything that satisfies only the second is not a rollback.
+
+## Where to put the branch
+
+This is a judgment call about the shape of the change, not a fixed rule. Four common shapes:
+
+| The change | Where the gate goes | Why |
+|---|---|---|
+| Changes a function's signature | The **call site** | A signature cannot be conditional. There is no other option. |
+| Would need several `if (Feature_Servicing_...)` branches inside one function | Add a **net-new function** beside the old one, branch once at the call site | Several gate checks threaded through one body fails requirement 2, and makes it hard to see that the disabled path is intact |
+| A small piece of code inside an existing function | **In place**, inside the function | Promoting a few lines to a new function to satisfy a rule adds indirection for nothing |
+| Rewrites how a whole class behaves | A **net-new class** beside the old one, chosen in the factory that constructs it | Gating a restructured 3,000-line file in place would mean dozens of sites; one check at the factory is far easier to verify |
+
+The last row is not hypothetical — the KS Aggregate endpoint manager rewrite was done exactly that
+way, with `...Manager3` alongside `...Manager2` and a single `IsEnabled()` check in
+`TransportState::ConstructEndpointManager()`. Carry every pre-existing gate in the old class over
+to the new one, and note deliberately dropped ones in the write-up. A change of that size is a
+maintainer conversation, not a decision to take alone.
+
+### In-place gating: what makes it safe
+
+When you gate inside a function, the `else` branch must reproduce the original body verbatim — not
+"equivalently". A shared JSON command helper used by four shipping transports is gated this way:
+both function bodies end in a single return, so one wrap in one header covers roughly ten call
+sites, and the disabled path is byte-for-byte what shipped. That is the test to apply.
+
+If you find yourself adding a **second** gate check to the same function, stop and promote it to a
+net-new function instead.
+
+## The rules that hold regardless of shape
+
+1. **Never combine another condition with the gate check in one `if`.** Nest instead. A reviewer
+   must be able to see the gate without untangling boolean logic.
+2. **A net-new function does not gate itself.** What gets gated is the choice between it and the
+   original, wherever you made that choice.
+3. **Do not rename an existing function.** Add a net-new one alongside it and choose between them.
+   Renaming makes the rollback path disappear.
+4. **The disabled path must reproduce the original exactly.**
+5. **The wrapping must be obvious to a human reviewer.** That is requirement 2, restated.
+6. **One gate = one rollback unit = one concern.** Do not reuse a gate for an unrelated fix, or
+   rolling back one drags out the other.
+7. **A follow-on defect attributable to a gated change ships under that same gate.** Otherwise the
+   gate gets rolled back as the apparent cause, and the original defect returns with it.
+
+### An example of the call-site form
+
+```cpp
+if (m_isDeviceSide)
+{
+    if (Feature_Servicing_MIDI2VirtualDeviceRemovalDeadlock::IsEnabled())
+    {
+        RETURN_IF_FAILED(table->OnDeviceDisconnectedAlwaysTeardown(m_endpointId));
+    }
+    else
+    {
+        RETURN_IF_FAILED(table->OnDeviceDisconnected(m_endpointId));
+    }
+}
+```
+
+Note the nesting: `m_isDeviceSide` is a separate `if`, not `&&`-ed into the gate check.
+
+### The header
+
+One header per gate, in `src/in-box/Inc/Feature_Servicing_<Name>.h`:
+
+```cpp
+#pragma once
+
+class Feature_Servicing_MIDI2MyChangeName
+{
+public:
+    static bool IsEnabled()
+    {
+        return true;
+    }
+};
+
+inline bool Feature_Servicing_MIDI2MyChangeName_IsEnabled()
+{
+    return true;
+}
+```
+
+Copy an existing header verbatim for the file banner and naming style. Names are
+`Feature_Servicing_MIDI2` followed by a short description of the fix, not of the bug number.
+
+### When a gate is impossible
+
+Some changes have no place to put a branch at all. Adding `#include <wil/cppwinrt.h>` to a module
+installs a process-wide exception translator hook and changes every catch site in the binary at
+once. Such a change has to ship ungated and be reported as such. Say so explicitly in the PR; do
+not quietly skip the gate.
+
+## Tests must be gated too
+
+For shipping code, the same gate that selects the behavior must gate the test. The test has to
+**no-op and pass trivially** when the gate is disabled, so that a rollback does not turn the suite
+red:
+
+```cpp
+if (!Feature_Servicing_MIDI2MyChangeName::IsEnabled())
+{
+    Log::Comment(L"KIR disabled, skipping.");
+    return;
+}
+```
+
+Keep any "the old behavior is preserved" test **ungated**: it must pass in both states.
+
+Write the test so it discriminates. A malformed input often already fails before your fix, just
+with a different error, so `VERIFY_IS_FALSE(IsSuccess())` passes either way and proves nothing.
+Assert the specific error code, and run the test against the unpatched binary to confirm it goes
+red.
+
+## Prove the gate, do not assume it
+
+1. Flip `IsEnabled()` to `false`.
+2. Rebuild **every** consumer of the header, not just the project you changed.
+3. Re-run the suites. Expect: gated tests skip, the "old behavior preserved" test still passes,
+   zero failures, everything compiles.
+4. Flip it back and rebuild.
+
+If your change introduces two gates, build the full on/off **matrix** (two gates = four builds),
+not each one alone.
+
+## The internal write-up
+
+A gated change is accompanied by an internal bug write-up with exactly three parts:
+
+- **Problem** — what is wrong, and the evidence for it. Evidence belongs here, not in its own
+  section.
+- **Fix** — what changed, and the gate name.
+- **Verification** — the repro, and what to observe with the gate on versus off.
+
+`mididiag` prints the list of gates present on the machine, with a short human-readable
+description, so give the gate a description that means something to somebody triaging a support
+case.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,6 +10,24 @@ and documentation. en-GB spellings are defects, not style preferences. Full rule
 [.github/instructions/en-us-spelling.instructions.md](.github/instructions/en-us-spelling.instructions.md).
 Check your work with `build/check_en_us_spelling.ps1 -Path <file or folder>`.
 
+## Writing or reviewing code
+
+Read [.github/skills/midi-contributing/SKILL.md](.github/skills/midi-contributing/SKILL.md) before
+you edit any source file. The rules that get broken most often:
+
+1. **Changes to code that ships in Windows must be wrapped in a servicing gate (KIR)**, with the
+   original behavior preserved exactly when the gate is disabled. The trigger is where the file
+   lives, not how small the diff is. Where the branch goes — call site, a net-new function, in
+   place, or a net-new class chosen at the factory — depends on the shape of the change.
+2. **SAL-annotate every function parameter**, and use `_Use_decl_annotations_` with bare parameters
+   in the `.cpp` when the declaration is in a header.
+3. **User-facing strings go in resource files** (`.resw` or `.rc`), never inline in code.
+4. **Review your own diff for use after free, TOCTOU, escaping exceptions, lock inversions and
+   untrusted input** before submitting. An exception escaping a thread body or an `HRESULT`
+   function in `midisrv` takes MIDI down for the whole machine.
+5. **Do not change public WinRT API surface without asking.** It ships in box and applications
+   depend on it.
+
 ## Filing bug reports and designing test plans
 
 Full guidance, including a write-up template, is in

--- a/docs/kb/porting-midi-libraries.md
+++ b/docs/kb/porting-midi-libraries.md
@@ -5,7 +5,7 @@ audience: developers
 description: Guidance for maintainers of cross-platform MIDI libraries, language bindings, and application frameworks which wrap the operating system MIDI API
 ---
 
-<!-- Short link for this page: aka.ms/MidiLibraryPorting (to be created) -->
+<!-- Short link for this page: aka.ms/MidiLibraryPorting -->
 
 # Porting a MIDI Library or Framework to Windows MIDI Services
 
@@ -222,6 +222,8 @@ Everything in [the threading section of the WinMM article](moving-from-winmm-to-
 
 **Do your MIDI work on a thread you own, initialized MTA, rather than on whichever thread the host happened to call you on.** A user interface thread is usually STA, and service startup can take several seconds, which is long enough for the host's window to be reported as unresponsive. Owning the thread also means the apartment model is yours to decide.
 
+If you still have a WinMM backend, there is a second reason the thread should be yours: a `midiOutLongMsg` carrying a large System Exclusive message can block until the transfer has essentially finished. Over a MIDI DIN connection at 31250 baud that is a long time, and it scales with the size of the dump. Firmware updaters and patch librarians are where this shows up.
+
 When shutting down, fully release and reset every COM reference before you uninitialize the apartment. Releasing them in the wrong order, or leaving one alive, can crash at process exit, and that crash will be reported against the host application rather than against you. Uninitializing the apartment is optional, especially when shutting down.
 
 ## Habits from WinMM that are now defects
@@ -240,7 +242,11 @@ The same is true on the new API: add your listeners or register your COM callbac
 
 ### Freeing a `MIDIHDR` buffer without unpreparing it
 
-**Call `midiOutUnprepareHeader` and wait for the completion notification before freeing the buffer.** Freeing on the success return of `midiOutLongMsg` was tolerable when the driver consumed the buffer synchronously. It is not something the API ever guaranteed, and it is not something you should rely on across an RPC boundary. The failure mode is a use-after-free that depends on timing, so it will not show up in your tests and will show up in a customer's crash dump.
+**Unprepare the header before you free the buffer, and act on what unprepare tells you.** The usual shortcut is to free on the success return of `midiOutLongMsg` and never unprepare at all. Some libraries unprepare only when the send *fails*, which is backwards: the failing path is the one where the driver never took the buffer in the first place.
+
+The contract is that the driver may still own the buffer after `midiOutLongMsg` returns. That is what `MHDR_INQUEUE`, the `MOM_DONE` callback and the `MIDIERR_STILLPLAYING` return value exist to express. **If `midiOutUnprepareHeader` returns `MIDIERR_STILLPLAYING`, the driver has not finished with the buffer and you must not free it**, so discarding that return value throws away the one signal that would have told you.
+
+This matters more for a library than for an application, because you do not control which driver is underneath you. WinMM still supports third-party `.drv` drivers, and how eagerly any particular one consumes a buffer is not something you can probe for or rely on. Write to the contract and you are correct everywhere. Write to the behavior of whichever driver you happened to test against and you are correct until your user installs something else.
 
 ### Closing a handle that was never opened
 
@@ -348,6 +354,7 @@ If you still have a WinMM backend:
 
 ## Getting help
 
+- The short link for this page is [aka.ms/MidiLibraryPorting](https://aka.ms/MidiLibraryPorting). Use it when citing this article, as it will keep working if the page moves.
 - Issues, questions and corrections to this page: [github.com/microsoft/MIDI/issues](https://github.com/microsoft/MIDI/issues)
 - Samples in several languages: [aka.ms/midisamples](https://aka.ms/midisamples)
 - The Windows MIDI Services Discord is the fastest way to reach the team and other implementers; the invitation link is on the [repository home page](https://aka.ms/midirepo)

--- a/samples/cpp-winrt/endpoint-listeners/endpoint-listeners-cpp.vcxproj
+++ b/samples/cpp-winrt/endpoint-listeners/endpoint-listeners-cpp.vcxproj
@@ -3,7 +3,6 @@
   <Import Project="..\packages\Windows.Devices.Midi2.0.99.67-devpreview.7\build\native\Windows.Devices.Midi2.props" Condition="Exists('..\packages\Windows.Devices.Midi2.0.99.67-devpreview.7\build\native\Windows.Devices.Midi2.props')" />
   <Import Project="..\packages\Microsoft.Windows.CppWinRT.3.0.260520.1\build\native\Microsoft.Windows.CppWinRT.props" Condition="Exists('..\packages\Microsoft.Windows.CppWinRT.3.0.260520.1\build\native\Microsoft.Windows.CppWinRT.props')" />
   <PropertyGroup Label="Globals">
-    <WindowsMidiServicesSdkPackage>Microsoft.Windows.Devices.Midi2.1.0.23-rc.5.17</WindowsMidiServicesSdkPackage>
     <CppWinRTOptimized>true</CppWinRTOptimized>
     <CppWinRTRootNamespaceAutoMerge>true</CppWinRTRootNamespaceAutoMerge>
     <CppWinRTGenerateWindowsMetadata>false</CppWinRTGenerateWindowsMetadata>

--- a/samples/cpp-winrt/loopback-basic-endpoints-winmm/loopback-basic-endpoints-winmm-cpp.vcxproj
+++ b/samples/cpp-winrt/loopback-basic-endpoints-winmm/loopback-basic-endpoints-winmm-cpp.vcxproj
@@ -3,7 +3,6 @@
   <Import Project="..\packages\Windows.Devices.Midi2.0.99.67-devpreview.7\build\native\Windows.Devices.Midi2.props" Condition="Exists('..\packages\Windows.Devices.Midi2.0.99.67-devpreview.7\build\native\Windows.Devices.Midi2.props')" />
   <Import Project="..\packages\Microsoft.Windows.CppWinRT.3.0.260520.1\build\native\Microsoft.Windows.CppWinRT.props" Condition="Exists('..\packages\Microsoft.Windows.CppWinRT.3.0.260520.1\build\native\Microsoft.Windows.CppWinRT.props')" />
   <PropertyGroup Label="Globals">
-    <WindowsMidiServicesSdkPackage>Microsoft.Windows.Devices.Midi2.1.0.23-rc.5.17</WindowsMidiServicesSdkPackage>
     <CppWinRTOptimized>true</CppWinRTOptimized>
     <CppWinRTRootNamespaceAutoMerge>true</CppWinRTRootNamespaceAutoMerge>
     <CppWinRTGenerateWindowsMetadata>true</CppWinRTGenerateWindowsMetadata>

--- a/samples/cpp-winrt/loopback-basic-endpoints/loopback-basic-endpoints-cpp.vcxproj
+++ b/samples/cpp-winrt/loopback-basic-endpoints/loopback-basic-endpoints-cpp.vcxproj
@@ -3,7 +3,6 @@
   <Import Project="..\packages\Windows.Devices.Midi2.0.99.67-devpreview.7\build\native\Windows.Devices.Midi2.props" Condition="Exists('..\packages\Windows.Devices.Midi2.0.99.67-devpreview.7\build\native\Windows.Devices.Midi2.props')" />
   <Import Project="..\packages\Microsoft.Windows.CppWinRT.3.0.260520.1\build\native\Microsoft.Windows.CppWinRT.props" Condition="Exists('..\packages\Microsoft.Windows.CppWinRT.3.0.260520.1\build\native\Microsoft.Windows.CppWinRT.props')" />
   <PropertyGroup Label="Globals">
-    <WindowsMidiServicesSdkPackage>Microsoft.Windows.Devices.Midi2.1.0.23-rc.5.17</WindowsMidiServicesSdkPackage>
     <CppWinRTOptimized>true</CppWinRTOptimized>
     <CppWinRTRootNamespaceAutoMerge>true</CppWinRTRootNamespaceAutoMerge>
     <CppWinRTGenerateWindowsMetadata>true</CppWinRTGenerateWindowsMetadata>

--- a/samples/cpp-winrt/loopback-endpoints/loopback-endpoints-cpp.vcxproj
+++ b/samples/cpp-winrt/loopback-endpoints/loopback-endpoints-cpp.vcxproj
@@ -3,7 +3,6 @@
   <Import Project="..\packages\Windows.Devices.Midi2.0.99.67-devpreview.7\build\native\Windows.Devices.Midi2.props" Condition="Exists('..\packages\Windows.Devices.Midi2.0.99.67-devpreview.7\build\native\Windows.Devices.Midi2.props')" />
   <Import Project="..\packages\Microsoft.Windows.CppWinRT.3.0.260520.1\build\native\Microsoft.Windows.CppWinRT.props" Condition="Exists('..\packages\Microsoft.Windows.CppWinRT.3.0.260520.1\build\native\Microsoft.Windows.CppWinRT.props')" />
   <PropertyGroup Label="Globals">
-    <WindowsMidiServicesSdkPackage>Microsoft.Windows.Devices.Midi2.1.0.23-rc.5.17</WindowsMidiServicesSdkPackage>
     <CppWinRTOptimized>true</CppWinRTOptimized>
     <CppWinRTRootNamespaceAutoMerge>true</CppWinRTRootNamespaceAutoMerge>
     <CppWinRTGenerateWindowsMetadata>true</CppWinRTGenerateWindowsMetadata>

--- a/samples/cpp-winrt/send-speed/send-speed-cpp.vcxproj
+++ b/samples/cpp-winrt/send-speed/send-speed-cpp.vcxproj
@@ -3,7 +3,6 @@
   <Import Project="..\packages\Windows.Devices.Midi2.0.99.67-devpreview.7\build\native\Windows.Devices.Midi2.props" Condition="Exists('..\packages\Windows.Devices.Midi2.0.99.67-devpreview.7\build\native\Windows.Devices.Midi2.props')" />
   <Import Project="..\packages\Microsoft.Windows.CppWinRT.3.0.260520.1\build\native\Microsoft.Windows.CppWinRT.props" Condition="Exists('..\packages\Microsoft.Windows.CppWinRT.3.0.260520.1\build\native\Microsoft.Windows.CppWinRT.props')" />
   <PropertyGroup Label="Globals">
-    <WindowsMidiServicesSdkPackage>Microsoft.Windows.Devices.Midi2.1.0.23-rc.5.17</WindowsMidiServicesSdkPackage>
     <CppWinRTOptimized>true</CppWinRTOptimized>
     <CppWinRTRootNamespaceAutoMerge>true</CppWinRTRootNamespaceAutoMerge>
     <CppWinRTGenerateWindowsMetadata>true</CppWinRTGenerateWindowsMetadata>

--- a/samples/cpp-winrt/simple-app-to-app-midi/simple-app-to-app-cpp.vcxproj
+++ b/samples/cpp-winrt/simple-app-to-app-midi/simple-app-to-app-cpp.vcxproj
@@ -3,7 +3,6 @@
   <Import Project="..\packages\Windows.Devices.Midi2.0.99.67-devpreview.7\build\native\Windows.Devices.Midi2.props" Condition="Exists('..\packages\Windows.Devices.Midi2.0.99.67-devpreview.7\build\native\Windows.Devices.Midi2.props')" />
   <Import Project="..\packages\Microsoft.Windows.CppWinRT.3.0.260520.1\build\native\Microsoft.Windows.CppWinRT.props" Condition="Exists('..\packages\Microsoft.Windows.CppWinRT.3.0.260520.1\build\native\Microsoft.Windows.CppWinRT.props')" />
   <PropertyGroup Label="Globals">
-    <WindowsMidiServicesSdkPackage>Microsoft.Windows.Devices.Midi2.1.0.23-rc.5.17</WindowsMidiServicesSdkPackage>
     <CppWinRTOptimized>true</CppWinRTOptimized>
     <CppWinRTRootNamespaceAutoMerge>true</CppWinRTRootNamespaceAutoMerge>
     <CppWinRTGenerateWindowsMetadata>true</CppWinRTGenerateWindowsMetadata>

--- a/src/in-box/Inc/MidiDefs.h
+++ b/src/in-box/Inc/MidiDefs.h
@@ -116,7 +116,7 @@ static_assert(    MAXIMUM_LOOPED_BUFFER_SIZE < ULONG_MAX/2, "The maximum looped 
 
 // this is the amount of time we allocate to discovery across all native UMP format MIDI 2 devices. Needs to fit within uint16_t
 #define MIDI_DISCOVERY_TIMEOUT_REG_VALUE                L"Midi2DiscoveryTimeoutMS"
-//#define MIDI_DISCOVERY_TIMEOUT_DEFAULT_VALUE            10000
+
 #define MIDI_DISCOVERY_TIMEOUT_DEFAULT_VALUE            5000
 #define MIDI_DISCOVERY_TIMEOUT_MINIMUM_VALUE            500
 #define MIDI_DISCOVERY_TIMEOUT_MAXIMUM_VALUE            50000


### PR DESCRIPTION
This pull request adds comprehensive contributor guidance for the Windows MIDI Services repository. It introduces a new skill document outlining best practices for making code changes, and includes a detailed reference on building, testing, and verifying changes. The new documentation emphasizes safety, correctness, and process requirements for contributors.

Contributor guidance and process documentation:

* Added `.github/skills/midi-contributing/SKILL.md`, a thorough guide for contributing code to Windows MIDI Services, covering requirements for servicing gates, SAL annotations, en-US spelling, localization practices, common failure classes, and expectations for pull request summaries.
* Added `.github/skills/midi-contributing/references/build-and-verify.md`, a detailed reference for building, testing, and verifying changes, including solution structure, troubleshooting common build and test issues, and deployment/validation steps.