### PR TITLE
Network MIDI 2.0 updates for customization, creating MIDI 1 ports, etc, plus some more utf-8 fixes.

### DIFF
--- a/.github/skills/midi-contributing/SKILL.md
+++ b/.github/skills/midi-contributing/SKILL.md
@@ -167,6 +167,14 @@ customer-visible defect in this project.
   to your own worker and return in microseconds.
 - **Untrusted input** — the configuration file is writable by a standard user and the service runs
   as `LOCAL SERVICE`. Treat config JSON, device-supplied names and network packets as hostile.
+- **Narrow/wide string conversion by iterator range** — `std::wstring(s.begin(), s.end())` on a
+  UTF-8 string makes one `wchar_t` per *byte*, so every character outside ASCII becomes several
+  garbage ones; `std::string(ws.begin(), ws.end())` truncates each `wchar_t` to a byte and loses
+  data silently. Names reach us from devices, from the network and from users, so ASCII is not a
+  safe assumption. Use `winrt::to_hstring` / `winrt::to_string`, `MultiByteToWideChar(CP_UTF8, …)`
+  or the helpers in `Inc/wstring_util.h`. This shipped in the WinMM port names and reached
+  customers. Beware that it hides in test helpers too: a helper that mangles the string on the way
+  in makes the assertion compare mangled to mangled and pass.
 - **Silent failure** — a `catch` that returns a default, a fallback that logs nothing, a wrong-type
   JSON value that quietly disappears. A defect you cannot see in a trace is worse than a crash.
 

--- a/.github/skills/midi-contributing/references/code-safety-review.md
+++ b/.github/skills/midi-contributing/references/code-safety-review.md
@@ -160,6 +160,21 @@ Device-supplied names, network packets and configuration values are all hostile 
 
 ## 5. Strings, buffers and identifiers
 
+- **Never convert between narrow and wide with an iterator range or a per-element copy.**
+  `std::wstring(s.begin(), s.end())` on UTF-8 produces one `wchar_t` per *byte*, so `’` (`E2 80 99`)
+  becomes three garbage characters. `std::string(ws.begin(), ws.end())` truncates each `wchar_t`
+  to a byte and loses data with no error. Use `winrt::to_hstring` / `winrt::to_string`, which are
+  a lossless CP_UTF8 pair, or `MultiByteToWideChar(CP_UTF8, …)`. This shipped in the legacy WinMM
+  port names: only ports after the first were affected, because only those took the narrow
+  round trip, so the giveaway is **the first port correct and the rest mangled**.
+  - Grep loosely, because a tight pattern misses sites:
+    `std::wstring\s*[\(\{]\s*\w+\.begin\(\)` and the `std::string` equivalent. Wide-to-wide
+    substrings match too and are fine.
+  - `to_hstring(std::format(… to_string(x) …))` looks like the same bug and is not — that pair
+    round-trips correctly.
+  - **Check the test helpers, not just the product.** A helper that mangles a name on the way in
+    makes the product store it mangled and the assertion compare mangled to mangled, so the test
+    passes and hides exactly the defect it should catch.
 - **UMP name and identifier limits are UTF-8 byte counts, not UTF-16 code units.** Never measure
   them with `wstring::length()` or `hstring::size()`. Use the helpers in
   `src/in-box/Inc/wstring_util.h`: `Utf8ByteCount`, `ExceedsUtf8ByteCount`,

--- a/build/staging/version/BundleInfo.wxi
+++ b/build/staging/version/BundleInfo.wxi
@@ -2,7 +2,7 @@
 <!-- Generated from build\version-plugins.json by build-plugins.ps1 or build-bluetooth.ps1. Do not edit. -->
 <Include>
   <?define SetupVersionName="Plugin Preview 5" ?>
-  <?define SetupVersionNumber="1.0.23-preview.5" ?>
-  <?define MidiSdkAndToolsVersion="1.0.23-preview.5" ?>
-  <?define MidiPluginsNumericVersion="1.0.23.0" ?>
+  <?define SetupVersionNumber="1.0.24-preview.5" ?>
+  <?define MidiSdkAndToolsVersion="1.0.24-preview.5" ?>
+  <?define MidiPluginsNumericVersion="1.0.24.0" ?>
 </Include>

--- a/build/staging/version/WindowsMidiServicesVersion.h
+++ b/build/staging/version/WindowsMidiServicesVersion.h
@@ -7,14 +7,14 @@
 
 #define WINDOWS_MIDI_SERVICES_NUGET_BUILD_IS_PREVIEW                         true
 #define WINDOWS_MIDI_SERVICES_NUGET_BUILD_SOURCE                             L"GitHub Preview"
-#define WINDOWS_MIDI_SERVICES_NUGET_BUILD_DATE                               L"2026-09-07"
+#define WINDOWS_MIDI_SERVICES_NUGET_BUILD_DATE                               L"2026-09-09"
 #define WINDOWS_MIDI_SERVICES_NUGET_BUILD_VERSION_NAME                       L"SDK Dev Preview 7"
-#define WINDOWS_MIDI_SERVICES_NUGET_BUILD_VERSION_FULL                       L"0.99.67-devpreview.7"
+#define WINDOWS_MIDI_SERVICES_NUGET_BUILD_VERSION_FULL                       L"0.99.68-devpreview.7"
 #define WINDOWS_MIDI_SERVICES_NUGET_BUILD_VERSION_MAJOR                      0
 #define WINDOWS_MIDI_SERVICES_NUGET_BUILD_VERSION_MINOR                      99
-#define WINDOWS_MIDI_SERVICES_NUGET_BUILD_VERSION_PATCH                      67
+#define WINDOWS_MIDI_SERVICES_NUGET_BUILD_VERSION_PATCH                      68
 #define WINDOWS_MIDI_SERVICES_NUGET_BUILD_VERSION_BUILD_NUMBER               0
 #define WINDOWS_MIDI_SERVICES_NUGET_BUILD_PREVIEW                            L"devpreview.7"
-#define WINDOWS_MIDI_SERVICES_NUGET_BUILD_VERSION_FILE                       L"0.99.67.0"
+#define WINDOWS_MIDI_SERVICES_NUGET_BUILD_VERSION_FILE                       L"0.99.68.0"
 
 #endif

--- a/build/version-plugins.json
+++ b/build/version-plugins.json
@@ -24,7 +24,7 @@
 
   "major": 1,
   "minor": 0,
-  "patch": 23,
+  "patch": 24,
 
   "channel": "preview",
   "channelNumber": 5,

--- a/build/version.json
+++ b/build/version.json
@@ -21,7 +21,7 @@
 
   "major": 0,
   "minor": 99,
-  "patch": 67,
+  "patch": 68,
 
   "channel": "devpreview",
   "channelNumber": 7,

--- a/docs/kb/network-midi2-transport.md
+++ b/docs/kb/network-midi2-transport.md
@@ -82,9 +82,11 @@ efficient, because Windows waits for an announcement rather than repeatedly prob
 **Naming.** Leave the name empty and Windows uses whatever the device calls itself. Give a name
 and that is what appears everywhere in Windows, including your DAW's device list.
 
-**MIDI 1.0 ports are optional.** A host can create classic MIDI 1.0 ports for connected devices
-so that older software, which does not understand the newer combined API, can use them. Most
-apps today fall into that category.
+**MIDI 1.0 ports are created by default.** Alongside the modern UMP endpoint, Windows creates
+classic MIDI 1.0 ports so that older software, which does not understand the newer combined API,
+can use the device. Most apps today fall into that category. This applies in both directions: to
+devices this PC connects out to, and to devices that connect in to a host here. You can turn it
+off per entry if you only want the UMP endpoint.
 
 ---
 
@@ -167,7 +169,8 @@ A few rules apply to the whole file:
             "advertise": true,
             "authentication": "none",
             "remoteClientPolicy": "requireApproval",
-            "createMidi1Ports": false,
+            "createMidi1Ports": true,
+            "fallbackMidi1PortCount": 1,
             "allowedClients": [
               { "umpEndpointName": "Bome BomeBox", "productInstanceId": "kb7C5D0A_1" }
             ],
@@ -177,6 +180,8 @@ A few rules apply to the whole file:
         "clients": {
           "{971DA520-4559-4A2F-A72E-F9BEA17521CC}": {
             "networkProtocol": "udp",
+            "createMidi1Ports": true,
+            "fallbackMidi1PortCount": 1,
             "match": {
               "directHostNameOrIP": "192.168.1.253",
               "directPort": "5004"
@@ -228,7 +233,8 @@ Lowering `maxHostConnections` does not disconnect clients that are already conne
 | `advertise` | boolean | Announce over mDNS. With this off, devices must be given the address |
 | `authentication` | string | `"none"` only. `"password"` and `"user"` are refused in this release |
 | `remoteClientPolicy` | string | `"allowAny"` or `"requireApproval"` |
-| `createMidi1Ports` | boolean | Create classic MIDI 1.0 ports for connected devices |
+| `createMidi1Ports` | boolean | Default true. Create classic MIDI 1.0 ports for connected devices |
+| `fallbackMidi1PortCount` | number | Default 1, range 1 – 16. Source and destination ports to create for a device that declares no function blocks. See [MIDI 1.0 ports](#midi-10-ports) |
 | `allowedClients` | array | Identity objects that may connect without asking |
 | `deniedClients` | array | Identity objects that are refused without asking |
 
@@ -240,6 +246,8 @@ rather than IP address, because a device's address moves and its identity does n
 | Key | Type | Notes |
 |---|---|---|
 | `networkProtocol` | string | Only `"udp"` |
+| `createMidi1Ports` | boolean | Default true. Create classic MIDI 1.0 ports for this device |
+| `fallbackMidi1PortCount` | number | Default 1, range 1 – 16. Source and destination ports to create when the device declares no function blocks. See [MIDI 1.0 ports](#midi-10-ports) |
 | `match` | object | How to find the device |
 
 `match` carries either an advertised identity or a direct address:
@@ -261,6 +269,34 @@ A configured client is in one of four states:
 | `live` | Connected, endpoint created |
 | `failed` | The entry itself is not valid, so retrying cannot help |
 | `unavailable` | A direct connection stopped answering. Nothing will announce its return, so it is retried only when an app asks again |
+
+## MIDI 1.0 ports
+
+A Network MIDI 2.0 device describes itself with **function blocks**, which it sends when Windows
+asks it to during endpoint discovery. Those say how many groups the device uses and in which
+direction, and Windows creates one MIDI 1.0 source and one destination per group from them. A
+device that describes itself properly needs nothing configured here.
+
+Not every device answers. Some never complete discovery, and unlike USB there are no group
+terminal blocks to fall back on, so Windows would have nothing to build ports from. For that case
+the transport supplies a block of its own, and `fallbackMidi1PortCount` says how wide it is: the
+value is the number of source ports and also the number of destination ports. It defaults to
+**1**, because a device which does not describe itself is usually a bridge with a single cable,
+and 16 would mean 32 ports of clutter in every MIDI 1.0 application.
+
+**The fallback is ignored the moment the device does describe itself.** Function blocks take
+precedence, so raising the count for a device that declares three groups changes nothing.
+
+Two things behave differently when you change them:
+
+| Setting | When it takes effect |
+|---|---|
+| `fallbackMidi1PortCount` | Straight away, on connections that are already up. Ports are added or removed without the session being interrupted |
+| `createMidi1Ports` | The next time the endpoint is created, so disconnect and reconnect, or restart the service |
+
+The difference is not arbitrary. Whether an endpoint has MIDI 1.0 ports at all is settled when the
+endpoint is built and cannot be changed underneath a running one; how many ports it has is driven
+by properties the service watches, so that can be rewritten live.
 
 ## Approval
 

--- a/docs/sdk-reference/Enumeration/MidiEndpointDeviceInformation.md
+++ b/docs/sdk-reference/Enumeration/MidiEndpointDeviceInformation.md
@@ -39,7 +39,6 @@ For more information about the Endpoint Discovery and Protocol Negotiation aspec
 | `DeclaredStreamConfigurationLastUpdateTime` | Protocol Negotiation | The time of the last update from protocol negotiation |
 | `DeclaredFunctionBlocksLastUpdateTime` | Discovery | The time of the last update of function blocks |
 | `Midi1PortNamingApproach` | User/Config | The naming approach used when generating MIDI 1.0 port names for this endpoint. |
-| `IsMidi1PortCreationEnabled` | Config | True if MIDI 1.0 API port creation is enabled for this endpoint. |
 | `IsMuted` | Config | True if this endpoint is muted (all MIDI communication suppressed). |
 | `Properties` | Windows | Returns the raw device properties for this endpoint. The property values and their ids are not something an application should rely upon -- they are an implementation detail subject to change, and are not part of the contract with apps. Instead, all of the interesting/useful properties have been broken out in other ways with strong types. |
 

--- a/docs/tools/midinetworksetup/index.md
+++ b/docs/tools/midinetworksetup/index.md
@@ -103,6 +103,33 @@ is on the network. **MIDI Endpoint** is the Windows device id, which is what oth
 when they ask you to identify a device. The small copy button on the right puts it on the
 clipboard.
 
+### Customizing a device
+
+Select **Customize** under a connected device to change how it appears in Windows.
+
+**Name**, **Description** and **Image** are yours to set. Leave a box empty and Windows uses what
+the device reports about itself, which is usually what you want until two devices of the same
+model turn up and you need to tell them apart. Browsing for an image copies it into the shared
+endpoint images folder, so it keeps working from other machines' tools and after the original file
+moves. **Remove** clears the image from the device without deleting the file.
+
+The name you set here is the one your DAW sees, and it's carried down to the MIDI 1.0 ports too.
+
+Two settings control the MIDI 1.0 ports:
+
+- **Create MIDI 1.0 ports for this device** turns them on or off. Because the ports are built
+  along with the endpoint, this one takes effect the next time the device connects, not straight
+  away.
+- **MIDI 1.0 ports to create if this device does not describe itself** applies immediately. Most
+  devices tell Windows how many ports they have and this number isn't used for them; it's only for
+  a device that never answers. See
+  [How Network MIDI 2.0 works in Windows]({{ site.baseurl }}/kb/network-midi2-transport/#midi-10-ports)
+  for the detail.
+
+**Reset** clears the name, description and image and goes back to what the device reports. It
+deliberately leaves the MIDI 1.0 port settings alone, so pressing it to clear a name doesn't take
+your ports away as a side effect.
+
 ### Connecting to a device that doesn't advertise itself
 
 Some devices don't announce themselves on the network, or are on a part of the network where those
@@ -159,6 +186,13 @@ Switch it off and devices can still connect, but they'll need the address typed 
 
 **Also create MIDI 1.0 ports for connected devices** makes connected devices usable from older
 software that doesn't understand the new combined MIDI 1.0/MIDI 2.0 API. Most apps today will fall under that category.
+It's on by default, and you'd normally leave it that way.
+
+Underneath it is **MIDI 1.0 ports to create for a device that does not describe itself**. Most
+devices say how many ports they have when Windows asks, and this number isn't used for them. It
+only applies to a device that never answers, which would otherwise get no ports at all. One pair
+is the right answer for almost everything; raise it only if you know a particular device carries
+more than one cable's worth of MIDI and doesn't say so.
 
 ### When a device asks to connect
 

--- a/samples/cpp-winrt/basics/client-basics-cpp.vcxproj
+++ b/samples/cpp-winrt/basics/client-basics-cpp.vcxproj
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\packages\Windows.Devices.Midi2.0.99.67-devpreview.7\build\native\Windows.Devices.Midi2.props" Condition="Exists('..\packages\Windows.Devices.Midi2.0.99.67-devpreview.7\build\native\Windows.Devices.Midi2.props')" />
+  <Import Project="..\packages\Windows.Devices.Midi2.0.99.68-devpreview.7\build\native\Windows.Devices.Midi2.props" Condition="Exists('..\packages\Windows.Devices.Midi2.0.99.68-devpreview.7\build\native\Windows.Devices.Midi2.props')" />
   <Import Project="..\packages\Microsoft.Windows.CppWinRT.3.0.260520.1\build\native\Microsoft.Windows.CppWinRT.props" Condition="Exists('..\packages\Microsoft.Windows.CppWinRT.3.0.260520.1\build\native\Microsoft.Windows.CppWinRT.props')" />
   <PropertyGroup Label="Globals">
     <CppWinRTOptimized>true</CppWinRTOptimized>
@@ -164,7 +164,7 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
     <Import Project="..\packages\Microsoft.Windows.CppWinRT.3.0.260520.1\build\native\Microsoft.Windows.CppWinRT.targets" Condition="Exists('..\packages\Microsoft.Windows.CppWinRT.3.0.260520.1\build\native\Microsoft.Windows.CppWinRT.targets')" />
-    <Import Project="..\packages\Windows.Devices.Midi2.0.99.67-devpreview.7\build\native\Windows.Devices.Midi2.targets" Condition="Exists('..\packages\Windows.Devices.Midi2.0.99.67-devpreview.7\build\native\Windows.Devices.Midi2.targets')" />
+    <Import Project="..\packages\Windows.Devices.Midi2.0.99.68-devpreview.7\build\native\Windows.Devices.Midi2.targets" Condition="Exists('..\packages\Windows.Devices.Midi2.0.99.68-devpreview.7\build\native\Windows.Devices.Midi2.targets')" />
   </ImportGroup>
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
@@ -172,7 +172,7 @@
     </PropertyGroup>
     <Error Condition="!Exists('..\packages\Microsoft.Windows.CppWinRT.3.0.260520.1\build\native\Microsoft.Windows.CppWinRT.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Windows.CppWinRT.3.0.260520.1\build\native\Microsoft.Windows.CppWinRT.props'))" />
     <Error Condition="!Exists('..\packages\Microsoft.Windows.CppWinRT.3.0.260520.1\build\native\Microsoft.Windows.CppWinRT.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Windows.CppWinRT.3.0.260520.1\build\native\Microsoft.Windows.CppWinRT.targets'))" />
-    <Error Condition="!Exists('..\packages\Windows.Devices.Midi2.0.99.67-devpreview.7\build\native\Windows.Devices.Midi2.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Windows.Devices.Midi2.0.99.67-devpreview.7\build\native\Windows.Devices.Midi2.props'))" />
-    <Error Condition="!Exists('..\packages\Windows.Devices.Midi2.0.99.67-devpreview.7\build\native\Windows.Devices.Midi2.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Windows.Devices.Midi2.0.99.67-devpreview.7\build\native\Windows.Devices.Midi2.targets'))" />
+    <Error Condition="!Exists('..\packages\Windows.Devices.Midi2.0.99.68-devpreview.7\build\native\Windows.Devices.Midi2.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Windows.Devices.Midi2.0.99.68-devpreview.7\build\native\Windows.Devices.Midi2.props'))" />
+    <Error Condition="!Exists('..\packages\Windows.Devices.Midi2.0.99.68-devpreview.7\build\native\Windows.Devices.Midi2.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Windows.Devices.Midi2.0.99.68-devpreview.7\build\native\Windows.Devices.Midi2.targets'))" />
   </Target>
 </Project>

--- a/samples/cpp-winrt/basics/packages.config
+++ b/samples/cpp-winrt/basics/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Microsoft.Windows.CppWinRT" version="3.0.260520.1" targetFramework="native" />
-  <package id="Windows.Devices.Midi2" version="0.99.67-devpreview.7" targetFramework="native" />
+  <package id="Windows.Devices.Midi2" version="0.99.68-devpreview.7" targetFramework="native" />
 </packages>

--- a/samples/cpp-winrt/com-extensions/com-extensions-cpp.vcxproj
+++ b/samples/cpp-winrt/com-extensions/com-extensions-cpp.vcxproj
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\packages\Windows.Devices.Midi2.0.99.67-devpreview.7\build\native\Windows.Devices.Midi2.props" Condition="Exists('..\packages\Windows.Devices.Midi2.0.99.67-devpreview.7\build\native\Windows.Devices.Midi2.props')" />
+  <Import Project="..\packages\Windows.Devices.Midi2.0.99.68-devpreview.7\build\native\Windows.Devices.Midi2.props" Condition="Exists('..\packages\Windows.Devices.Midi2.0.99.68-devpreview.7\build\native\Windows.Devices.Midi2.props')" />
   <Import Project="..\packages\Microsoft.Windows.CppWinRT.3.0.260520.1\build\native\Microsoft.Windows.CppWinRT.props" Condition="Exists('..\packages\Microsoft.Windows.CppWinRT.3.0.260520.1\build\native\Microsoft.Windows.CppWinRT.props')" />
   <PropertyGroup Label="Globals">
     <CppWinRTOptimized>true</CppWinRTOptimized>
@@ -164,7 +164,7 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
     <Import Project="..\packages\Microsoft.Windows.CppWinRT.3.0.260520.1\build\native\Microsoft.Windows.CppWinRT.targets" Condition="Exists('..\packages\Microsoft.Windows.CppWinRT.3.0.260520.1\build\native\Microsoft.Windows.CppWinRT.targets')" />
-    <Import Project="..\packages\Windows.Devices.Midi2.0.99.67-devpreview.7\build\native\Windows.Devices.Midi2.targets" Condition="Exists('..\packages\Windows.Devices.Midi2.0.99.67-devpreview.7\build\native\Windows.Devices.Midi2.targets')" />
+    <Import Project="..\packages\Windows.Devices.Midi2.0.99.68-devpreview.7\build\native\Windows.Devices.Midi2.targets" Condition="Exists('..\packages\Windows.Devices.Midi2.0.99.68-devpreview.7\build\native\Windows.Devices.Midi2.targets')" />
   </ImportGroup>
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
@@ -172,7 +172,7 @@
     </PropertyGroup>
     <Error Condition="!Exists('..\packages\Microsoft.Windows.CppWinRT.3.0.260520.1\build\native\Microsoft.Windows.CppWinRT.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Windows.CppWinRT.3.0.260520.1\build\native\Microsoft.Windows.CppWinRT.props'))" />
     <Error Condition="!Exists('..\packages\Microsoft.Windows.CppWinRT.3.0.260520.1\build\native\Microsoft.Windows.CppWinRT.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Windows.CppWinRT.3.0.260520.1\build\native\Microsoft.Windows.CppWinRT.targets'))" />
-    <Error Condition="!Exists('..\packages\Windows.Devices.Midi2.0.99.67-devpreview.7\build\native\Windows.Devices.Midi2.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Windows.Devices.Midi2.0.99.67-devpreview.7\build\native\Windows.Devices.Midi2.props'))" />
-    <Error Condition="!Exists('..\packages\Windows.Devices.Midi2.0.99.67-devpreview.7\build\native\Windows.Devices.Midi2.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Windows.Devices.Midi2.0.99.67-devpreview.7\build\native\Windows.Devices.Midi2.targets'))" />
+    <Error Condition="!Exists('..\packages\Windows.Devices.Midi2.0.99.68-devpreview.7\build\native\Windows.Devices.Midi2.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Windows.Devices.Midi2.0.99.68-devpreview.7\build\native\Windows.Devices.Midi2.props'))" />
+    <Error Condition="!Exists('..\packages\Windows.Devices.Midi2.0.99.68-devpreview.7\build\native\Windows.Devices.Midi2.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Windows.Devices.Midi2.0.99.68-devpreview.7\build\native\Windows.Devices.Midi2.targets'))" />
   </Target>
 </Project>

--- a/samples/cpp-winrt/com-extensions/packages.config
+++ b/samples/cpp-winrt/com-extensions/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Microsoft.Windows.CppWinRT" version="3.0.260520.1" targetFramework="native" />
-  <package id="Windows.Devices.Midi2" version="0.99.67-devpreview.7" targetFramework="native" />
+  <package id="Windows.Devices.Midi2" version="0.99.68-devpreview.7" targetFramework="native" />
 </packages>

--- a/samples/cpp-winrt/endpoint-listeners/endpoint-listeners-cpp.vcxproj
+++ b/samples/cpp-winrt/endpoint-listeners/endpoint-listeners-cpp.vcxproj
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\packages\Windows.Devices.Midi2.0.99.67-devpreview.7\build\native\Windows.Devices.Midi2.props" Condition="Exists('..\packages\Windows.Devices.Midi2.0.99.67-devpreview.7\build\native\Windows.Devices.Midi2.props')" />
+  <Import Project="..\packages\Windows.Devices.Midi2.0.99.68-devpreview.7\build\native\Windows.Devices.Midi2.props" Condition="Exists('..\packages\Windows.Devices.Midi2.0.99.68-devpreview.7\build\native\Windows.Devices.Midi2.props')" />
   <Import Project="..\packages\Microsoft.Windows.CppWinRT.3.0.260520.1\build\native\Microsoft.Windows.CppWinRT.props" Condition="Exists('..\packages\Microsoft.Windows.CppWinRT.3.0.260520.1\build\native\Microsoft.Windows.CppWinRT.props')" />
   <PropertyGroup Label="Globals">
     <CppWinRTOptimized>true</CppWinRTOptimized>
@@ -164,7 +164,7 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
     <Import Project="..\packages\Microsoft.Windows.CppWinRT.3.0.260520.1\build\native\Microsoft.Windows.CppWinRT.targets" Condition="Exists('..\packages\Microsoft.Windows.CppWinRT.3.0.260520.1\build\native\Microsoft.Windows.CppWinRT.targets')" />
-    <Import Project="..\packages\Windows.Devices.Midi2.0.99.67-devpreview.7\build\native\Windows.Devices.Midi2.targets" Condition="Exists('..\packages\Windows.Devices.Midi2.0.99.67-devpreview.7\build\native\Windows.Devices.Midi2.targets')" />
+    <Import Project="..\packages\Windows.Devices.Midi2.0.99.68-devpreview.7\build\native\Windows.Devices.Midi2.targets" Condition="Exists('..\packages\Windows.Devices.Midi2.0.99.68-devpreview.7\build\native\Windows.Devices.Midi2.targets')" />
   </ImportGroup>
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
@@ -172,7 +172,7 @@
     </PropertyGroup>
     <Error Condition="!Exists('..\packages\Microsoft.Windows.CppWinRT.3.0.260520.1\build\native\Microsoft.Windows.CppWinRT.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Windows.CppWinRT.3.0.260520.1\build\native\Microsoft.Windows.CppWinRT.props'))" />
     <Error Condition="!Exists('..\packages\Microsoft.Windows.CppWinRT.3.0.260520.1\build\native\Microsoft.Windows.CppWinRT.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Windows.CppWinRT.3.0.260520.1\build\native\Microsoft.Windows.CppWinRT.targets'))" />
-    <Error Condition="!Exists('..\packages\Windows.Devices.Midi2.0.99.67-devpreview.7\build\native\Windows.Devices.Midi2.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Windows.Devices.Midi2.0.99.67-devpreview.7\build\native\Windows.Devices.Midi2.props'))" />
-    <Error Condition="!Exists('..\packages\Windows.Devices.Midi2.0.99.67-devpreview.7\build\native\Windows.Devices.Midi2.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Windows.Devices.Midi2.0.99.67-devpreview.7\build\native\Windows.Devices.Midi2.targets'))" />
+    <Error Condition="!Exists('..\packages\Windows.Devices.Midi2.0.99.68-devpreview.7\build\native\Windows.Devices.Midi2.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Windows.Devices.Midi2.0.99.68-devpreview.7\build\native\Windows.Devices.Midi2.props'))" />
+    <Error Condition="!Exists('..\packages\Windows.Devices.Midi2.0.99.68-devpreview.7\build\native\Windows.Devices.Midi2.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Windows.Devices.Midi2.0.99.68-devpreview.7\build\native\Windows.Devices.Midi2.targets'))" />
   </Target>
 </Project>

--- a/samples/cpp-winrt/endpoint-listeners/packages.config
+++ b/samples/cpp-winrt/endpoint-listeners/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Microsoft.Windows.CppWinRT" version="3.0.260520.1" targetFramework="native" />
-  <package id="Windows.Devices.Midi2" version="0.99.67-devpreview.7" targetFramework="native" />
+  <package id="Windows.Devices.Midi2" version="0.99.68-devpreview.7" targetFramework="native" />
 </packages>

--- a/samples/cpp-winrt/get-vid-pid/get-vid-pid-cpp.vcxproj
+++ b/samples/cpp-winrt/get-vid-pid/get-vid-pid-cpp.vcxproj
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\packages\Windows.Devices.Midi2.0.99.67-devpreview.7\build\native\Windows.Devices.Midi2.props" Condition="Exists('..\packages\Windows.Devices.Midi2.0.99.67-devpreview.7\build\native\Windows.Devices.Midi2.props')" />
+  <Import Project="..\packages\Windows.Devices.Midi2.0.99.68-devpreview.7\build\native\Windows.Devices.Midi2.props" Condition="Exists('..\packages\Windows.Devices.Midi2.0.99.68-devpreview.7\build\native\Windows.Devices.Midi2.props')" />
   <Import Project="..\packages\Microsoft.Windows.CppWinRT.3.0.260520.1\build\native\Microsoft.Windows.CppWinRT.props" Condition="Exists('..\packages\Microsoft.Windows.CppWinRT.3.0.260520.1\build\native\Microsoft.Windows.CppWinRT.props')" />
   <PropertyGroup Label="Globals">
     <CppWinRTOptimized>true</CppWinRTOptimized>
@@ -164,7 +164,7 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
     <Import Project="..\packages\Microsoft.Windows.CppWinRT.3.0.260520.1\build\native\Microsoft.Windows.CppWinRT.targets" Condition="Exists('..\packages\Microsoft.Windows.CppWinRT.3.0.260520.1\build\native\Microsoft.Windows.CppWinRT.targets')" />
-    <Import Project="..\packages\Windows.Devices.Midi2.0.99.67-devpreview.7\build\native\Windows.Devices.Midi2.targets" Condition="Exists('..\packages\Windows.Devices.Midi2.0.99.67-devpreview.7\build\native\Windows.Devices.Midi2.targets')" />
+    <Import Project="..\packages\Windows.Devices.Midi2.0.99.68-devpreview.7\build\native\Windows.Devices.Midi2.targets" Condition="Exists('..\packages\Windows.Devices.Midi2.0.99.68-devpreview.7\build\native\Windows.Devices.Midi2.targets')" />
   </ImportGroup>
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
@@ -172,7 +172,7 @@
     </PropertyGroup>
     <Error Condition="!Exists('..\packages\Microsoft.Windows.CppWinRT.3.0.260520.1\build\native\Microsoft.Windows.CppWinRT.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Windows.CppWinRT.3.0.260520.1\build\native\Microsoft.Windows.CppWinRT.props'))" />
     <Error Condition="!Exists('..\packages\Microsoft.Windows.CppWinRT.3.0.260520.1\build\native\Microsoft.Windows.CppWinRT.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Windows.CppWinRT.3.0.260520.1\build\native\Microsoft.Windows.CppWinRT.targets'))" />
-    <Error Condition="!Exists('..\packages\Windows.Devices.Midi2.0.99.67-devpreview.7\build\native\Windows.Devices.Midi2.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Windows.Devices.Midi2.0.99.67-devpreview.7\build\native\Windows.Devices.Midi2.props'))" />
-    <Error Condition="!Exists('..\packages\Windows.Devices.Midi2.0.99.67-devpreview.7\build\native\Windows.Devices.Midi2.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Windows.Devices.Midi2.0.99.67-devpreview.7\build\native\Windows.Devices.Midi2.targets'))" />
+    <Error Condition="!Exists('..\packages\Windows.Devices.Midi2.0.99.68-devpreview.7\build\native\Windows.Devices.Midi2.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Windows.Devices.Midi2.0.99.68-devpreview.7\build\native\Windows.Devices.Midi2.props'))" />
+    <Error Condition="!Exists('..\packages\Windows.Devices.Midi2.0.99.68-devpreview.7\build\native\Windows.Devices.Midi2.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Windows.Devices.Midi2.0.99.68-devpreview.7\build\native\Windows.Devices.Midi2.targets'))" />
   </Target>
 </Project>

--- a/samples/cpp-winrt/get-vid-pid/packages.config
+++ b/samples/cpp-winrt/get-vid-pid/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Microsoft.Windows.CppWinRT" version="3.0.260520.1" targetFramework="native" />
-  <package id="Windows.Devices.Midi2" version="0.99.67-devpreview.7" targetFramework="native" />
+  <package id="Windows.Devices.Midi2" version="0.99.68-devpreview.7" targetFramework="native" />
 </packages>

--- a/samples/cpp-winrt/identify-endpoint-type/identify-endpoint-type-cpp.vcxproj
+++ b/samples/cpp-winrt/identify-endpoint-type/identify-endpoint-type-cpp.vcxproj
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\packages\Windows.Devices.Midi2.0.99.67-devpreview.7\build\native\Windows.Devices.Midi2.props" Condition="Exists('..\packages\Windows.Devices.Midi2.0.99.67-devpreview.7\build\native\Windows.Devices.Midi2.props')" />
+  <Import Project="..\packages\Windows.Devices.Midi2.0.99.68-devpreview.7\build\native\Windows.Devices.Midi2.props" Condition="Exists('..\packages\Windows.Devices.Midi2.0.99.68-devpreview.7\build\native\Windows.Devices.Midi2.props')" />
   <Import Project="..\packages\Microsoft.Windows.CppWinRT.3.0.260520.1\build\native\Microsoft.Windows.CppWinRT.props" Condition="Exists('..\packages\Microsoft.Windows.CppWinRT.3.0.260520.1\build\native\Microsoft.Windows.CppWinRT.props')" />
   <PropertyGroup Label="Globals">
     <CppWinRTOptimized>true</CppWinRTOptimized>
@@ -164,7 +164,7 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
     <Import Project="..\packages\Microsoft.Windows.CppWinRT.3.0.260520.1\build\native\Microsoft.Windows.CppWinRT.targets" Condition="Exists('..\packages\Microsoft.Windows.CppWinRT.3.0.260520.1\build\native\Microsoft.Windows.CppWinRT.targets')" />
-    <Import Project="..\packages\Windows.Devices.Midi2.0.99.67-devpreview.7\build\native\Windows.Devices.Midi2.targets" Condition="Exists('..\packages\Windows.Devices.Midi2.0.99.67-devpreview.7\build\native\Windows.Devices.Midi2.targets')" />
+    <Import Project="..\packages\Windows.Devices.Midi2.0.99.68-devpreview.7\build\native\Windows.Devices.Midi2.targets" Condition="Exists('..\packages\Windows.Devices.Midi2.0.99.68-devpreview.7\build\native\Windows.Devices.Midi2.targets')" />
   </ImportGroup>
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
@@ -172,7 +172,7 @@
     </PropertyGroup>
     <Error Condition="!Exists('..\packages\Microsoft.Windows.CppWinRT.3.0.260520.1\build\native\Microsoft.Windows.CppWinRT.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Windows.CppWinRT.3.0.260520.1\build\native\Microsoft.Windows.CppWinRT.props'))" />
     <Error Condition="!Exists('..\packages\Microsoft.Windows.CppWinRT.3.0.260520.1\build\native\Microsoft.Windows.CppWinRT.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Windows.CppWinRT.3.0.260520.1\build\native\Microsoft.Windows.CppWinRT.targets'))" />
-    <Error Condition="!Exists('..\packages\Windows.Devices.Midi2.0.99.67-devpreview.7\build\native\Windows.Devices.Midi2.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Windows.Devices.Midi2.0.99.67-devpreview.7\build\native\Windows.Devices.Midi2.props'))" />
-    <Error Condition="!Exists('..\packages\Windows.Devices.Midi2.0.99.67-devpreview.7\build\native\Windows.Devices.Midi2.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Windows.Devices.Midi2.0.99.67-devpreview.7\build\native\Windows.Devices.Midi2.targets'))" />
+    <Error Condition="!Exists('..\packages\Windows.Devices.Midi2.0.99.68-devpreview.7\build\native\Windows.Devices.Midi2.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Windows.Devices.Midi2.0.99.68-devpreview.7\build\native\Windows.Devices.Midi2.props'))" />
+    <Error Condition="!Exists('..\packages\Windows.Devices.Midi2.0.99.68-devpreview.7\build\native\Windows.Devices.Midi2.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Windows.Devices.Midi2.0.99.68-devpreview.7\build\native\Windows.Devices.Midi2.targets'))" />
   </Target>
 </Project>

--- a/samples/cpp-winrt/identify-endpoint-type/packages.config
+++ b/samples/cpp-winrt/identify-endpoint-type/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Microsoft.Windows.CppWinRT" version="3.0.260520.1" targetFramework="native" />
-  <package id="Windows.Devices.Midi2" version="0.99.67-devpreview.7" targetFramework="native" />
+  <package id="Windows.Devices.Midi2" version="0.99.68-devpreview.7" targetFramework="native" />
 </packages>

--- a/samples/cpp-winrt/loopback-basic-endpoints-winmm/loopback-basic-endpoints-winmm-cpp.vcxproj
+++ b/samples/cpp-winrt/loopback-basic-endpoints-winmm/loopback-basic-endpoints-winmm-cpp.vcxproj
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\packages\Windows.Devices.Midi2.0.99.67-devpreview.7\build\native\Windows.Devices.Midi2.props" Condition="Exists('..\packages\Windows.Devices.Midi2.0.99.67-devpreview.7\build\native\Windows.Devices.Midi2.props')" />
+  <Import Project="..\packages\Windows.Devices.Midi2.0.99.68-devpreview.7\build\native\Windows.Devices.Midi2.props" Condition="Exists('..\packages\Windows.Devices.Midi2.0.99.68-devpreview.7\build\native\Windows.Devices.Midi2.props')" />
   <Import Project="..\packages\Microsoft.Windows.CppWinRT.3.0.260520.1\build\native\Microsoft.Windows.CppWinRT.props" Condition="Exists('..\packages\Microsoft.Windows.CppWinRT.3.0.260520.1\build\native\Microsoft.Windows.CppWinRT.props')" />
   <PropertyGroup Label="Globals">
     <CppWinRTOptimized>true</CppWinRTOptimized>
@@ -160,7 +160,7 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
     <Import Project="..\packages\Microsoft.Windows.CppWinRT.3.0.260520.1\build\native\Microsoft.Windows.CppWinRT.targets" Condition="Exists('..\packages\Microsoft.Windows.CppWinRT.3.0.260520.1\build\native\Microsoft.Windows.CppWinRT.targets')" />
-    <Import Project="..\packages\Windows.Devices.Midi2.0.99.67-devpreview.7\build\native\Windows.Devices.Midi2.targets" Condition="Exists('..\packages\Windows.Devices.Midi2.0.99.67-devpreview.7\build\native\Windows.Devices.Midi2.targets')" />
+    <Import Project="..\packages\Windows.Devices.Midi2.0.99.68-devpreview.7\build\native\Windows.Devices.Midi2.targets" Condition="Exists('..\packages\Windows.Devices.Midi2.0.99.68-devpreview.7\build\native\Windows.Devices.Midi2.targets')" />
   </ImportGroup>
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
@@ -168,7 +168,7 @@
     </PropertyGroup>
     <Error Condition="!Exists('..\packages\Microsoft.Windows.CppWinRT.3.0.260520.1\build\native\Microsoft.Windows.CppWinRT.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Windows.CppWinRT.3.0.260520.1\build\native\Microsoft.Windows.CppWinRT.props'))" />
     <Error Condition="!Exists('..\packages\Microsoft.Windows.CppWinRT.3.0.260520.1\build\native\Microsoft.Windows.CppWinRT.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Windows.CppWinRT.3.0.260520.1\build\native\Microsoft.Windows.CppWinRT.targets'))" />
-    <Error Condition="!Exists('..\packages\Windows.Devices.Midi2.0.99.67-devpreview.7\build\native\Windows.Devices.Midi2.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Windows.Devices.Midi2.0.99.67-devpreview.7\build\native\Windows.Devices.Midi2.props'))" />
-    <Error Condition="!Exists('..\packages\Windows.Devices.Midi2.0.99.67-devpreview.7\build\native\Windows.Devices.Midi2.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Windows.Devices.Midi2.0.99.67-devpreview.7\build\native\Windows.Devices.Midi2.targets'))" />
+    <Error Condition="!Exists('..\packages\Windows.Devices.Midi2.0.99.68-devpreview.7\build\native\Windows.Devices.Midi2.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Windows.Devices.Midi2.0.99.68-devpreview.7\build\native\Windows.Devices.Midi2.props'))" />
+    <Error Condition="!Exists('..\packages\Windows.Devices.Midi2.0.99.68-devpreview.7\build\native\Windows.Devices.Midi2.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Windows.Devices.Midi2.0.99.68-devpreview.7\build\native\Windows.Devices.Midi2.targets'))" />
   </Target>
 </Project>

--- a/samples/cpp-winrt/loopback-basic-endpoints-winmm/packages.config
+++ b/samples/cpp-winrt/loopback-basic-endpoints-winmm/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Microsoft.Windows.CppWinRT" version="3.0.260520.1" targetFramework="native" />
-  <package id="Windows.Devices.Midi2" version="0.99.67-devpreview.7" targetFramework="native" />
+  <package id="Windows.Devices.Midi2" version="0.99.68-devpreview.7" targetFramework="native" />
 </packages>

--- a/samples/cpp-winrt/loopback-basic-endpoints/loopback-basic-endpoints-cpp.vcxproj
+++ b/samples/cpp-winrt/loopback-basic-endpoints/loopback-basic-endpoints-cpp.vcxproj
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\packages\Windows.Devices.Midi2.0.99.67-devpreview.7\build\native\Windows.Devices.Midi2.props" Condition="Exists('..\packages\Windows.Devices.Midi2.0.99.67-devpreview.7\build\native\Windows.Devices.Midi2.props')" />
+  <Import Project="..\packages\Windows.Devices.Midi2.0.99.68-devpreview.7\build\native\Windows.Devices.Midi2.props" Condition="Exists('..\packages\Windows.Devices.Midi2.0.99.68-devpreview.7\build\native\Windows.Devices.Midi2.props')" />
   <Import Project="..\packages\Microsoft.Windows.CppWinRT.3.0.260520.1\build\native\Microsoft.Windows.CppWinRT.props" Condition="Exists('..\packages\Microsoft.Windows.CppWinRT.3.0.260520.1\build\native\Microsoft.Windows.CppWinRT.props')" />
   <PropertyGroup Label="Globals">
     <CppWinRTOptimized>true</CppWinRTOptimized>
@@ -154,7 +154,7 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
     <Import Project="..\packages\Microsoft.Windows.CppWinRT.3.0.260520.1\build\native\Microsoft.Windows.CppWinRT.targets" Condition="Exists('..\packages\Microsoft.Windows.CppWinRT.3.0.260520.1\build\native\Microsoft.Windows.CppWinRT.targets')" />
-    <Import Project="..\packages\Windows.Devices.Midi2.0.99.67-devpreview.7\build\native\Windows.Devices.Midi2.targets" Condition="Exists('..\packages\Windows.Devices.Midi2.0.99.67-devpreview.7\build\native\Windows.Devices.Midi2.targets')" />
+    <Import Project="..\packages\Windows.Devices.Midi2.0.99.68-devpreview.7\build\native\Windows.Devices.Midi2.targets" Condition="Exists('..\packages\Windows.Devices.Midi2.0.99.68-devpreview.7\build\native\Windows.Devices.Midi2.targets')" />
   </ImportGroup>
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
@@ -162,7 +162,7 @@
     </PropertyGroup>
     <Error Condition="!Exists('..\packages\Microsoft.Windows.CppWinRT.3.0.260520.1\build\native\Microsoft.Windows.CppWinRT.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Windows.CppWinRT.3.0.260520.1\build\native\Microsoft.Windows.CppWinRT.props'))" />
     <Error Condition="!Exists('..\packages\Microsoft.Windows.CppWinRT.3.0.260520.1\build\native\Microsoft.Windows.CppWinRT.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Windows.CppWinRT.3.0.260520.1\build\native\Microsoft.Windows.CppWinRT.targets'))" />
-    <Error Condition="!Exists('..\packages\Windows.Devices.Midi2.0.99.67-devpreview.7\build\native\Windows.Devices.Midi2.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Windows.Devices.Midi2.0.99.67-devpreview.7\build\native\Windows.Devices.Midi2.props'))" />
-    <Error Condition="!Exists('..\packages\Windows.Devices.Midi2.0.99.67-devpreview.7\build\native\Windows.Devices.Midi2.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Windows.Devices.Midi2.0.99.67-devpreview.7\build\native\Windows.Devices.Midi2.targets'))" />
+    <Error Condition="!Exists('..\packages\Windows.Devices.Midi2.0.99.68-devpreview.7\build\native\Windows.Devices.Midi2.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Windows.Devices.Midi2.0.99.68-devpreview.7\build\native\Windows.Devices.Midi2.props'))" />
+    <Error Condition="!Exists('..\packages\Windows.Devices.Midi2.0.99.68-devpreview.7\build\native\Windows.Devices.Midi2.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Windows.Devices.Midi2.0.99.68-devpreview.7\build\native\Windows.Devices.Midi2.targets'))" />
   </Target>
 </Project>

--- a/samples/cpp-winrt/loopback-basic-endpoints/packages.config
+++ b/samples/cpp-winrt/loopback-basic-endpoints/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Microsoft.Windows.CppWinRT" version="3.0.260520.1" targetFramework="native" />
-  <package id="Windows.Devices.Midi2" version="0.99.67-devpreview.7" targetFramework="native" />
+  <package id="Windows.Devices.Midi2" version="0.99.68-devpreview.7" targetFramework="native" />
 </packages>

--- a/samples/cpp-winrt/loopback-endpoints/loopback-endpoints-cpp.vcxproj
+++ b/samples/cpp-winrt/loopback-endpoints/loopback-endpoints-cpp.vcxproj
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\packages\Windows.Devices.Midi2.0.99.67-devpreview.7\build\native\Windows.Devices.Midi2.props" Condition="Exists('..\packages\Windows.Devices.Midi2.0.99.67-devpreview.7\build\native\Windows.Devices.Midi2.props')" />
+  <Import Project="..\packages\Windows.Devices.Midi2.0.99.68-devpreview.7\build\native\Windows.Devices.Midi2.props" Condition="Exists('..\packages\Windows.Devices.Midi2.0.99.68-devpreview.7\build\native\Windows.Devices.Midi2.props')" />
   <Import Project="..\packages\Microsoft.Windows.CppWinRT.3.0.260520.1\build\native\Microsoft.Windows.CppWinRT.props" Condition="Exists('..\packages\Microsoft.Windows.CppWinRT.3.0.260520.1\build\native\Microsoft.Windows.CppWinRT.props')" />
   <PropertyGroup Label="Globals">
     <CppWinRTOptimized>true</CppWinRTOptimized>
@@ -154,7 +154,7 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
     <Import Project="..\packages\Microsoft.Windows.CppWinRT.3.0.260520.1\build\native\Microsoft.Windows.CppWinRT.targets" Condition="Exists('..\packages\Microsoft.Windows.CppWinRT.3.0.260520.1\build\native\Microsoft.Windows.CppWinRT.targets')" />
-    <Import Project="..\packages\Windows.Devices.Midi2.0.99.67-devpreview.7\build\native\Windows.Devices.Midi2.targets" Condition="Exists('..\packages\Windows.Devices.Midi2.0.99.67-devpreview.7\build\native\Windows.Devices.Midi2.targets')" />
+    <Import Project="..\packages\Windows.Devices.Midi2.0.99.68-devpreview.7\build\native\Windows.Devices.Midi2.targets" Condition="Exists('..\packages\Windows.Devices.Midi2.0.99.68-devpreview.7\build\native\Windows.Devices.Midi2.targets')" />
   </ImportGroup>
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
@@ -162,7 +162,7 @@
     </PropertyGroup>
     <Error Condition="!Exists('..\packages\Microsoft.Windows.CppWinRT.3.0.260520.1\build\native\Microsoft.Windows.CppWinRT.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Windows.CppWinRT.3.0.260520.1\build\native\Microsoft.Windows.CppWinRT.props'))" />
     <Error Condition="!Exists('..\packages\Microsoft.Windows.CppWinRT.3.0.260520.1\build\native\Microsoft.Windows.CppWinRT.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Windows.CppWinRT.3.0.260520.1\build\native\Microsoft.Windows.CppWinRT.targets'))" />
-    <Error Condition="!Exists('..\packages\Windows.Devices.Midi2.0.99.67-devpreview.7\build\native\Windows.Devices.Midi2.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Windows.Devices.Midi2.0.99.67-devpreview.7\build\native\Windows.Devices.Midi2.props'))" />
-    <Error Condition="!Exists('..\packages\Windows.Devices.Midi2.0.99.67-devpreview.7\build\native\Windows.Devices.Midi2.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Windows.Devices.Midi2.0.99.67-devpreview.7\build\native\Windows.Devices.Midi2.targets'))" />
+    <Error Condition="!Exists('..\packages\Windows.Devices.Midi2.0.99.68-devpreview.7\build\native\Windows.Devices.Midi2.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Windows.Devices.Midi2.0.99.68-devpreview.7\build\native\Windows.Devices.Midi2.props'))" />
+    <Error Condition="!Exists('..\packages\Windows.Devices.Midi2.0.99.68-devpreview.7\build\native\Windows.Devices.Midi2.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Windows.Devices.Midi2.0.99.68-devpreview.7\build\native\Windows.Devices.Midi2.targets'))" />
   </Target>
 </Project>

--- a/samples/cpp-winrt/loopback-endpoints/packages.config
+++ b/samples/cpp-winrt/loopback-endpoints/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Microsoft.Windows.CppWinRT" version="3.0.260520.1" targetFramework="native" />
-  <package id="Windows.Devices.Midi2" version="0.99.67-devpreview.7" targetFramework="native" />
+  <package id="Windows.Devices.Midi2" version="0.99.68-devpreview.7" targetFramework="native" />
 </packages>

--- a/samples/cpp-winrt/scheduled-messages-com-extensions/packages.config
+++ b/samples/cpp-winrt/scheduled-messages-com-extensions/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Microsoft.Windows.CppWinRT" version="3.0.260520.1" targetFramework="native" />
-  <package id="Windows.Devices.Midi2" version="0.99.67-devpreview.7" targetFramework="native" />
+  <package id="Windows.Devices.Midi2" version="0.99.68-devpreview.7" targetFramework="native" />
 </packages>

--- a/samples/cpp-winrt/scheduled-messages-com-extensions/scheduled-messages-com-extensions-cpp.vcxproj
+++ b/samples/cpp-winrt/scheduled-messages-com-extensions/scheduled-messages-com-extensions-cpp.vcxproj
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\packages\Windows.Devices.Midi2.0.99.67-devpreview.7\build\native\Windows.Devices.Midi2.props" Condition="Exists('..\packages\Windows.Devices.Midi2.0.99.67-devpreview.7\build\native\Windows.Devices.Midi2.props')" />
+  <Import Project="..\packages\Windows.Devices.Midi2.0.99.68-devpreview.7\build\native\Windows.Devices.Midi2.props" Condition="Exists('..\packages\Windows.Devices.Midi2.0.99.68-devpreview.7\build\native\Windows.Devices.Midi2.props')" />
   <Import Project="..\packages\Microsoft.Windows.CppWinRT.3.0.260520.1\build\native\Microsoft.Windows.CppWinRT.props" Condition="Exists('..\packages\Microsoft.Windows.CppWinRT.3.0.260520.1\build\native\Microsoft.Windows.CppWinRT.props')" />
   <PropertyGroup Label="Globals">
     <CppWinRTOptimized>true</CppWinRTOptimized>
@@ -164,7 +164,7 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
     <Import Project="..\packages\Microsoft.Windows.CppWinRT.3.0.260520.1\build\native\Microsoft.Windows.CppWinRT.targets" Condition="Exists('..\packages\Microsoft.Windows.CppWinRT.3.0.260520.1\build\native\Microsoft.Windows.CppWinRT.targets')" />
-    <Import Project="..\packages\Windows.Devices.Midi2.0.99.67-devpreview.7\build\native\Windows.Devices.Midi2.targets" Condition="Exists('..\packages\Windows.Devices.Midi2.0.99.67-devpreview.7\build\native\Windows.Devices.Midi2.targets')" />
+    <Import Project="..\packages\Windows.Devices.Midi2.0.99.68-devpreview.7\build\native\Windows.Devices.Midi2.targets" Condition="Exists('..\packages\Windows.Devices.Midi2.0.99.68-devpreview.7\build\native\Windows.Devices.Midi2.targets')" />
   </ImportGroup>
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
@@ -172,7 +172,7 @@
     </PropertyGroup>
     <Error Condition="!Exists('..\packages\Microsoft.Windows.CppWinRT.3.0.260520.1\build\native\Microsoft.Windows.CppWinRT.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Windows.CppWinRT.3.0.260520.1\build\native\Microsoft.Windows.CppWinRT.props'))" />
     <Error Condition="!Exists('..\packages\Microsoft.Windows.CppWinRT.3.0.260520.1\build\native\Microsoft.Windows.CppWinRT.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Windows.CppWinRT.3.0.260520.1\build\native\Microsoft.Windows.CppWinRT.targets'))" />
-    <Error Condition="!Exists('..\packages\Windows.Devices.Midi2.0.99.67-devpreview.7\build\native\Windows.Devices.Midi2.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Windows.Devices.Midi2.0.99.67-devpreview.7\build\native\Windows.Devices.Midi2.props'))" />
-    <Error Condition="!Exists('..\packages\Windows.Devices.Midi2.0.99.67-devpreview.7\build\native\Windows.Devices.Midi2.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Windows.Devices.Midi2.0.99.67-devpreview.7\build\native\Windows.Devices.Midi2.targets'))" />
+    <Error Condition="!Exists('..\packages\Windows.Devices.Midi2.0.99.68-devpreview.7\build\native\Windows.Devices.Midi2.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Windows.Devices.Midi2.0.99.68-devpreview.7\build\native\Windows.Devices.Midi2.props'))" />
+    <Error Condition="!Exists('..\packages\Windows.Devices.Midi2.0.99.68-devpreview.7\build\native\Windows.Devices.Midi2.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Windows.Devices.Midi2.0.99.68-devpreview.7\build\native\Windows.Devices.Midi2.targets'))" />
   </Target>
 </Project>

--- a/samples/cpp-winrt/scheduled-send-messages/packages.config
+++ b/samples/cpp-winrt/scheduled-send-messages/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Microsoft.Windows.CppWinRT" version="3.0.260520.1" targetFramework="native" />
-  <package id="Windows.Devices.Midi2" version="0.99.67-devpreview.7" targetFramework="native" />
+  <package id="Windows.Devices.Midi2" version="0.99.68-devpreview.7" targetFramework="native" />
 </packages>

--- a/samples/cpp-winrt/scheduled-send-messages/scheduled-send-messages-cpp.vcxproj
+++ b/samples/cpp-winrt/scheduled-send-messages/scheduled-send-messages-cpp.vcxproj
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\packages\Windows.Devices.Midi2.0.99.67-devpreview.7\build\native\Windows.Devices.Midi2.props" Condition="Exists('..\packages\Windows.Devices.Midi2.0.99.67-devpreview.7\build\native\Windows.Devices.Midi2.props')" />
+  <Import Project="..\packages\Windows.Devices.Midi2.0.99.68-devpreview.7\build\native\Windows.Devices.Midi2.props" Condition="Exists('..\packages\Windows.Devices.Midi2.0.99.68-devpreview.7\build\native\Windows.Devices.Midi2.props')" />
   <Import Project="..\packages\Microsoft.Windows.CppWinRT.3.0.260520.1\build\native\Microsoft.Windows.CppWinRT.props" Condition="Exists('..\packages\Microsoft.Windows.CppWinRT.3.0.260520.1\build\native\Microsoft.Windows.CppWinRT.props')" />
   <PropertyGroup Label="Globals">
     <CppWinRTOptimized>true</CppWinRTOptimized>
@@ -164,7 +164,7 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
     <Import Project="..\packages\Microsoft.Windows.CppWinRT.3.0.260520.1\build\native\Microsoft.Windows.CppWinRT.targets" Condition="Exists('..\packages\Microsoft.Windows.CppWinRT.3.0.260520.1\build\native\Microsoft.Windows.CppWinRT.targets')" />
-    <Import Project="..\packages\Windows.Devices.Midi2.0.99.67-devpreview.7\build\native\Windows.Devices.Midi2.targets" Condition="Exists('..\packages\Windows.Devices.Midi2.0.99.67-devpreview.7\build\native\Windows.Devices.Midi2.targets')" />
+    <Import Project="..\packages\Windows.Devices.Midi2.0.99.68-devpreview.7\build\native\Windows.Devices.Midi2.targets" Condition="Exists('..\packages\Windows.Devices.Midi2.0.99.68-devpreview.7\build\native\Windows.Devices.Midi2.targets')" />
   </ImportGroup>
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
@@ -172,7 +172,7 @@
     </PropertyGroup>
     <Error Condition="!Exists('..\packages\Microsoft.Windows.CppWinRT.3.0.260520.1\build\native\Microsoft.Windows.CppWinRT.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Windows.CppWinRT.3.0.260520.1\build\native\Microsoft.Windows.CppWinRT.props'))" />
     <Error Condition="!Exists('..\packages\Microsoft.Windows.CppWinRT.3.0.260520.1\build\native\Microsoft.Windows.CppWinRT.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Windows.CppWinRT.3.0.260520.1\build\native\Microsoft.Windows.CppWinRT.targets'))" />
-    <Error Condition="!Exists('..\packages\Windows.Devices.Midi2.0.99.67-devpreview.7\build\native\Windows.Devices.Midi2.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Windows.Devices.Midi2.0.99.67-devpreview.7\build\native\Windows.Devices.Midi2.props'))" />
-    <Error Condition="!Exists('..\packages\Windows.Devices.Midi2.0.99.67-devpreview.7\build\native\Windows.Devices.Midi2.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Windows.Devices.Midi2.0.99.67-devpreview.7\build\native\Windows.Devices.Midi2.targets'))" />
+    <Error Condition="!Exists('..\packages\Windows.Devices.Midi2.0.99.68-devpreview.7\build\native\Windows.Devices.Midi2.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Windows.Devices.Midi2.0.99.68-devpreview.7\build\native\Windows.Devices.Midi2.props'))" />
+    <Error Condition="!Exists('..\packages\Windows.Devices.Midi2.0.99.68-devpreview.7\build\native\Windows.Devices.Midi2.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Windows.Devices.Midi2.0.99.68-devpreview.7\build\native\Windows.Devices.Midi2.targets'))" />
   </Target>
 </Project>

--- a/samples/cpp-winrt/send-speed/packages.config
+++ b/samples/cpp-winrt/send-speed/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Microsoft.Windows.CppWinRT" version="3.0.260520.1" targetFramework="native" />
-  <package id="Windows.Devices.Midi2" version="0.99.67-devpreview.7" targetFramework="native" />
+  <package id="Windows.Devices.Midi2" version="0.99.68-devpreview.7" targetFramework="native" />
 </packages>

--- a/samples/cpp-winrt/send-speed/send-speed-cpp.vcxproj
+++ b/samples/cpp-winrt/send-speed/send-speed-cpp.vcxproj
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\packages\Windows.Devices.Midi2.0.99.67-devpreview.7\build\native\Windows.Devices.Midi2.props" Condition="Exists('..\packages\Windows.Devices.Midi2.0.99.67-devpreview.7\build\native\Windows.Devices.Midi2.props')" />
+  <Import Project="..\packages\Windows.Devices.Midi2.0.99.68-devpreview.7\build\native\Windows.Devices.Midi2.props" Condition="Exists('..\packages\Windows.Devices.Midi2.0.99.68-devpreview.7\build\native\Windows.Devices.Midi2.props')" />
   <Import Project="..\packages\Microsoft.Windows.CppWinRT.3.0.260520.1\build\native\Microsoft.Windows.CppWinRT.props" Condition="Exists('..\packages\Microsoft.Windows.CppWinRT.3.0.260520.1\build\native\Microsoft.Windows.CppWinRT.props')" />
   <PropertyGroup Label="Globals">
     <CppWinRTOptimized>true</CppWinRTOptimized>
@@ -164,7 +164,7 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
     <Import Project="..\packages\Microsoft.Windows.CppWinRT.3.0.260520.1\build\native\Microsoft.Windows.CppWinRT.targets" Condition="Exists('..\packages\Microsoft.Windows.CppWinRT.3.0.260520.1\build\native\Microsoft.Windows.CppWinRT.targets')" />
-    <Import Project="..\packages\Windows.Devices.Midi2.0.99.67-devpreview.7\build\native\Windows.Devices.Midi2.targets" Condition="Exists('..\packages\Windows.Devices.Midi2.0.99.67-devpreview.7\build\native\Windows.Devices.Midi2.targets')" />
+    <Import Project="..\packages\Windows.Devices.Midi2.0.99.68-devpreview.7\build\native\Windows.Devices.Midi2.targets" Condition="Exists('..\packages\Windows.Devices.Midi2.0.99.68-devpreview.7\build\native\Windows.Devices.Midi2.targets')" />
   </ImportGroup>
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
@@ -172,7 +172,7 @@
     </PropertyGroup>
     <Error Condition="!Exists('..\packages\Microsoft.Windows.CppWinRT.3.0.260520.1\build\native\Microsoft.Windows.CppWinRT.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Windows.CppWinRT.3.0.260520.1\build\native\Microsoft.Windows.CppWinRT.props'))" />
     <Error Condition="!Exists('..\packages\Microsoft.Windows.CppWinRT.3.0.260520.1\build\native\Microsoft.Windows.CppWinRT.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Windows.CppWinRT.3.0.260520.1\build\native\Microsoft.Windows.CppWinRT.targets'))" />
-    <Error Condition="!Exists('..\packages\Windows.Devices.Midi2.0.99.67-devpreview.7\build\native\Windows.Devices.Midi2.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Windows.Devices.Midi2.0.99.67-devpreview.7\build\native\Windows.Devices.Midi2.props'))" />
-    <Error Condition="!Exists('..\packages\Windows.Devices.Midi2.0.99.67-devpreview.7\build\native\Windows.Devices.Midi2.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Windows.Devices.Midi2.0.99.67-devpreview.7\build\native\Windows.Devices.Midi2.targets'))" />
+    <Error Condition="!Exists('..\packages\Windows.Devices.Midi2.0.99.68-devpreview.7\build\native\Windows.Devices.Midi2.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Windows.Devices.Midi2.0.99.68-devpreview.7\build\native\Windows.Devices.Midi2.props'))" />
+    <Error Condition="!Exists('..\packages\Windows.Devices.Midi2.0.99.68-devpreview.7\build\native\Windows.Devices.Midi2.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Windows.Devices.Midi2.0.99.68-devpreview.7\build\native\Windows.Devices.Midi2.targets'))" />
   </Target>
 </Project>

--- a/samples/cpp-winrt/simple-app-to-app-midi/packages.config
+++ b/samples/cpp-winrt/simple-app-to-app-midi/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Microsoft.Windows.CppWinRT" version="3.0.260520.1" targetFramework="native" />
-  <package id="Windows.Devices.Midi2" version="0.99.67-devpreview.7" targetFramework="native" />
+  <package id="Windows.Devices.Midi2" version="0.99.68-devpreview.7" targetFramework="native" />
 </packages>

--- a/samples/cpp-winrt/simple-app-to-app-midi/simple-app-to-app-cpp.vcxproj
+++ b/samples/cpp-winrt/simple-app-to-app-midi/simple-app-to-app-cpp.vcxproj
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\packages\Windows.Devices.Midi2.0.99.67-devpreview.7\build\native\Windows.Devices.Midi2.props" Condition="Exists('..\packages\Windows.Devices.Midi2.0.99.67-devpreview.7\build\native\Windows.Devices.Midi2.props')" />
+  <Import Project="..\packages\Windows.Devices.Midi2.0.99.68-devpreview.7\build\native\Windows.Devices.Midi2.props" Condition="Exists('..\packages\Windows.Devices.Midi2.0.99.68-devpreview.7\build\native\Windows.Devices.Midi2.props')" />
   <Import Project="..\packages\Microsoft.Windows.CppWinRT.3.0.260520.1\build\native\Microsoft.Windows.CppWinRT.props" Condition="Exists('..\packages\Microsoft.Windows.CppWinRT.3.0.260520.1\build\native\Microsoft.Windows.CppWinRT.props')" />
   <PropertyGroup Label="Globals">
     <CppWinRTOptimized>true</CppWinRTOptimized>
@@ -151,7 +151,7 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
     <Import Project="..\packages\Microsoft.Windows.CppWinRT.3.0.260520.1\build\native\Microsoft.Windows.CppWinRT.targets" Condition="Exists('..\packages\Microsoft.Windows.CppWinRT.3.0.260520.1\build\native\Microsoft.Windows.CppWinRT.targets')" />
-    <Import Project="..\packages\Windows.Devices.Midi2.0.99.67-devpreview.7\build\native\Windows.Devices.Midi2.targets" Condition="Exists('..\packages\Windows.Devices.Midi2.0.99.67-devpreview.7\build\native\Windows.Devices.Midi2.targets')" />
+    <Import Project="..\packages\Windows.Devices.Midi2.0.99.68-devpreview.7\build\native\Windows.Devices.Midi2.targets" Condition="Exists('..\packages\Windows.Devices.Midi2.0.99.68-devpreview.7\build\native\Windows.Devices.Midi2.targets')" />
   </ImportGroup>
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
@@ -159,7 +159,7 @@
     </PropertyGroup>
     <Error Condition="!Exists('..\packages\Microsoft.Windows.CppWinRT.3.0.260520.1\build\native\Microsoft.Windows.CppWinRT.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Windows.CppWinRT.3.0.260520.1\build\native\Microsoft.Windows.CppWinRT.props'))" />
     <Error Condition="!Exists('..\packages\Microsoft.Windows.CppWinRT.3.0.260520.1\build\native\Microsoft.Windows.CppWinRT.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Windows.CppWinRT.3.0.260520.1\build\native\Microsoft.Windows.CppWinRT.targets'))" />
-    <Error Condition="!Exists('..\packages\Windows.Devices.Midi2.0.99.67-devpreview.7\build\native\Windows.Devices.Midi2.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Windows.Devices.Midi2.0.99.67-devpreview.7\build\native\Windows.Devices.Midi2.props'))" />
-    <Error Condition="!Exists('..\packages\Windows.Devices.Midi2.0.99.67-devpreview.7\build\native\Windows.Devices.Midi2.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Windows.Devices.Midi2.0.99.67-devpreview.7\build\native\Windows.Devices.Midi2.targets'))" />
+    <Error Condition="!Exists('..\packages\Windows.Devices.Midi2.0.99.68-devpreview.7\build\native\Windows.Devices.Midi2.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Windows.Devices.Midi2.0.99.68-devpreview.7\build\native\Windows.Devices.Midi2.props'))" />
+    <Error Condition="!Exists('..\packages\Windows.Devices.Midi2.0.99.68-devpreview.7\build\native\Windows.Devices.Midi2.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Windows.Devices.Midi2.0.99.68-devpreview.7\build\native\Windows.Devices.Midi2.targets'))" />
   </Target>
 </Project>

--- a/samples/cpp-winrt/static-enum-endpoints/packages.config
+++ b/samples/cpp-winrt/static-enum-endpoints/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Microsoft.Windows.CppWinRT" version="3.0.260520.1" targetFramework="native" />
-  <package id="Windows.Devices.Midi2" version="0.99.67-devpreview.7" targetFramework="native" />
+  <package id="Windows.Devices.Midi2" version="0.99.68-devpreview.7" targetFramework="native" />
 </packages>

--- a/samples/cpp-winrt/static-enum-endpoints/static-enum-endpoints-cpp.vcxproj
+++ b/samples/cpp-winrt/static-enum-endpoints/static-enum-endpoints-cpp.vcxproj
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\packages\Windows.Devices.Midi2.0.99.67-devpreview.7\build\native\Windows.Devices.Midi2.props" Condition="Exists('..\packages\Windows.Devices.Midi2.0.99.67-devpreview.7\build\native\Windows.Devices.Midi2.props')" />
+  <Import Project="..\packages\Windows.Devices.Midi2.0.99.68-devpreview.7\build\native\Windows.Devices.Midi2.props" Condition="Exists('..\packages\Windows.Devices.Midi2.0.99.68-devpreview.7\build\native\Windows.Devices.Midi2.props')" />
   <Import Project="..\packages\Microsoft.Windows.CppWinRT.3.0.260520.1\build\native\Microsoft.Windows.CppWinRT.props" Condition="Exists('..\packages\Microsoft.Windows.CppWinRT.3.0.260520.1\build\native\Microsoft.Windows.CppWinRT.props')" />
   <PropertyGroup Label="Globals">
     <CppWinRTOptimized>true</CppWinRTOptimized>
@@ -164,7 +164,7 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
     <Import Project="..\packages\Microsoft.Windows.CppWinRT.3.0.260520.1\build\native\Microsoft.Windows.CppWinRT.targets" Condition="Exists('..\packages\Microsoft.Windows.CppWinRT.3.0.260520.1\build\native\Microsoft.Windows.CppWinRT.targets')" />
-    <Import Project="..\packages\Windows.Devices.Midi2.0.99.67-devpreview.7\build\native\Windows.Devices.Midi2.targets" Condition="Exists('..\packages\Windows.Devices.Midi2.0.99.67-devpreview.7\build\native\Windows.Devices.Midi2.targets')" />
+    <Import Project="..\packages\Windows.Devices.Midi2.0.99.68-devpreview.7\build\native\Windows.Devices.Midi2.targets" Condition="Exists('..\packages\Windows.Devices.Midi2.0.99.68-devpreview.7\build\native\Windows.Devices.Midi2.targets')" />
   </ImportGroup>
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
@@ -172,7 +172,7 @@
     </PropertyGroup>
     <Error Condition="!Exists('..\packages\Microsoft.Windows.CppWinRT.3.0.260520.1\build\native\Microsoft.Windows.CppWinRT.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Windows.CppWinRT.3.0.260520.1\build\native\Microsoft.Windows.CppWinRT.props'))" />
     <Error Condition="!Exists('..\packages\Microsoft.Windows.CppWinRT.3.0.260520.1\build\native\Microsoft.Windows.CppWinRT.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Windows.CppWinRT.3.0.260520.1\build\native\Microsoft.Windows.CppWinRT.targets'))" />
-    <Error Condition="!Exists('..\packages\Windows.Devices.Midi2.0.99.67-devpreview.7\build\native\Windows.Devices.Midi2.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Windows.Devices.Midi2.0.99.67-devpreview.7\build\native\Windows.Devices.Midi2.props'))" />
-    <Error Condition="!Exists('..\packages\Windows.Devices.Midi2.0.99.67-devpreview.7\build\native\Windows.Devices.Midi2.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Windows.Devices.Midi2.0.99.67-devpreview.7\build\native\Windows.Devices.Midi2.targets'))" />
+    <Error Condition="!Exists('..\packages\Windows.Devices.Midi2.0.99.68-devpreview.7\build\native\Windows.Devices.Midi2.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Windows.Devices.Midi2.0.99.68-devpreview.7\build\native\Windows.Devices.Midi2.props'))" />
+    <Error Condition="!Exists('..\packages\Windows.Devices.Midi2.0.99.68-devpreview.7\build\native\Windows.Devices.Midi2.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Windows.Devices.Midi2.0.99.68-devpreview.7\build\native\Windows.Devices.Midi2.targets'))" />
   </Target>
 </Project>

--- a/samples/cpp-winrt/sysex-file-receiver/packages.config
+++ b/samples/cpp-winrt/sysex-file-receiver/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Microsoft.Windows.CppWinRT" version="3.0.260520.1" targetFramework="native" />
-  <package id="Windows.Devices.Midi2" version="0.99.67-devpreview.7" targetFramework="native" />
+  <package id="Windows.Devices.Midi2" version="0.99.68-devpreview.7" targetFramework="native" />
 </packages>

--- a/samples/cpp-winrt/sysex-file-receiver/sysex-file-receiver-cpp.vcxproj
+++ b/samples/cpp-winrt/sysex-file-receiver/sysex-file-receiver-cpp.vcxproj
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\packages\Windows.Devices.Midi2.0.99.67-devpreview.7\build\native\Windows.Devices.Midi2.props" Condition="Exists('..\packages\Windows.Devices.Midi2.0.99.67-devpreview.7\build\native\Windows.Devices.Midi2.props')" />
+  <Import Project="..\packages\Windows.Devices.Midi2.0.99.68-devpreview.7\build\native\Windows.Devices.Midi2.props" Condition="Exists('..\packages\Windows.Devices.Midi2.0.99.68-devpreview.7\build\native\Windows.Devices.Midi2.props')" />
   <Import Project="..\packages\Microsoft.Windows.CppWinRT.3.0.260520.1\build\native\Microsoft.Windows.CppWinRT.props" Condition="Exists('..\packages\Microsoft.Windows.CppWinRT.3.0.260520.1\build\native\Microsoft.Windows.CppWinRT.props')" />
   <PropertyGroup Label="Globals">
     <CppWinRTOptimized>true</CppWinRTOptimized>
@@ -164,7 +164,7 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
     <Import Project="..\packages\Microsoft.Windows.CppWinRT.3.0.260520.1\build\native\Microsoft.Windows.CppWinRT.targets" Condition="Exists('..\packages\Microsoft.Windows.CppWinRT.3.0.260520.1\build\native\Microsoft.Windows.CppWinRT.targets')" />
-    <Import Project="..\packages\Windows.Devices.Midi2.0.99.67-devpreview.7\build\native\Windows.Devices.Midi2.targets" Condition="Exists('..\packages\Windows.Devices.Midi2.0.99.67-devpreview.7\build\native\Windows.Devices.Midi2.targets')" />
+    <Import Project="..\packages\Windows.Devices.Midi2.0.99.68-devpreview.7\build\native\Windows.Devices.Midi2.targets" Condition="Exists('..\packages\Windows.Devices.Midi2.0.99.68-devpreview.7\build\native\Windows.Devices.Midi2.targets')" />
   </ImportGroup>
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
@@ -172,7 +172,7 @@
     </PropertyGroup>
     <Error Condition="!Exists('..\packages\Microsoft.Windows.CppWinRT.3.0.260520.1\build\native\Microsoft.Windows.CppWinRT.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Windows.CppWinRT.3.0.260520.1\build\native\Microsoft.Windows.CppWinRT.props'))" />
     <Error Condition="!Exists('..\packages\Microsoft.Windows.CppWinRT.3.0.260520.1\build\native\Microsoft.Windows.CppWinRT.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Windows.CppWinRT.3.0.260520.1\build\native\Microsoft.Windows.CppWinRT.targets'))" />
-    <Error Condition="!Exists('..\packages\Windows.Devices.Midi2.0.99.67-devpreview.7\build\native\Windows.Devices.Midi2.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Windows.Devices.Midi2.0.99.67-devpreview.7\build\native\Windows.Devices.Midi2.props'))" />
-    <Error Condition="!Exists('..\packages\Windows.Devices.Midi2.0.99.67-devpreview.7\build\native\Windows.Devices.Midi2.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Windows.Devices.Midi2.0.99.67-devpreview.7\build\native\Windows.Devices.Midi2.targets'))" />
+    <Error Condition="!Exists('..\packages\Windows.Devices.Midi2.0.99.68-devpreview.7\build\native\Windows.Devices.Midi2.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Windows.Devices.Midi2.0.99.68-devpreview.7\build\native\Windows.Devices.Midi2.props'))" />
+    <Error Condition="!Exists('..\packages\Windows.Devices.Midi2.0.99.68-devpreview.7\build\native\Windows.Devices.Midi2.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Windows.Devices.Midi2.0.99.68-devpreview.7\build\native\Windows.Devices.Midi2.targets'))" />
   </Target>
 </Project>

--- a/samples/cpp-winrt/sysex-file-sender/packages.config
+++ b/samples/cpp-winrt/sysex-file-sender/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Microsoft.Windows.CppWinRT" version="3.0.260520.1" targetFramework="native" />
-  <package id="Windows.Devices.Midi2" version="0.99.67-devpreview.7" targetFramework="native" />
+  <package id="Windows.Devices.Midi2" version="0.99.68-devpreview.7" targetFramework="native" />
 </packages>

--- a/samples/cpp-winrt/sysex-file-sender/sysex-file-sender-cpp.vcxproj
+++ b/samples/cpp-winrt/sysex-file-sender/sysex-file-sender-cpp.vcxproj
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\packages\Windows.Devices.Midi2.0.99.67-devpreview.7\build\native\Windows.Devices.Midi2.props" Condition="Exists('..\packages\Windows.Devices.Midi2.0.99.67-devpreview.7\build\native\Windows.Devices.Midi2.props')" />
+  <Import Project="..\packages\Windows.Devices.Midi2.0.99.68-devpreview.7\build\native\Windows.Devices.Midi2.props" Condition="Exists('..\packages\Windows.Devices.Midi2.0.99.68-devpreview.7\build\native\Windows.Devices.Midi2.props')" />
   <Import Project="..\packages\Microsoft.Windows.CppWinRT.3.0.260520.1\build\native\Microsoft.Windows.CppWinRT.props" Condition="Exists('..\packages\Microsoft.Windows.CppWinRT.3.0.260520.1\build\native\Microsoft.Windows.CppWinRT.props')" />
   <PropertyGroup Label="Globals">
     <CppWinRTOptimized>true</CppWinRTOptimized>
@@ -164,7 +164,7 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
     <Import Project="..\packages\Microsoft.Windows.CppWinRT.3.0.260520.1\build\native\Microsoft.Windows.CppWinRT.targets" Condition="Exists('..\packages\Microsoft.Windows.CppWinRT.3.0.260520.1\build\native\Microsoft.Windows.CppWinRT.targets')" />
-    <Import Project="..\packages\Windows.Devices.Midi2.0.99.67-devpreview.7\build\native\Windows.Devices.Midi2.targets" Condition="Exists('..\packages\Windows.Devices.Midi2.0.99.67-devpreview.7\build\native\Windows.Devices.Midi2.targets')" />
+    <Import Project="..\packages\Windows.Devices.Midi2.0.99.68-devpreview.7\build\native\Windows.Devices.Midi2.targets" Condition="Exists('..\packages\Windows.Devices.Midi2.0.99.68-devpreview.7\build\native\Windows.Devices.Midi2.targets')" />
   </ImportGroup>
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
@@ -172,7 +172,7 @@
     </PropertyGroup>
     <Error Condition="!Exists('..\packages\Microsoft.Windows.CppWinRT.3.0.260520.1\build\native\Microsoft.Windows.CppWinRT.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Windows.CppWinRT.3.0.260520.1\build\native\Microsoft.Windows.CppWinRT.props'))" />
     <Error Condition="!Exists('..\packages\Microsoft.Windows.CppWinRT.3.0.260520.1\build\native\Microsoft.Windows.CppWinRT.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Windows.CppWinRT.3.0.260520.1\build\native\Microsoft.Windows.CppWinRT.targets'))" />
-    <Error Condition="!Exists('..\packages\Windows.Devices.Midi2.0.99.67-devpreview.7\build\native\Windows.Devices.Midi2.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Windows.Devices.Midi2.0.99.67-devpreview.7\build\native\Windows.Devices.Midi2.props'))" />
-    <Error Condition="!Exists('..\packages\Windows.Devices.Midi2.0.99.67-devpreview.7\build\native\Windows.Devices.Midi2.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Windows.Devices.Midi2.0.99.67-devpreview.7\build\native\Windows.Devices.Midi2.targets'))" />
+    <Error Condition="!Exists('..\packages\Windows.Devices.Midi2.0.99.68-devpreview.7\build\native\Windows.Devices.Midi2.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Windows.Devices.Midi2.0.99.68-devpreview.7\build\native\Windows.Devices.Midi2.props'))" />
+    <Error Condition="!Exists('..\packages\Windows.Devices.Midi2.0.99.68-devpreview.7\build\native\Windows.Devices.Midi2.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Windows.Devices.Midi2.0.99.68-devpreview.7\build\native\Windows.Devices.Midi2.targets'))" />
   </Target>
 </Project>

--- a/samples/cpp-winrt/sysex-send-bytes/packages.config
+++ b/samples/cpp-winrt/sysex-send-bytes/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Microsoft.Windows.CppWinRT" version="3.0.260520.1" targetFramework="native" />
-  <package id="Windows.Devices.Midi2" version="0.99.67-devpreview.7" targetFramework="native" />
+  <package id="Windows.Devices.Midi2" version="0.99.68-devpreview.7" targetFramework="native" />
 </packages>

--- a/samples/cpp-winrt/sysex-send-bytes/sysex-send-bytes-cpp.vcxproj
+++ b/samples/cpp-winrt/sysex-send-bytes/sysex-send-bytes-cpp.vcxproj
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\packages\Windows.Devices.Midi2.0.99.67-devpreview.7\build\native\Windows.Devices.Midi2.props" Condition="Exists('..\packages\Windows.Devices.Midi2.0.99.67-devpreview.7\build\native\Windows.Devices.Midi2.props')" />
+  <Import Project="..\packages\Windows.Devices.Midi2.0.99.68-devpreview.7\build\native\Windows.Devices.Midi2.props" Condition="Exists('..\packages\Windows.Devices.Midi2.0.99.68-devpreview.7\build\native\Windows.Devices.Midi2.props')" />
   <Import Project="..\packages\Microsoft.Windows.CppWinRT.3.0.260520.1\build\native\Microsoft.Windows.CppWinRT.props" Condition="Exists('..\packages\Microsoft.Windows.CppWinRT.3.0.260520.1\build\native\Microsoft.Windows.CppWinRT.props')" />
   <PropertyGroup Label="Globals">
     <CppWinRTOptimized>true</CppWinRTOptimized>
@@ -164,7 +164,7 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
     <Import Project="..\packages\Microsoft.Windows.CppWinRT.3.0.260520.1\build\native\Microsoft.Windows.CppWinRT.targets" Condition="Exists('..\packages\Microsoft.Windows.CppWinRT.3.0.260520.1\build\native\Microsoft.Windows.CppWinRT.targets')" />
-    <Import Project="..\packages\Windows.Devices.Midi2.0.99.67-devpreview.7\build\native\Windows.Devices.Midi2.targets" Condition="Exists('..\packages\Windows.Devices.Midi2.0.99.67-devpreview.7\build\native\Windows.Devices.Midi2.targets')" />
+    <Import Project="..\packages\Windows.Devices.Midi2.0.99.68-devpreview.7\build\native\Windows.Devices.Midi2.targets" Condition="Exists('..\packages\Windows.Devices.Midi2.0.99.68-devpreview.7\build\native\Windows.Devices.Midi2.targets')" />
   </ImportGroup>
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
@@ -172,7 +172,7 @@
     </PropertyGroup>
     <Error Condition="!Exists('..\packages\Microsoft.Windows.CppWinRT.3.0.260520.1\build\native\Microsoft.Windows.CppWinRT.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Windows.CppWinRT.3.0.260520.1\build\native\Microsoft.Windows.CppWinRT.props'))" />
     <Error Condition="!Exists('..\packages\Microsoft.Windows.CppWinRT.3.0.260520.1\build\native\Microsoft.Windows.CppWinRT.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Windows.CppWinRT.3.0.260520.1\build\native\Microsoft.Windows.CppWinRT.targets'))" />
-    <Error Condition="!Exists('..\packages\Windows.Devices.Midi2.0.99.67-devpreview.7\build\native\Windows.Devices.Midi2.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Windows.Devices.Midi2.0.99.67-devpreview.7\build\native\Windows.Devices.Midi2.props'))" />
-    <Error Condition="!Exists('..\packages\Windows.Devices.Midi2.0.99.67-devpreview.7\build\native\Windows.Devices.Midi2.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Windows.Devices.Midi2.0.99.67-devpreview.7\build\native\Windows.Devices.Midi2.targets'))" />
+    <Error Condition="!Exists('..\packages\Windows.Devices.Midi2.0.99.68-devpreview.7\build\native\Windows.Devices.Midi2.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Windows.Devices.Midi2.0.99.68-devpreview.7\build\native\Windows.Devices.Midi2.props'))" />
+    <Error Condition="!Exists('..\packages\Windows.Devices.Midi2.0.99.68-devpreview.7\build\native\Windows.Devices.Midi2.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Windows.Devices.Midi2.0.99.68-devpreview.7\build\native\Windows.Devices.Midi2.targets'))" />
   </Target>
 </Project>

--- a/samples/cpp-winrt/watch-endpoints/packages.config
+++ b/samples/cpp-winrt/watch-endpoints/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Microsoft.Windows.CppWinRT" version="3.0.260520.1" targetFramework="native" />
-  <package id="Windows.Devices.Midi2" version="0.99.67-devpreview.7" targetFramework="native" />
+  <package id="Windows.Devices.Midi2" version="0.99.68-devpreview.7" targetFramework="native" />
 </packages>

--- a/samples/cpp-winrt/watch-endpoints/watch-endpoints-cpp.vcxproj
+++ b/samples/cpp-winrt/watch-endpoints/watch-endpoints-cpp.vcxproj
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\packages\Windows.Devices.Midi2.0.99.67-devpreview.7\build\native\Windows.Devices.Midi2.props" Condition="Exists('..\packages\Windows.Devices.Midi2.0.99.67-devpreview.7\build\native\Windows.Devices.Midi2.props')" />
+  <Import Project="..\packages\Windows.Devices.Midi2.0.99.68-devpreview.7\build\native\Windows.Devices.Midi2.props" Condition="Exists('..\packages\Windows.Devices.Midi2.0.99.68-devpreview.7\build\native\Windows.Devices.Midi2.props')" />
   <Import Project="..\packages\Microsoft.Windows.CppWinRT.3.0.260520.1\build\native\Microsoft.Windows.CppWinRT.props" Condition="Exists('..\packages\Microsoft.Windows.CppWinRT.3.0.260520.1\build\native\Microsoft.Windows.CppWinRT.props')" />
   <PropertyGroup Label="Globals">
     <CppWinRTOptimized>true</CppWinRTOptimized>
@@ -164,7 +164,7 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
     <Import Project="..\packages\Microsoft.Windows.CppWinRT.3.0.260520.1\build\native\Microsoft.Windows.CppWinRT.targets" Condition="Exists('..\packages\Microsoft.Windows.CppWinRT.3.0.260520.1\build\native\Microsoft.Windows.CppWinRT.targets')" />
-    <Import Project="..\packages\Windows.Devices.Midi2.0.99.67-devpreview.7\build\native\Windows.Devices.Midi2.targets" Condition="Exists('..\packages\Windows.Devices.Midi2.0.99.67-devpreview.7\build\native\Windows.Devices.Midi2.targets')" />
+    <Import Project="..\packages\Windows.Devices.Midi2.0.99.68-devpreview.7\build\native\Windows.Devices.Midi2.targets" Condition="Exists('..\packages\Windows.Devices.Midi2.0.99.68-devpreview.7\build\native\Windows.Devices.Midi2.targets')" />
   </ImportGroup>
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
@@ -172,7 +172,7 @@
     </PropertyGroup>
     <Error Condition="!Exists('..\packages\Microsoft.Windows.CppWinRT.3.0.260520.1\build\native\Microsoft.Windows.CppWinRT.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Windows.CppWinRT.3.0.260520.1\build\native\Microsoft.Windows.CppWinRT.props'))" />
     <Error Condition="!Exists('..\packages\Microsoft.Windows.CppWinRT.3.0.260520.1\build\native\Microsoft.Windows.CppWinRT.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Windows.CppWinRT.3.0.260520.1\build\native\Microsoft.Windows.CppWinRT.targets'))" />
-    <Error Condition="!Exists('..\packages\Windows.Devices.Midi2.0.99.67-devpreview.7\build\native\Windows.Devices.Midi2.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Windows.Devices.Midi2.0.99.67-devpreview.7\build\native\Windows.Devices.Midi2.props'))" />
-    <Error Condition="!Exists('..\packages\Windows.Devices.Midi2.0.99.67-devpreview.7\build\native\Windows.Devices.Midi2.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Windows.Devices.Midi2.0.99.67-devpreview.7\build\native\Windows.Devices.Midi2.targets'))" />
+    <Error Condition="!Exists('..\packages\Windows.Devices.Midi2.0.99.68-devpreview.7\build\native\Windows.Devices.Midi2.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Windows.Devices.Midi2.0.99.68-devpreview.7\build\native\Windows.Devices.Midi2.props'))" />
+    <Error Condition="!Exists('..\packages\Windows.Devices.Midi2.0.99.68-devpreview.7\build\native\Windows.Devices.Midi2.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Windows.Devices.Midi2.0.99.68-devpreview.7\build\native\Windows.Devices.Midi2.targets'))" />
   </Target>
 </Project>

--- a/samples/cpp-winrt/watch-midi1-ports/packages.config
+++ b/samples/cpp-winrt/watch-midi1-ports/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Microsoft.Windows.CppWinRT" version="3.0.260520.1" targetFramework="native" />
-  <package id="Windows.Devices.Midi2" version="0.99.67-devpreview.7" targetFramework="native" />
+  <package id="Windows.Devices.Midi2" version="0.99.68-devpreview.7" targetFramework="native" />
 </packages>

--- a/samples/cpp-winrt/watch-midi1-ports/watch-midi1-ports-cpp.vcxproj
+++ b/samples/cpp-winrt/watch-midi1-ports/watch-midi1-ports-cpp.vcxproj
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\packages\Windows.Devices.Midi2.0.99.67-devpreview.7\build\native\Windows.Devices.Midi2.props" Condition="Exists('..\packages\Windows.Devices.Midi2.0.99.67-devpreview.7\build\native\Windows.Devices.Midi2.props')" />
+  <Import Project="..\packages\Windows.Devices.Midi2.0.99.68-devpreview.7\build\native\Windows.Devices.Midi2.props" Condition="Exists('..\packages\Windows.Devices.Midi2.0.99.68-devpreview.7\build\native\Windows.Devices.Midi2.props')" />
   <Import Project="..\packages\Microsoft.Windows.CppWinRT.3.0.260520.1\build\native\Microsoft.Windows.CppWinRT.props" Condition="Exists('..\packages\Microsoft.Windows.CppWinRT.3.0.260520.1\build\native\Microsoft.Windows.CppWinRT.props')" />
   <PropertyGroup Label="Globals">
     <CppWinRTOptimized>true</CppWinRTOptimized>
@@ -164,7 +164,7 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
     <Import Project="..\packages\Microsoft.Windows.CppWinRT.3.0.260520.1\build\native\Microsoft.Windows.CppWinRT.targets" Condition="Exists('..\packages\Microsoft.Windows.CppWinRT.3.0.260520.1\build\native\Microsoft.Windows.CppWinRT.targets')" />
-    <Import Project="..\packages\Windows.Devices.Midi2.0.99.67-devpreview.7\build\native\Windows.Devices.Midi2.targets" Condition="Exists('..\packages\Windows.Devices.Midi2.0.99.67-devpreview.7\build\native\Windows.Devices.Midi2.targets')" />
+    <Import Project="..\packages\Windows.Devices.Midi2.0.99.68-devpreview.7\build\native\Windows.Devices.Midi2.targets" Condition="Exists('..\packages\Windows.Devices.Midi2.0.99.68-devpreview.7\build\native\Windows.Devices.Midi2.targets')" />
   </ImportGroup>
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
@@ -172,7 +172,7 @@
     </PropertyGroup>
     <Error Condition="!Exists('..\packages\Microsoft.Windows.CppWinRT.3.0.260520.1\build\native\Microsoft.Windows.CppWinRT.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Windows.CppWinRT.3.0.260520.1\build\native\Microsoft.Windows.CppWinRT.props'))" />
     <Error Condition="!Exists('..\packages\Microsoft.Windows.CppWinRT.3.0.260520.1\build\native\Microsoft.Windows.CppWinRT.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Windows.CppWinRT.3.0.260520.1\build\native\Microsoft.Windows.CppWinRT.targets'))" />
-    <Error Condition="!Exists('..\packages\Windows.Devices.Midi2.0.99.67-devpreview.7\build\native\Windows.Devices.Midi2.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Windows.Devices.Midi2.0.99.67-devpreview.7\build\native\Windows.Devices.Midi2.props'))" />
-    <Error Condition="!Exists('..\packages\Windows.Devices.Midi2.0.99.67-devpreview.7\build\native\Windows.Devices.Midi2.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Windows.Devices.Midi2.0.99.67-devpreview.7\build\native\Windows.Devices.Midi2.targets'))" />
+    <Error Condition="!Exists('..\packages\Windows.Devices.Midi2.0.99.68-devpreview.7\build\native\Windows.Devices.Midi2.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Windows.Devices.Midi2.0.99.68-devpreview.7\build\native\Windows.Devices.Midi2.props'))" />
+    <Error Condition="!Exists('..\packages\Windows.Devices.Midi2.0.99.68-devpreview.7\build\native\Windows.Devices.Midi2.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Windows.Devices.Midi2.0.99.68-devpreview.7\build\native\Windows.Devices.Midi2.targets'))" />
   </Target>
 </Project>

--- a/samples/csharp-net/basics/client-basics-cs.csproj
+++ b/samples/csharp-net/basics/client-basics-cs.csproj
@@ -17,7 +17,7 @@
   
   <ItemGroup>
     <PackageReference Include="Microsoft.Windows.CsWinRT" Version="2.2.0" />
-    <PackageReference Include="Windows.Devices.Midi2" Version="0.99.67-devpreview.7" />
+    <PackageReference Include="Windows.Devices.Midi2" Version="0.99.68-devpreview.7" />
   </ItemGroup>
 
     <!-- For versioning info: https://learn.microsoft.com/en-us/nuget/concepts/dependency-resolution#floating-versions -->

--- a/samples/csharp-net/endpoint-listeners/endpoint-listeners-cs.csproj
+++ b/samples/csharp-net/endpoint-listeners/endpoint-listeners-cs.csproj
@@ -17,7 +17,7 @@
   
   <ItemGroup>
     <PackageReference Include="Microsoft.Windows.CsWinRT" Version="2.2.0" />
-    <PackageReference Include="Windows.Devices.Midi2" Version="0.99.67-devpreview.7" />
+    <PackageReference Include="Windows.Devices.Midi2" Version="0.99.68-devpreview.7" />
   </ItemGroup>
 
     <!-- For versioning info: https://learn.microsoft.com/en-us/nuget/concepts/dependency-resolution#floating-versions -->

--- a/samples/csharp-net/get-vid-pid/get-vid-pid-cs.csproj
+++ b/samples/csharp-net/get-vid-pid/get-vid-pid-cs.csproj
@@ -17,7 +17,7 @@
   
   <ItemGroup>
     <PackageReference Include="Microsoft.Windows.CsWinRT" Version="2.2.0" />
-    <PackageReference Include="Windows.Devices.Midi2" Version="0.99.67-devpreview.7" />
+    <PackageReference Include="Windows.Devices.Midi2" Version="0.99.68-devpreview.7" />
   </ItemGroup>
 
     <!-- For versioning info: https://learn.microsoft.com/en-us/nuget/concepts/dependency-resolution#floating-versions -->

--- a/samples/csharp-net/identify-endpoint-type/identify-endpoint-type-cs.csproj
+++ b/samples/csharp-net/identify-endpoint-type/identify-endpoint-type-cs.csproj
@@ -17,7 +17,7 @@
   
   <ItemGroup>
     <PackageReference Include="Microsoft.Windows.CsWinRT" Version="2.2.0" />
-    <PackageReference Include="Windows.Devices.Midi2" Version="0.99.67-devpreview.7" />
+    <PackageReference Include="Windows.Devices.Midi2" Version="0.99.68-devpreview.7" />
   </ItemGroup>
 
     <!-- For versioning info: https://learn.microsoft.com/en-us/nuget/concepts/dependency-resolution#floating-versions -->

--- a/samples/csharp-net/loopback-basic-endpoints/loopback-basic-endpoints-cs.csproj
+++ b/samples/csharp-net/loopback-basic-endpoints/loopback-basic-endpoints-cs.csproj
@@ -17,7 +17,7 @@
   
   <ItemGroup>
     <PackageReference Include="Microsoft.Windows.CsWinRT" Version="2.2.0" />
-    <PackageReference Include="Windows.Devices.Midi2" Version="0.99.67-devpreview.7" />
+    <PackageReference Include="Windows.Devices.Midi2" Version="0.99.68-devpreview.7" />
   </ItemGroup>
 
     <!-- For versioning info: https://learn.microsoft.com/en-us/nuget/concepts/dependency-resolution#floating-versions -->

--- a/samples/csharp-net/loopback-endpoints/loopback-endpoints-cs.csproj
+++ b/samples/csharp-net/loopback-endpoints/loopback-endpoints-cs.csproj
@@ -17,7 +17,7 @@
   
   <ItemGroup>
     <PackageReference Include="Microsoft.Windows.CsWinRT" Version="2.2.0" />
-    <PackageReference Include="Windows.Devices.Midi2" Version="0.99.67-devpreview.7" />
+    <PackageReference Include="Windows.Devices.Midi2" Version="0.99.68-devpreview.7" />
   </ItemGroup>
 
     <!-- For versioning info: https://learn.microsoft.com/en-us/nuget/concepts/dependency-resolution#floating-versions -->

--- a/samples/csharp-net/scheduled-send-messages/scheduled-send-messages-cs.csproj
+++ b/samples/csharp-net/scheduled-send-messages/scheduled-send-messages-cs.csproj
@@ -17,7 +17,7 @@
   
   <ItemGroup>
     <PackageReference Include="Microsoft.Windows.CsWinRT" Version="2.2.0" />
-    <PackageReference Include="Windows.Devices.Midi2" Version="0.99.67-devpreview.7" />
+    <PackageReference Include="Windows.Devices.Midi2" Version="0.99.68-devpreview.7" />
   </ItemGroup>
 
     <!-- For versioning info: https://learn.microsoft.com/en-us/nuget/concepts/dependency-resolution#floating-versions -->

--- a/samples/csharp-net/send-speed/send-speed-cs.csproj
+++ b/samples/csharp-net/send-speed/send-speed-cs.csproj
@@ -17,7 +17,7 @@
   
   <ItemGroup>
     <PackageReference Include="Microsoft.Windows.CsWinRT" Version="2.2.0" />
-    <PackageReference Include="Windows.Devices.Midi2" Version="0.99.67-devpreview.7" />
+    <PackageReference Include="Windows.Devices.Midi2" Version="0.99.68-devpreview.7" />
   </ItemGroup>
 
     <!-- For versioning info: https://learn.microsoft.com/en-us/nuget/concepts/dependency-resolution#floating-versions -->

--- a/samples/csharp-net/static-enum-endpoints/static-enum-endpoints-cs.csproj
+++ b/samples/csharp-net/static-enum-endpoints/static-enum-endpoints-cs.csproj
@@ -17,7 +17,7 @@
   
   <ItemGroup>
     <PackageReference Include="Microsoft.Windows.CsWinRT" Version="2.2.0" />
-    <PackageReference Include="Windows.Devices.Midi2" Version="0.99.67-devpreview.7" />
+    <PackageReference Include="Windows.Devices.Midi2" Version="0.99.68-devpreview.7" />
   </ItemGroup>
 
     <!-- For versioning info: https://learn.microsoft.com/en-us/nuget/concepts/dependency-resolution#floating-versions -->

--- a/samples/csharp-net/sysex-file-receiver/sysex-file-receiver-cs.csproj
+++ b/samples/csharp-net/sysex-file-receiver/sysex-file-receiver-cs.csproj
@@ -17,7 +17,7 @@
   
   <ItemGroup>
     <PackageReference Include="Microsoft.Windows.CsWinRT" Version="2.2.0" />
-    <PackageReference Include="Windows.Devices.Midi2" Version="0.99.67-devpreview.7" />
+    <PackageReference Include="Windows.Devices.Midi2" Version="0.99.68-devpreview.7" />
   </ItemGroup>
 
     <!-- For versioning info: https://learn.microsoft.com/en-us/nuget/concepts/dependency-resolution#floating-versions -->

--- a/samples/csharp-net/sysex-file-sender/sysex-file-sender-cs.csproj
+++ b/samples/csharp-net/sysex-file-sender/sysex-file-sender-cs.csproj
@@ -17,7 +17,7 @@
   
   <ItemGroup>
     <PackageReference Include="Microsoft.Windows.CsWinRT" Version="2.2.0" />
-    <PackageReference Include="Windows.Devices.Midi2" Version="0.99.67-devpreview.7" />
+    <PackageReference Include="Windows.Devices.Midi2" Version="0.99.68-devpreview.7" />
   </ItemGroup>
 
     <!-- For versioning info: https://learn.microsoft.com/en-us/nuget/concepts/dependency-resolution#floating-versions -->

--- a/samples/csharp-net/sysex-send-bytes/sysex-send-bytes-cs.csproj
+++ b/samples/csharp-net/sysex-send-bytes/sysex-send-bytes-cs.csproj
@@ -17,7 +17,7 @@
   
   <ItemGroup>
     <PackageReference Include="Microsoft.Windows.CsWinRT" Version="2.2.0" />
-    <PackageReference Include="Windows.Devices.Midi2" Version="0.99.67-devpreview.7" />
+    <PackageReference Include="Windows.Devices.Midi2" Version="0.99.68-devpreview.7" />
   </ItemGroup>
 
     <!-- For versioning info: https://learn.microsoft.com/en-us/nuget/concepts/dependency-resolution#floating-versions -->

--- a/samples/csharp-net/virtual-device-app-winui/virtual-device-app-winui-cs.csproj
+++ b/samples/csharp-net/virtual-device-app-winui/virtual-device-app-winui-cs.csproj
@@ -58,7 +58,7 @@
     <PackageReference Include="Microsoft.Windows.CsWinRT" Version="2.2.0" />
     <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.8.250916003" />
     <PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.26100.6584" />
-    <PackageReference Include="Windows.Devices.Midi2" Version="0.99.67-devpreview.7" />
+    <PackageReference Include="Windows.Devices.Midi2" Version="0.99.68-devpreview.7" />
     <PackageReference Include="WinUIEx" Version="2.8.0" />
     <Manifest Include="$(ApplicationManifest)" />
   </ItemGroup>

--- a/samples/csharp-net/watch-endpoints/watch-endpoints-cs.csproj
+++ b/samples/csharp-net/watch-endpoints/watch-endpoints-cs.csproj
@@ -17,7 +17,7 @@
   
   <ItemGroup>
     <PackageReference Include="Microsoft.Windows.CsWinRT" Version="2.2.0" />
-    <PackageReference Include="Windows.Devices.Midi2" Version="0.99.67-devpreview.7" />
+    <PackageReference Include="Windows.Devices.Midi2" Version="0.99.68-devpreview.7" />
   </ItemGroup>
 
     <!-- For versioning info: https://learn.microsoft.com/en-us/nuget/concepts/dependency-resolution#floating-versions -->

--- a/samples/csharp-net/watch-midi1-ports/watch-midi1-ports-cs.csproj
+++ b/samples/csharp-net/watch-midi1-ports/watch-midi1-ports-cs.csproj
@@ -17,7 +17,7 @@
   
   <ItemGroup>
     <PackageReference Include="Microsoft.Windows.CsWinRT" Version="2.2.0" />
-    <PackageReference Include="Windows.Devices.Midi2" Version="0.99.67-devpreview.7" />
+    <PackageReference Include="Windows.Devices.Midi2" Version="0.99.68-devpreview.7" />
   </ItemGroup>
 
     <!-- For versioning info: https://learn.microsoft.com/en-us/nuget/concepts/dependency-resolution#floating-versions -->

--- a/src/in-box/Client/WinRT/NuGet/Windows.Devices.Midi2.NuGet/nuget/Windows.Devices.Midi2.nuspec
+++ b/src/in-box/Client/WinRT/NuGet/Windows.Devices.Midi2.NuGet/nuget/Windows.Devices.Midi2.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2012/06/nuspec.xsd">
 	<metadata>
 		<id>Windows.Devices.Midi2</id>
-		<version>0.99.67-devpreview.7</version>
+		<version>0.99.68-devpreview.7</version>
 		<authors>Microsoft</authors>
 		<description>Windows MIDI Services App SDK. Temporary package to use until the metadata is in an official Windows SDK</description>
 		<license type="expression">MIT</license>

--- a/src/in-box/Client/WinRT/core/MidiEndpointDeviceInformation.cpp
+++ b/src/in-box/Client/WinRT/core/MidiEndpointDeviceInformation.cpp
@@ -212,7 +212,7 @@ namespace winrt::Windows::Devices::Midi2::Enumeration::implementation
 
             // WinMM / Naming properties ==========================================================
       //      additionalProperties.Append(STRING_PKEY_MIDI_UseLegacyMidi1PortNamingScheme);
-            additionalProperties.Append(STRING_PKEY_MIDI_CreateMidi1PortsForEndpoint);
+       //     additionalProperties.Append(STRING_PKEY_MIDI_CreateMidi1PortsForEndpoint);
             additionalProperties.Append(STRING_PKEY_MIDI_Midi1PortNamingSelection);
             additionalProperties.Append(STRING_PKEY_MIDI_Midi1PortNameTable);
 

--- a/src/in-box/Client/WinRT/core/MidiEndpointDeviceInformation.cpp
+++ b/src/in-box/Client/WinRT/core/MidiEndpointDeviceInformation.cpp
@@ -229,6 +229,8 @@ namespace winrt::Windows::Devices::Midi2::Enumeration::implementation
             additionalProperties.Append(STRING_PKEY_MIDI_IsMuted);
             additionalProperties.Append(STRING_PKEY_MIDI_CreateMidi1PortsForEndpoint);
 
+            additionalProperties.Append(STRING_PKEY_MIDI_EndpointDiscoveryProcessComplete);
+
 
 
             // Calculated metrics =================================================================

--- a/src/in-box/Client/WinRT/core/MidiEndpointDeviceInformation.cpp
+++ b/src/in-box/Client/WinRT/core/MidiEndpointDeviceInformation.cpp
@@ -227,7 +227,7 @@ namespace winrt::Windows::Devices::Midi2::Enumeration::implementation
 
         
             additionalProperties.Append(STRING_PKEY_MIDI_IsMuted);
-            additionalProperties.Append(STRING_PKEY_MIDI_CreateMidi1PortsForEndpoint);
+//            additionalProperties.Append(STRING_PKEY_MIDI_CreateMidi1PortsForEndpoint);
 
             additionalProperties.Append(STRING_PKEY_MIDI_EndpointDiscoveryProcessComplete);
 

--- a/src/in-box/Client/WinRT/core/MidiEndpointDeviceInformation.h
+++ b/src/in-box/Client/WinRT/core/MidiEndpointDeviceInformation.h
@@ -121,7 +121,7 @@ namespace winrt::Windows::Devices::Midi2::Enumeration::implementation
 
     public:
         bool IsMuted() const noexcept { return internal::GetDeviceInfoProperty<bool>(m_properties, STRING_PKEY_MIDI_IsMuted, false); }
-        bool IsMidi1PortCreationEnabled() const noexcept { return internal::GetDeviceInfoProperty<bool>(m_properties, STRING_PKEY_MIDI_CreateMidi1PortsForEndpoint, true); }
+        //bool IsMidi1PortCreationEnabled() const noexcept { return internal::GetDeviceInfoProperty<bool>(m_properties, STRING_PKEY_MIDI_CreateMidi1PortsForEndpoint, true); }
 
     };
 }

--- a/src/in-box/Client/WinRT/core/MidiEndpointDeviceInformation.idl
+++ b/src/in-box/Client/WinRT/core/MidiEndpointDeviceInformation.idl
@@ -96,7 +96,8 @@ namespace Windows.Devices.Midi2.Enumeration
         [noexcept] Midi1PortNamingApproach Midi1PortNamingApproach{ get; };
 
 
-        [noexcept] Boolean IsMidi1PortCreationEnabled{ get; };
+        //[noexcept] Boolean IsMidi1PortCreationEnabled{ get; };    // removed because this is never actually populated anywhere. Breaking change before production.
+
         [noexcept] Boolean IsMuted{ get; };
 
 

--- a/src/in-box/Client/WinRT/core/MidiEndpointDevicePropertyHelper.cpp
+++ b/src/in-box/Client/WinRT/core/MidiEndpointDevicePropertyHelper.cpp
@@ -300,7 +300,8 @@ namespace winrt::Windows::Devices::Midi2::Enumeration::implementation
 
         AddSingleMapEntry(PROPERTY_PAIR(STRING_PKEY_MIDI_IsMuted));
         
-
+        AddSingleMapEntry(PROPERTY_PAIR(STRING_PKEY_MIDI_EndpointDiscoveryProcessComplete));
+        
         //AddSingleMapEntry(PROPERTY_PAIR(STRING_PKEY_KsAgg));
 
         m_initialized = true;

--- a/src/in-box/Client/WinRT/core/MidiEndpointDevicePropertyHelper.cpp
+++ b/src/in-box/Client/WinRT/core/MidiEndpointDevicePropertyHelper.cpp
@@ -292,7 +292,7 @@ namespace winrt::Windows::Devices::Midi2::Enumeration::implementation
         AddSingleMapEntry(PROPERTY_PAIR(STRING_PKEY_MIDI_NetworkMidiConnectionRole));      
 
         //AddSingleMapEntry(PROPERTY_PAIR(STRING_PKEY_MIDI_UseLegacyMidi1PortNamingScheme));
-        AddSingleMapEntry(PROPERTY_PAIR(STRING_PKEY_MIDI_CreateMidi1PortsForEndpoint));
+    //    AddSingleMapEntry(PROPERTY_PAIR(STRING_PKEY_MIDI_CreateMidi1PortsForEndpoint));
         AddSingleMapEntry(PROPERTY_PAIR(STRING_PKEY_MIDI_Midi1PortNamingSelection));
         AddSingleMapEntry(PROPERTY_PAIR(STRING_PKEY_MIDI_Midi1PortNameTable));
 

--- a/src/in-box/Client/WinRT/core/MidiNetworkClientConnectConfig.cpp
+++ b/src/in-box/Client/WinRT/core/MidiNetworkClientConnectConfig.cpp
@@ -57,6 +57,10 @@ namespace winrt::Windows::Devices::Midi2::Transports::Network::implementation
             json::JsonValue::CreateBooleanValue(!CreateOnlyUmpEndpoints()));
 
         clientObject.SetNamedValue(
+            MIDI_CONFIG_JSON_NETWORK_MIDI_FALLBACK_MIDI1_PORT_COUNT_KEY,
+            json::JsonValue::CreateNumberValue(FallbackMidi1PortCount()));
+
+        clientObject.SetNamedValue(
             WindowsMidiServicesPluginConfigurationLib::MidiEndpointMatchCriteria::PropertyKey,
             matchObject);
 

--- a/src/in-box/Client/WinRT/core/MidiNetworkClientConnectConfig.h
+++ b/src/in-box/Client/WinRT/core/MidiNetworkClientConnectConfig.h
@@ -10,6 +10,7 @@
 #include "Transports.Network.MidiNetworkClientConnectConfig.g.h"
 
 #include "..\..\..\Transport\UdpNetworkMidi2Transport\net2udp_transport_defs.h"
+#include "..\..\..\Transport\UdpNetworkMidi2Transport\network_json_defs.h"
 
 namespace winrt::Windows::Devices::Midi2::Transports::Network::implementation
 {
@@ -35,6 +36,9 @@ namespace winrt::Windows::Devices::Midi2::Transports::Network::implementation
         bool CreateOnlyUmpEndpoints() const noexcept { return m_umpOnly; }
         void CreateOnlyUmpEndpoints(_In_ bool const value) noexcept { m_umpOnly = value; }
 
+        uint8_t FallbackMidi1PortCount() const noexcept { return m_fallbackMidi1PortCount; }
+        void FallbackMidi1PortCount(_In_ uint8_t const value) noexcept { m_fallbackMidi1PortCount = value; }
+
         bool AutoReconnect() const noexcept{ return m_autoReconnect; }
         void AutoReconnect(_In_ bool const value) noexcept { m_autoReconnect = value; }
 
@@ -46,6 +50,7 @@ namespace winrt::Windows::Devices::Midi2::Transports::Network::implementation
         winrt::hstring m_customEndpointName{};
         winrt::guid m_id{};
         bool m_umpOnly{ false };
+        uint8_t m_fallbackMidi1PortCount{ MIDI_NETWORK_MIDI_FALLBACK_MIDI1_PORT_COUNT_DEFAULT };
         bool m_autoReconnect{ true };
         winrt::hstring m_comment{};
 

--- a/src/in-box/Client/WinRT/core/MidiNetworkClientConnectConfig.idl
+++ b/src/in-box/Client/WinRT/core/MidiNetworkClientConnectConfig.idl
@@ -26,6 +26,13 @@ namespace Windows.Devices.Midi2.Transports.Network
 		[noexcept] Guid ClientId;						// GUID  we use in the config file and for subsequent edits/deletes
 		[noexcept] String Comment;						// optional comment that is put into the config file
 		[noexcept] Boolean CreateOnlyUmpEndpoints;	    // todo: this will also need a table of port names
+
+		// A Network MIDI 2.0 device describes itself with function blocks, and the MIDI 1.0 ports
+		// are built from those. A device which never completes discovery declares none, and would
+		// otherwise get no ports at all, so this many source and destination ports are created for
+		// it instead. Ignored when the device does describe itself, and when CreateOnlyUmpEndpoints
+		// is true. Valid values are 1 through 16.
+		[noexcept] UInt8 FallbackMidi1PortCount;
 		//Boolean AutoReconnect;				// true if we reconnect after any disconnects. Otherwise, we connect only once.
 
 

--- a/src/in-box/Client/WinRT/core/MidiNetworkClientUpdateConfig.cpp
+++ b/src/in-box/Client/WinRT/core/MidiNetworkClientUpdateConfig.cpp
@@ -1,0 +1,73 @@
+// Copyright (c) Microsoft Corporation and Contributors.
+// Licensed under the MIT License
+// ============================================================================
+// This is part of the Windows MIDI Services App WinRT API and should be used
+// in your Windows application via an official binary distribution.
+// Further information: https://aka.ms/midi
+// ============================================================================
+
+#include "pch.h"
+#include "MidiNetworkClientUpdateConfig.h"
+#include "Transports.Network.MidiNetworkClientUpdateConfig.g.cpp"
+
+// when this component goes in-box, move the json defs to the common json_defs.h
+#include "..\..\..\Transport\UdpNetworkMidi2Transport\network_json_defs.h"
+
+namespace winrt::Windows::Devices::Midi2::Transports::Network::implementation
+{
+    // The same client entry shape as MidiNetworkClientConnectConfig, under the "update" key. Only
+    // the named properties are touched: the merge into the configuration file cannot delete a key,
+    // so the match criteria and the rest of the entry are left alone.
+    json::JsonObject MidiNetworkClientUpdateConfig::ConfigJson() const noexcept
+    {
+        try
+        {
+            json::JsonObject clientObject{};
+
+            clientObject.SetNamedValue(
+                MIDI_CONFIG_JSON_NETWORK_MIDI_CREATE_MIDI1_PORTS_KEY,
+                json::JsonValue::CreateBooleanValue(CreateMidi1Ports()));
+
+            clientObject.SetNamedValue(
+                MIDI_CONFIG_JSON_NETWORK_MIDI_FALLBACK_MIDI1_PORT_COUNT_KEY,
+                json::JsonValue::CreateNumberValue(FallbackMidi1PortCount()));
+
+            json::JsonObject clientsContainer{};
+            clientsContainer.SetNamedValue(
+                winrt::to_hstring(ClientId()),
+                clientObject);
+
+            // "clients": { ... }
+            json::JsonObject updateObject{};
+            updateObject.SetNamedValue(
+                MIDI_CONFIG_JSON_NETWORK_MIDI_CLIENTS_KEY,
+                clientsContainer);
+
+            // "update": { ... }
+            json::JsonObject transportObject{};
+            transportObject.SetNamedValue(
+                MIDI_CONFIG_JSON_NETWORK_MIDI_UPDATE_ENTRIES_KEY,
+                updateObject);
+
+            // "{C95DCD1F-CDE3-4C2D-913C-528CB8A4CBE6}": { ... }
+            json::JsonObject transportSettingsObject{};
+            transportSettingsObject.SetNamedValue(
+                internal::GuidToString(network::MidiNetworkTransportManager::TransportId()),
+                transportObject);
+
+            // "endpointTransportPluginSettings": { ... }
+            json::JsonObject wrapperObject{};
+            wrapperObject.SetNamedValue(
+                MIDI_CONFIG_JSON_TRANSPORT_PLUGIN_SETTINGS_OBJECT,
+                transportSettingsObject);
+
+            return wrapperObject;
+        }
+        catch (...)
+        {
+            LOG_IF_FAILED(E_FAIL);
+
+            return json::JsonObject{};
+        }
+    }
+}

--- a/src/in-box/Client/WinRT/core/MidiNetworkClientUpdateConfig.h
+++ b/src/in-box/Client/WinRT/core/MidiNetworkClientUpdateConfig.h
@@ -1,0 +1,47 @@
+// Copyright (c) Microsoft Corporation and Contributors.
+// Licensed under the MIT License
+// ============================================================================
+// This is part of the Windows MIDI Services App WinRT API and should be used
+// in your Windows application via an official binary distribution.
+// Further information: https://aka.ms/midi
+// ============================================================================
+
+#pragma once
+#include "Transports.Network.MidiNetworkClientUpdateConfig.g.h"
+
+#include "..\..\..\Transport\UdpNetworkMidi2Transport\net2udp_transport_defs.h"
+#include "..\..\..\Transport\UdpNetworkMidi2Transport\network_json_defs.h"
+
+namespace winrt::Windows::Devices::Midi2::Transports::Network::implementation
+{
+    struct MidiNetworkClientUpdateConfig : MidiNetworkClientUpdateConfigT<MidiNetworkClientUpdateConfig>
+    {
+        MidiNetworkClientUpdateConfig() = default;
+
+        MidiNetworkClientUpdateConfig(_In_ winrt::guid const& clientId) { m_clientId = clientId; }
+
+        winrt::guid TransportId() const noexcept { return internal::StringToGuid(MIDI_NETWORK_TRANSPORT_ID); }
+
+        winrt::guid ClientId() const noexcept { return m_clientId; }
+        void ClientId(_In_ winrt::guid const& value) noexcept { m_clientId = value; }
+
+        bool CreateMidi1Ports() const noexcept { return m_createMidi1Ports; }
+        void CreateMidi1Ports(_In_ bool const value) noexcept { m_createMidi1Ports = value; }
+
+        uint8_t FallbackMidi1PortCount() const noexcept { return m_fallbackMidi1PortCount; }
+        void FallbackMidi1PortCount(_In_ uint8_t const value) noexcept { m_fallbackMidi1PortCount = value; }
+
+        json::JsonObject ConfigJson() const noexcept;
+
+    private:
+        winrt::guid m_clientId{};
+        bool m_createMidi1Ports{ MIDI_NETWORK_MIDI_CREATE_MIDI1_PORTS_DEFAULT };
+        uint8_t m_fallbackMidi1PortCount{ MIDI_NETWORK_MIDI_FALLBACK_MIDI1_PORT_COUNT_DEFAULT };
+    };
+}
+namespace winrt::Windows::Devices::Midi2::Transports::Network::factory_implementation
+{
+    struct MidiNetworkClientUpdateConfig : MidiNetworkClientUpdateConfigT<MidiNetworkClientUpdateConfig, implementation::MidiNetworkClientUpdateConfig>
+    {
+    };
+}

--- a/src/in-box/Client/WinRT/core/MidiNetworkClientUpdateConfig.idl
+++ b/src/in-box/Client/WinRT/core/MidiNetworkClientUpdateConfig.idl
@@ -1,0 +1,41 @@
+// Copyright (c) Microsoft Corporation and Contributors.
+// Licensed under the MIT License
+// ============================================================================
+// This is part of the Windows MIDI Services App WinRT API and should be used
+// in your Windows application via an official binary distribution.
+// Further information: https://aka.ms/midi
+// ============================================================================
+
+#include "..\..\..\Inc\midi_sdk_idl_defs.h"
+import "MidiApiContracts.idl";
+
+
+
+import "IMidiServiceTransportPluginConfig.idl";
+
+namespace Windows.Devices.Midi2.Transports.Network
+{
+    // Changes to an existing client entry, applied without disconnecting it. Send it through
+    // MidiServiceTransportPluginConfigManager.SendUpdate to apply it to the running service, and
+    // SaveUpdate to keep it across restarts.
+    [contract(MidiTransportsNetworkApiContract, 1)]
+    [interface_name("Windows.Devices.Midi2.Transports.Network.IMidiNetworkClientUpdateConfig", UUID_IMidiNetworkClientUpdateConfig)]
+    [constructor_name("Windows.Devices.Midi2.Transports.Network.IMidiNetworkClientUpdateConfigFactory", UUID_IMidiNetworkClientUpdateConfigFactory)]
+    runtimeclass MidiNetworkClientUpdateConfig : Windows.Devices.Midi2.ServiceConfig.IMidiServiceTransportPluginConfig
+    {
+        MidiNetworkClientUpdateConfig();
+        MidiNetworkClientUpdateConfig(Guid clientId);
+
+        [noexcept] Guid ClientId { get; set; };
+
+        // Whether this connection gets MIDI 1.0 ports. Whether an endpoint has MIDI 1.0 ports at
+        // all is decided when the endpoint is created, so this is recorded for the next connection
+        // rather than applied to one already up. Disconnect and reconnect to act on it now.
+        [noexcept] Boolean CreateMidi1Ports;
+
+        // How many MIDI 1.0 source and destination ports to create for a remote host which
+        // declares no function blocks. Applied to an endpoint which is already up. Ignored for a
+        // device which does describe itself, because its function blocks say how many to create.
+        [noexcept] UInt8 FallbackMidi1PortCount;
+    }
+}

--- a/src/in-box/Client/WinRT/core/MidiNetworkHostCreationConfig.cpp
+++ b/src/in-box/Client/WinRT/core/MidiNetworkHostCreationConfig.cpp
@@ -244,9 +244,9 @@ namespace winrt::Windows::Devices::Midi2::Transports::Network::implementation
             // yes, we advertise over mDNS
             config->m_advertise = true;
 
-            // UMP endpoints only by default. A caller which wants the compatibility MIDI 1.0
-            // ports for connected clients sets CreateOnlyUmpEndpoints to false.
-            config->m_umpOnly = true;
+            // MIDI 1.0 ports for connected clients by default, which is what a client entry
+            // already does. A caller which wants UMP only sets CreateOnlyUmpEndpoints to true.
+            config->m_umpOnly = false;
 
             // default to no authentication.
             config->m_authenticationType = network::MidiNetworkAuthenticationType::NoAuthentication;

--- a/src/in-box/Client/WinRT/core/MidiNetworkHostCreationConfig.cpp
+++ b/src/in-box/Client/WinRT/core/MidiNetworkHostCreationConfig.cpp
@@ -247,6 +247,7 @@ namespace winrt::Windows::Devices::Midi2::Transports::Network::implementation
             // MIDI 1.0 ports for connected clients by default, which is what a client entry
             // already does. A caller which wants UMP only sets CreateOnlyUmpEndpoints to true.
             config->m_umpOnly = false;
+            config->m_fallbackMidi1PortCount = MIDI_NETWORK_MIDI_FALLBACK_MIDI1_PORT_COUNT_DEFAULT;
 
             // default to no authentication.
             config->m_authenticationType = network::MidiNetworkAuthenticationType::NoAuthentication;
@@ -311,6 +312,10 @@ namespace winrt::Windows::Devices::Midi2::Transports::Network::implementation
         hostObject.SetNamedValue(
             MIDI_CONFIG_JSON_NETWORK_MIDI_CREATE_MIDI1_PORTS_KEY,
             json::JsonValue::CreateBooleanValue(!CreateOnlyUmpEndpoints()));
+
+        hostObject.SetNamedValue(
+            MIDI_CONFIG_JSON_NETWORK_MIDI_FALLBACK_MIDI1_PORT_COUNT_KEY,
+            json::JsonValue::CreateNumberValue(FallbackMidi1PortCount()));
 
         hostObject.SetNamedValue(
             MIDI_CONFIG_JSON_NETWORK_MIDI_MDNS_ADVERTISE_KEY,

--- a/src/in-box/Client/WinRT/core/MidiNetworkHostCreationConfig.h
+++ b/src/in-box/Client/WinRT/core/MidiNetworkHostCreationConfig.h
@@ -70,7 +70,7 @@ namespace winrt::Windows::Devices::Midi2::Transports::Network::implementation
         winrt::hstring m_name{};
         winrt::hstring m_serviceInstanceName{};
         winrt::hstring m_productInstanceId{};
-        bool m_umpOnly{ true };
+        bool m_umpOnly{ false };
         bool m_useAutomaticPortAllocation{ true };
         bool m_allowPortFallback{ true };
         winrt::hstring m_manuallyAssignedPort{};

--- a/src/in-box/Client/WinRT/core/MidiNetworkHostCreationConfig.h
+++ b/src/in-box/Client/WinRT/core/MidiNetworkHostCreationConfig.h
@@ -10,6 +10,7 @@
 #include "Transports.Network.MidiNetworkHostCreationConfig.g.h"
 
 #include "..\..\..\Transport\UdpNetworkMidi2Transport\net2udp_transport_defs.h"
+#include "..\..\..\Transport\UdpNetworkMidi2Transport\network_json_defs.h"
 
 namespace winrt::Windows::Devices::Midi2::Transports::Network::implementation
 {
@@ -44,6 +45,9 @@ namespace winrt::Windows::Devices::Midi2::Transports::Network::implementation
         bool CreateOnlyUmpEndpoints() const noexcept { return m_umpOnly; }
         void CreateOnlyUmpEndpoints(_In_ bool const value) noexcept { m_umpOnly = value; }
 
+        uint8_t FallbackMidi1PortCount() const noexcept { return m_fallbackMidi1PortCount; }
+        void FallbackMidi1PortCount(_In_ uint8_t const value) noexcept { m_fallbackMidi1PortCount = value; }
+
         bool UseAutomaticPortAllocation() const noexcept { return m_useAutomaticPortAllocation; }
         void UseAutomaticPortAllocation(_In_ bool const value) noexcept { m_useAutomaticPortAllocation = value; }
 
@@ -71,6 +75,7 @@ namespace winrt::Windows::Devices::Midi2::Transports::Network::implementation
         winrt::hstring m_serviceInstanceName{};
         winrt::hstring m_productInstanceId{};
         bool m_umpOnly{ false };
+        uint8_t m_fallbackMidi1PortCount{ MIDI_NETWORK_MIDI_FALLBACK_MIDI1_PORT_COUNT_DEFAULT };
         bool m_useAutomaticPortAllocation{ true };
         bool m_allowPortFallback{ true };
         winrt::hstring m_manuallyAssignedPort{};

--- a/src/in-box/Client/WinRT/core/MidiNetworkHostCreationConfig.idl
+++ b/src/in-box/Client/WinRT/core/MidiNetworkHostCreationConfig.idl
@@ -47,6 +47,13 @@ namespace Windows.Devices.Midi2.Transports.Network
 
         [noexcept] Boolean CreateOnlyUmpEndpoints;
 
+        // A remote client is described by the function blocks it declares, and the MIDI 1.0 ports
+        // for it are built from those. A client which never completes discovery declares none, and
+        // would otherwise get no ports at all, so this many source and destination ports are
+        // created for it instead. Ignored when the client does describe itself, and when
+        // CreateOnlyUmpEndpoints is true. Valid values are 1 through 16.
+        [noexcept] UInt8 FallbackMidi1PortCount;
+
         [noexcept] Boolean UseAutomaticPortAllocation;
         [noexcept] String ManuallyAssignedPort;
 

--- a/src/in-box/Client/WinRT/core/MidiNetworkHostUpdateConfig.cpp
+++ b/src/in-box/Client/WinRT/core/MidiNetworkHostUpdateConfig.cpp
@@ -1,0 +1,73 @@
+// Copyright (c) Microsoft Corporation and Contributors.
+// Licensed under the MIT License
+// ============================================================================
+// This is part of the Windows MIDI Services App WinRT API and should be used
+// in your Windows application via an official binary distribution.
+// Further information: https://aka.ms/midi
+// ============================================================================
+
+#include "pch.h"
+#include "MidiNetworkHostUpdateConfig.h"
+#include "Transports.Network.MidiNetworkHostUpdateConfig.g.cpp"
+
+// when this component goes in-box, move the json defs to the common json_defs.h
+#include "..\..\..\Transport\UdpNetworkMidi2Transport\network_json_defs.h"
+
+namespace winrt::Windows::Devices::Midi2::Transports::Network::implementation
+{
+    // The same host entry shape as MidiNetworkHostCreationConfig, under the "update" key. Only the
+    // named properties are touched: the merge into the configuration file cannot delete a key, so
+    // the rest of the entry, including the port and the service instance name, is left alone.
+    json::JsonObject MidiNetworkHostUpdateConfig::ConfigJson() const noexcept
+    {
+        try
+        {
+            json::JsonObject hostObject{};
+
+            hostObject.SetNamedValue(
+                MIDI_CONFIG_JSON_NETWORK_MIDI_CREATE_MIDI1_PORTS_KEY,
+                json::JsonValue::CreateBooleanValue(CreateMidi1Ports()));
+
+            hostObject.SetNamedValue(
+                MIDI_CONFIG_JSON_NETWORK_MIDI_FALLBACK_MIDI1_PORT_COUNT_KEY,
+                json::JsonValue::CreateNumberValue(FallbackMidi1PortCount()));
+
+            json::JsonObject hostsContainer{};
+            hostsContainer.SetNamedValue(
+                winrt::to_hstring(HostId()),
+                hostObject);
+
+            // "hosts": { ... }
+            json::JsonObject updateObject{};
+            updateObject.SetNamedValue(
+                MIDI_CONFIG_JSON_NETWORK_MIDI_HOSTS_KEY,
+                hostsContainer);
+
+            // "update": { ... }
+            json::JsonObject transportObject{};
+            transportObject.SetNamedValue(
+                MIDI_CONFIG_JSON_NETWORK_MIDI_UPDATE_ENTRIES_KEY,
+                updateObject);
+
+            // "{C95DCD1F-CDE3-4C2D-913C-528CB8A4CBE6}": { ... }
+            json::JsonObject transportSettingsObject{};
+            transportSettingsObject.SetNamedValue(
+                internal::GuidToString(network::MidiNetworkTransportManager::TransportId()),
+                transportObject);
+
+            // "endpointTransportPluginSettings": { ... }
+            json::JsonObject wrapperObject{};
+            wrapperObject.SetNamedValue(
+                MIDI_CONFIG_JSON_TRANSPORT_PLUGIN_SETTINGS_OBJECT,
+                transportSettingsObject);
+
+            return wrapperObject;
+        }
+        catch (...)
+        {
+            LOG_IF_FAILED(E_FAIL);
+
+            return json::JsonObject{};
+        }
+    }
+}

--- a/src/in-box/Client/WinRT/core/MidiNetworkHostUpdateConfig.h
+++ b/src/in-box/Client/WinRT/core/MidiNetworkHostUpdateConfig.h
@@ -1,0 +1,47 @@
+// Copyright (c) Microsoft Corporation and Contributors.
+// Licensed under the MIT License
+// ============================================================================
+// This is part of the Windows MIDI Services App WinRT API and should be used
+// in your Windows application via an official binary distribution.
+// Further information: https://aka.ms/midi
+// ============================================================================
+
+#pragma once
+#include "Transports.Network.MidiNetworkHostUpdateConfig.g.h"
+
+#include "..\..\..\Transport\UdpNetworkMidi2Transport\net2udp_transport_defs.h"
+#include "..\..\..\Transport\UdpNetworkMidi2Transport\network_json_defs.h"
+
+namespace winrt::Windows::Devices::Midi2::Transports::Network::implementation
+{
+    struct MidiNetworkHostUpdateConfig : MidiNetworkHostUpdateConfigT<MidiNetworkHostUpdateConfig>
+    {
+        MidiNetworkHostUpdateConfig() = default;
+
+        MidiNetworkHostUpdateConfig(_In_ winrt::guid const& hostId) { m_hostId = hostId; }
+
+        winrt::guid TransportId() const noexcept { return internal::StringToGuid(MIDI_NETWORK_TRANSPORT_ID); }
+
+        winrt::guid HostId() const noexcept { return m_hostId; }
+        void HostId(_In_ winrt::guid const& value) noexcept { m_hostId = value; }
+
+        bool CreateMidi1Ports() const noexcept { return m_createMidi1Ports; }
+        void CreateMidi1Ports(_In_ bool const value) noexcept { m_createMidi1Ports = value; }
+
+        uint8_t FallbackMidi1PortCount() const noexcept { return m_fallbackMidi1PortCount; }
+        void FallbackMidi1PortCount(_In_ uint8_t const value) noexcept { m_fallbackMidi1PortCount = value; }
+
+        json::JsonObject ConfigJson() const noexcept;
+
+    private:
+        winrt::guid m_hostId{};
+        bool m_createMidi1Ports{ MIDI_NETWORK_MIDI_CREATE_MIDI1_PORTS_DEFAULT };
+        uint8_t m_fallbackMidi1PortCount{ MIDI_NETWORK_MIDI_FALLBACK_MIDI1_PORT_COUNT_DEFAULT };
+    };
+}
+namespace winrt::Windows::Devices::Midi2::Transports::Network::factory_implementation
+{
+    struct MidiNetworkHostUpdateConfig : MidiNetworkHostUpdateConfigT<MidiNetworkHostUpdateConfig, implementation::MidiNetworkHostUpdateConfig>
+    {
+    };
+}

--- a/src/in-box/Client/WinRT/core/MidiNetworkHostUpdateConfig.idl
+++ b/src/in-box/Client/WinRT/core/MidiNetworkHostUpdateConfig.idl
@@ -1,0 +1,41 @@
+// Copyright (c) Microsoft Corporation and Contributors.
+// Licensed under the MIT License
+// ============================================================================
+// This is part of the Windows MIDI Services App WinRT API and should be used
+// in your Windows application via an official binary distribution.
+// Further information: https://aka.ms/midi
+// ============================================================================
+
+#include "..\..\..\Inc\midi_sdk_idl_defs.h"
+import "MidiApiContracts.idl";
+
+
+
+import "IMidiServiceTransportPluginConfig.idl";
+
+namespace Windows.Devices.Midi2.Transports.Network
+{
+    // Changes to an existing host entry, applied without taking the host down. Send it through
+    // MidiServiceTransportPluginConfigManager.SendUpdate to apply it to the running service, and
+    // SaveUpdate to keep it across restarts.
+    [contract(MidiTransportsNetworkApiContract, 1)]
+    [interface_name("Windows.Devices.Midi2.Transports.Network.IMidiNetworkHostUpdateConfig", UUID_IMidiNetworkHostUpdateConfig)]
+    [constructor_name("Windows.Devices.Midi2.Transports.Network.IMidiNetworkHostUpdateConfigFactory", UUID_IMidiNetworkHostUpdateConfigFactory)]
+    runtimeclass MidiNetworkHostUpdateConfig : Windows.Devices.Midi2.ServiceConfig.IMidiServiceTransportPluginConfig
+    {
+        MidiNetworkHostUpdateConfig();
+        MidiNetworkHostUpdateConfig(Guid hostId);
+
+        [noexcept] Guid HostId { get; set; };
+
+        // Whether a remote client connecting to this host gets MIDI 1.0 ports. Whether an endpoint
+        // has MIDI 1.0 ports at all is decided when the endpoint is created, so this is recorded
+        // for the next connection rather than applied to the ones already up.
+        [noexcept] Boolean CreateMidi1Ports;
+
+        // How many MIDI 1.0 source and destination ports to create for a remote client which
+        // declares no function blocks. Applied to endpoints which are already up. Ignored for a
+        // client which does describe itself, because its function blocks say how many to create.
+        [noexcept] UInt8 FallbackMidi1PortCount;
+    }
+}

--- a/src/in-box/Client/WinRT/core/Windows.Devices.Midi2.vcxproj
+++ b/src/in-box/Client/WinRT/core/Windows.Devices.Midi2.vcxproj
@@ -670,6 +670,12 @@
     <ClInclude Include="MidiNetworkHostCreationConfig.h">
       <DependentUpon>MidiNetworkHostCreationConfig.idl</DependentUpon>
     </ClInclude>
+    <ClInclude Include="MidiNetworkHostUpdateConfig.h">
+      <DependentUpon>MidiNetworkHostUpdateConfig.idl</DependentUpon>
+    </ClInclude>
+    <ClInclude Include="MidiNetworkClientUpdateConfig.h">
+      <DependentUpon>MidiNetworkClientUpdateConfig.idl</DependentUpon>
+    </ClInclude>
     <ClInclude Include="MidiNetworkHostRemovalConfig.h">
       <DependentUpon>MidiNetworkHostRemovalConfig.idl</DependentUpon>
     </ClInclude>
@@ -1045,6 +1051,12 @@
     <ClCompile Include="MidiNetworkHostCreationConfig.cpp">
       <DependentUpon>MidiNetworkHostCreationConfig.idl</DependentUpon>
     </ClCompile>
+    <ClCompile Include="MidiNetworkHostUpdateConfig.cpp">
+      <DependentUpon>MidiNetworkHostUpdateConfig.idl</DependentUpon>
+    </ClCompile>
+    <ClCompile Include="MidiNetworkClientUpdateConfig.cpp">
+      <DependentUpon>MidiNetworkClientUpdateConfig.idl</DependentUpon>
+    </ClCompile>
     <ClCompile Include="MidiNetworkHostRemovalConfig.cpp">
       <DependentUpon>MidiNetworkHostRemovalConfig.idl</DependentUpon>
     </ClCompile>
@@ -1256,6 +1268,8 @@
     <Midl Include="MidiNetworkHostCreationConfig.idl" />
     <Midl Include="MidiNetworkHostCreationResponse.idl" />
     <Midl Include="MidiNetworkHostRemovalConfig.idl" />
+    <Midl Include="MidiNetworkHostUpdateConfig.idl" />
+    <Midl Include="MidiNetworkClientUpdateConfig.idl" />
     <Midl Include="MidiNetworkHostRemovalResponse.idl" />
   </ItemGroup>
   <ItemGroup>

--- a/src/in-box/Inc/MidiDefs.h
+++ b/src/in-box/Inc/MidiDefs.h
@@ -706,8 +706,9 @@ DEFINE_MIDIDEVPROPKEY(PKEY_MIDI_NetworkMidiConnectionRole, 923);        // DEVPR
 // MIDI 1.0 Port Naming Properties  ==========================================================
 // Starts at 950
 
-#define STRING_PKEY_MIDI_CreateMidi1PortsForEndpoint MIDI_STRING_PKEY_GUID MIDI_STRING_PKEY_PID_SEPARATOR L"950"
-DEFINE_MIDIDEVPROPKEY(PKEY_MIDI_CreateMidi1PortsForEndpoint, 950);     // DEVPROP_TYPE_BOOLEAN
+// Removed because this was never actually written to, but was being read by clients getting incorrect data
+//#define STRING_PKEY_MIDI_CreateMidi1PortsForEndpoint MIDI_STRING_PKEY_GUID MIDI_STRING_PKEY_PID_SEPARATOR L"950"
+//DEFINE_MIDIDEVPROPKEY(PKEY_MIDI_CreateMidi1PortsForEndpoint, 950);     // DEVPROP_TYPE_BOOLEAN
 
 // this is set at the parent endpoint level, and applies to all WinMM and WinRT MIDI 1.0 ports created from this endpoint
 #define STRING_PKEY_MIDI_Midi1PortNamingSelection MIDI_STRING_PKEY_GUID MIDI_STRING_PKEY_PID_SEPARATOR L"955"

--- a/src/in-box/Inc/midi_sdk_idl_defs.h
+++ b/src/in-box/Inc/midi_sdk_idl_defs.h
@@ -327,6 +327,12 @@
 #define UUID_IMidiNetworkTransportSettingsStatics               8087b303-0519-c0de-31d1-ee00F0319000
 //#define UUID_IMidiNetworkTransportSettingsFactory               8087b303-0519-c0de-31d1-ff00F0319000
 
+#define UUID_IMidiNetworkHostUpdateConfig                       8087b303-0519-c0de-31d1-dd00F031A000
+#define UUID_IMidiNetworkHostUpdateConfigFactory                8087b303-0519-c0de-31d1-ff00F031A000
+
+#define UUID_IMidiNetworkClientUpdateConfig                     8087b303-0519-c0de-31d1-dd00F031B000
+#define UUID_IMidiNetworkClientUpdateConfigFactory              8087b303-0519-c0de-31d1-ff00F031B000
+
 // ============================================================================
 // Windows.Devices.Midi2.Transports.Virtual : Interface number 00F04
 

--- a/src/in-box/Libs/MidiEndpointNamingLib/MidiEndpointNameTable.cpp
+++ b/src/in-box/Libs/MidiEndpointNamingLib/MidiEndpointNameTable.cpp
@@ -31,6 +31,7 @@
 #include "MidiEndpointNameTable.h"
 
 #include "Feature_Servicing_MIDIPortDisambiguators.h"
+#include "Feature_Servicing_MIDI2UnicodeConversion.h"
 
 namespace WindowsMidiServicesNamingLib
 {
@@ -302,6 +303,42 @@ std::wstring GenerateLegacyMidi1PortName(
 
     if (portIndexWithinThisFilterAndDirection > 0)
     {
+        if (Feature_Servicing_MIDI2UnicodeConversion::IsEnabled())
+        {
+            // Formatting narrow and then widening a byte at a time turned each non-ASCII
+            // character into its separate UTF-8 bytes, so a name like "Pete\u2019s MacBook Pro"
+            // came out with three garbage characters. Staying wide has no conversion to get
+            // wrong. Truncation is by character for the same reason.
+            std::wstring formatted{ };
+
+            if (flowFromUserPerspective == MidiFlow::MidiFlowIn)
+            {
+                formatted = std::format(L"MIDIIN{} ({})", portIndexWithinThisFilterAndDirection + 1, generatedName);
+            }
+            else if (flowFromUserPerspective == MidiFlow::MidiFlowOut)
+            {
+                formatted = std::format(L"MIDIOUT{} ({})", portIndexWithinThisFilterAndDirection + 1, generatedName);
+            }
+            else
+            {
+                // unexpected
+                return generatedName;
+            }
+
+            if (formatted.length() > MAXPNAMELEN - 1)
+            {
+                formatted.resize(MAXPNAMELEN - 1);
+
+                // never leave a lead surrogate without its trail
+                if (!formatted.empty() && IS_HIGH_SURROGATE(formatted.back()))
+                {
+                    formatted.pop_back();
+                }
+            }
+
+            return WindowsMidiServicesInternal::TrimmedWStringCopy(formatted);
+        }
+
         // switching back and forth between wstring and string here is probably not a great idea, but the original
         // values from USB should all be narrow standard strings anyway.
         if (flowFromUserPerspective == MidiFlow::MidiFlowIn)

--- a/src/in-box/Test/Midi2.SharedIncludes.unittests/NamingTests.cpp
+++ b/src/in-box/Test/Midi2.SharedIncludes.unittests/NamingTests.cpp
@@ -188,7 +188,6 @@ void NamingTests::TestPopulateEntryForNativeUmpDevice()
 void NamingTests::TestPopulateEntryForMidi1DeviceUsingUmpDriver()
 {
     MidiEndpointNameTable table;
-
     uint8_t portIndexSource{ 0 };
     uint8_t portIndexDestination{ 0 };
 
@@ -295,6 +294,42 @@ void NamingTests::TestPopulateEntryForMidi1DeviceUsingUmpDriver()
 
 
 
+}
+
+
+// A name with a character outside ASCII used to be formatted through a narrow string and widened
+// one byte at a time, so "Pete\u2019s MacBook Pro" reached WinMM as its UTF-8 bytes. Only the
+// ports after the first were affected, because only those get the MIDIIN/MIDIOUT prefix.
+void NamingTests::TestLegacyNameKeepsNonAsciiCharacters()
+{
+    MidiEndpointNameTable table;
+
+    std::wstring const deviceName{ L"Pete\u2019s Mac" };
+
+    for (uint8_t groupIndex = 0; groupIndex < 3; groupIndex++)
+    {
+        VERIFY_SUCCEEDED(table.PopulateEntryForNativeUmpDevice(
+            groupIndex, MidiFlow::MidiFlowIn, L"", deviceName, deviceName, L"MIDI", groupIndex));
+
+        VERIFY_SUCCEEDED(table.PopulateEntryForNativeUmpDevice(
+            groupIndex, MidiFlow::MidiFlowOut, L"", deviceName, deviceName, L"MIDI", groupIndex));
+    }
+
+    // the first port carries the name alone, and never went through the conversion
+    VERIFY_ARE_EQUAL(table.GetSourceEntry(0)->LegacyWinMMName, deviceName);
+    VERIFY_ARE_EQUAL(table.GetDestinationEntry(0)->LegacyWinMMName, deviceName);
+
+    VERIFY_ARE_EQUAL(table.GetSourceEntry(1)->LegacyWinMMName, L"MIDIIN2 (" + deviceName + L")");
+    VERIFY_ARE_EQUAL(table.GetSourceEntry(2)->LegacyWinMMName, L"MIDIIN3 (" + deviceName + L")");
+
+    VERIFY_ARE_EQUAL(table.GetDestinationEntry(1)->LegacyWinMMName, L"MIDIOUT2 (" + deviceName + L")");
+    VERIFY_ARE_EQUAL(table.GetDestinationEntry(2)->LegacyWinMMName, L"MIDIOUT3 (" + deviceName + L")");
+
+    // the byte-at-a-time widening turned one character into three, so the length catches the
+    // regression even somewhere the difference cannot be seen
+    size_t const expectedLength = deviceName.length() + wcslen(L"MIDIIN2 ()");
+
+    VERIFY_ARE_EQUAL(wcslen(table.GetSourceEntry(1)->LegacyWinMMName), expectedLength);
 }
 
 void NamingTests::TestPopulateEntryForMidi1DeviceUsingMidi1Driver()

--- a/src/in-box/Test/Midi2.SharedIncludes.unittests/NamingTests.h
+++ b/src/in-box/Test/Midi2.SharedIncludes.unittests/NamingTests.h
@@ -56,6 +56,8 @@ public:
 
     TEST_METHOD(TestValidateMidi1DriverAndMidi2DriverCreateCompatibleLegacyNames);
 
+    TEST_METHOD(TestLegacyNameKeepsNonAsciiCharacters);
+
     TEST_METHOD(TestGitHubIssue652);
     TEST_METHOD(TestGitHubIssue616);
 

--- a/src/in-box/Test/Midi2.Transport.NetworkMidi2.unittests/Midi2.Transport.NetworkMidi2.unittests.vcxproj
+++ b/src/in-box/Test/Midi2.Transport.NetworkMidi2.unittests/Midi2.Transport.NetworkMidi2.unittests.vcxproj
@@ -175,6 +175,7 @@
     <ClInclude Include="NetworkMidiApprovalTests.h" />
     <ClInclude Include="NetworkMidiTransportSettingsTests.h" />
     <ClInclude Include="NetworkMidiClientTests.h" />
+    <ClInclude Include="NetworkMidiPortCreationTests.h" />
     <ClInclude Include="NetworkMidiErrorTests.h" />
     <ClInclude Include="NetworkMidiMalformedTests.h" />
     <ClInclude Include="NetworkMidiSessionTests.h" />
@@ -194,6 +195,7 @@
     <ClCompile Include="NetworkMidiApprovalTests.cpp" />
     <ClCompile Include="NetworkMidiTransportSettingsTests.cpp" />
     <ClCompile Include="NetworkMidiClientTests.cpp" />
+    <ClCompile Include="NetworkMidiPortCreationTests.cpp" />
     <ClCompile Include="NetworkMidiErrorTests.cpp" />
     <ClCompile Include="NetworkMidiMalformedTests.cpp" />
     <ClCompile Include="NetworkMidiSessionTests.cpp" />

--- a/src/in-box/Test/Midi2.Transport.NetworkMidi2.unittests/NetworkMidiApprovalTests.cpp
+++ b/src/in-box/Test/Midi2.Transport.NetworkMidi2.unittests/NetworkMidiApprovalTests.cpp
@@ -58,9 +58,12 @@ namespace
     }
 
 
+    // These names come back from the service as UTF-8. Copying byte by byte would turn each
+    // non-ASCII character into several garbage ones, and a test comparing one mangled string to
+    // another would still pass.
     std::wstring Widen(_In_ std::string const& value)
     {
-        return std::wstring(value.begin(), value.end());
+        return std::wstring{ winrt::to_hstring(value) };
     }
 
 

--- a/src/in-box/Test/Midi2.Transport.NetworkMidi2.unittests/NetworkMidiClientTests.cpp
+++ b/src/in-box/Test/Midi2.Transport.NetworkMidi2.unittests/NetworkMidiClientTests.cpp
@@ -378,7 +378,8 @@ namespace NetworkMidiTest
 
         size_t CountLiveEndpointsNamed(_In_ std::string const& endpointName)
         {
-            return CountLiveEndpointsNamedWide(std::wstring(endpointName.begin(), endpointName.end()));
+            // UTF-8 in, so a byte-per-character copy would look for a name no endpoint has
+            return CountLiveEndpointsNamedWide(std::wstring{ winrt::to_hstring(endpointName) });
         }
     }
 
@@ -1396,7 +1397,7 @@ namespace NetworkMidiTest
                 FakeNetworkHost::Address(),
                 host.Port(),
                 L"Test Client",
-                std::wstring(customName.begin(), customName.end())).IsSuccess());
+                std::wstring{ winrt::to_hstring(customName) }).IsSuccess());
 
         // Wait for the session, which is what triggers endpoint creation.
         VERIFY_IS_TRUE(host.WaitForCommand(CommandCode::Invitation, InvitationTimeout).has_value());
@@ -1492,7 +1493,7 @@ namespace NetworkMidiTest
                 FakeNetworkHost::Address(),
                 host.Port(),
                 false,
-                std::wstring(customName.begin(), customName.end())).CallSucceeded);
+                std::wstring{ winrt::to_hstring(customName) }).CallSucceeded);
 
         VERIFY_IS_TRUE(host.WaitForCommand(CommandCode::Invitation, InvitationTimeout).has_value());
         VERIFY_IS_TRUE(host.WaitForCommand(CommandCode::UmpData, SessionTimeout).has_value());

--- a/src/in-box/Test/Midi2.Transport.NetworkMidi2.unittests/NetworkMidiPortCreationTests.cpp
+++ b/src/in-box/Test/Midi2.Transport.NetworkMidi2.unittests/NetworkMidiPortCreationTests.cpp
@@ -284,8 +284,56 @@ namespace NetworkMidiTest
             return counts;
         }
 
-        json::JsonObject ParseResponse(_In_ std::wstring const& responseJson)
+        // Polls until no port carries the text any more. The name it reverts to is truncated to
+        // the WinMM limit, so absence of the withdrawn one is the assertion that holds.
+        std::vector<std::wstring> WaitForMidi1PortNamesWithout(
+            _In_ std::wstring const& endpointDeviceId,
+            _In_ std::wstring const& unwanted,
+            _In_ std::chrono::milliseconds const timeout)
         {
+            auto const deadline = std::chrono::steady_clock::now() + timeout;
+
+            std::vector<std::wstring> names{ };
+
+            while (std::chrono::steady_clock::now() < deadline)
+            {
+                names = CollectPortNamesWithSelector(Midi1SourceSelector, endpointDeviceId);
+
+                if (!names.empty() && !AllNamesContain(names, unwanted))
+                {
+                    return names;
+                }
+
+                std::this_thread::sleep_for(PollInterval);
+            }
+
+            return names;
+        }
+
+        size_t WaitForEndpointDiscoveryRequest(
+            _In_ FakeNetworkHost& host,
+            _In_ std::chrono::milliseconds const timeout)
+        {
+            auto const deadline = std::chrono::steady_clock::now() + timeout;
+
+            size_t count{ 0 };
+
+            while (std::chrono::steady_clock::now() < deadline)
+            {
+                count = host.EndpointDiscoveryRequestCount();
+
+                if (count > 0)
+                {
+                    return count;
+                }
+
+                std::this_thread::sleep_for(PollInterval);
+            }
+
+            return count;
+        }
+
+        json::JsonObject ParseResponse(_In_ std::wstring const& responseJson)        {
             json::JsonObject parsed{ nullptr };
 
             if (!json::JsonObject::TryParse(winrt::hstring{ responseJson }, parsed))
@@ -676,8 +724,10 @@ namespace NetworkMidiTest
 
         Log::Comment(String().Format(L"Endpoint: %s", endpointDeviceId.c_str()));
 
+        // The endpoint appears as soon as the session is up. Discovery is a separate exchange on
+        // a background thread, so this has to be waited for rather than sampled.
         VERIFY_IS_GREATER_THAN(
-            remote.Host().EndpointDiscoveryRequestCount(), static_cast<size_t>(0),
+            WaitForEndpointDiscoveryRequest(remote.Host(), PortCreationTimeout), static_cast<size_t>(0),
             L"The service never asked the remote host to describe itself.");
 
         auto const counts = WaitForMidi1Ports(endpointDeviceId, GroupCount, PortCreationTimeout);
@@ -909,6 +959,66 @@ namespace NetworkMidiTest
         VERIFY_IS_TRUE(
             AllNamesContain(namesAfter, customName),
             L"Changing the port count reverted the ports to the name the remote supplied.");
+    }
+
+
+    void PortCreationTests::RemovingACustomizationRevertsTheMidi1PortNames()
+    {
+        if (!RequireService()) return;
+
+        RemoteHostUnderTest remote;
+
+        auto const hostName = ProtocolTestContext::Current().MakeUniqueEndpointName("Revert");
+
+        VERIFY_IS_TRUE(remote.Start(0, true, hostName));
+
+        VERIFY_IS_TRUE(
+            remote.Host().WaitForCommand(CommandCode::Invitation, SessionTimeout).has_value(),
+            L"The service never invited the remote host.");
+
+        auto endpointDeviceId = WaitForClientEndpointDeviceId(remote.EntryIdentifier());
+
+        VERIFY_IS_FALSE(endpointDeviceId.empty(), L"The service never reported an endpoint for this client.");
+
+        if (endpointDeviceId.empty()) return;
+
+        VERIFY_ARE_EQUAL(
+            static_cast<uint32_t>(1),
+            WaitForMidi1Ports(endpointDeviceId, 1, PortCreationTimeout).Sources,
+            L"One source to start with.");
+
+        std::wstring const customName{ L"Name To Be Withdrawn" };
+
+        VERIFY_IS_TRUE(
+            RenameEndpoint(endpointDeviceId, customName).IsSuccess(),
+            L"The rename was refused.");
+
+        VERIFY_IS_TRUE(
+            AllNamesContain(WaitForMidi1PortNames(endpointDeviceId, customName, PortCreationTimeout), customName),
+            L"The rename did not reach the ports, so this test cannot say anything about removing it.");
+
+        VERIFY_IS_TRUE(
+            RemoveEndpointCustomization(endpointDeviceId).IsSuccess(),
+            L"The removal was refused.");
+
+        // The remote's own name, which the endpoint manager still has on record
+        auto const reverted = WaitForMidi1PortNamesWithout(endpointDeviceId, customName, PortCreationTimeout);
+
+        for (auto const& name : reverted)
+        {
+            Log::Comment(String().Format(L"After removal: %s", name.c_str()));
+        }
+
+        Log::Comment(String().Format(
+            L"Custom name property after removal: '%s'", ReadCustomEndpointName(endpointDeviceId).c_str()));
+
+        VERIFY_IS_TRUE(
+            ReadCustomEndpointName(endpointDeviceId).empty(),
+            L"The custom name property was not cleared.");
+
+        VERIFY_IS_FALSE(
+            AllNamesContain(reverted, customName),
+            L"The ports kept the withdrawn name.");
     }
 
 

--- a/src/in-box/Test/Midi2.Transport.NetworkMidi2.unittests/NetworkMidiPortCreationTests.cpp
+++ b/src/in-box/Test/Midi2.Transport.NetworkMidi2.unittests/NetworkMidiPortCreationTests.cpp
@@ -1,0 +1,663 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License
+// ============================================================================
+// This is part of the Windows MIDI Services App API and should be used
+// in your Windows application via an official binary distribution.
+// Further information: https://github.com/microsoft/MIDI/
+// ============================================================================
+
+#include "pch.h"
+
+using namespace WEX::Logging;
+using namespace WEX::Common;
+
+namespace enumeration = winrt::Windows::Devices::Enumeration;
+namespace json = winrt::Windows::Data::Json;
+
+namespace NetworkMidiTest
+{
+    namespace
+    {
+        bool g_serviceAvailable{ false };
+
+        // The service creates the endpoint, negotiates, and only then builds the ports, and each
+        // step is on its own thread. Ten seconds is the discovery timeout, so this has to be
+        // comfortably longer for the negative cases which deliberately wait it out.
+        constexpr auto PortCreationTimeout = std::chrono::milliseconds(25000);
+        constexpr auto EndpointCreationTimeout = std::chrono::milliseconds(20000);
+        constexpr auto SessionTimeout = std::chrono::milliseconds(10000);
+        constexpr auto PollInterval = std::chrono::milliseconds(250);
+
+        // Both directions of MIDI 1.0 port, keyed the way a user sees them rather than the way a
+        // block declares them.
+        struct Midi1PortCounts
+        {
+            uint32_t Sources{ 0 };          // MIDI In to the user
+            uint32_t Destinations{ 0 };     // MIDI Out to the user
+
+            uint32_t Total() const { return Sources + Destinations; }
+        };
+
+        // Device interface classes for the MIDI 1.0 ports the service publishes. Restated here
+        // rather than included, so a test failure says the service changed rather than silently
+        // following it.
+        constexpr wchar_t Midi1SourceSelector[] =
+            L"System.Devices.InterfaceClassGuid:=\"{504BE32C-CCF6-4D2C-B73F-6F8B3747E22B}\"";
+        constexpr wchar_t Midi1DestinationSelector[] =
+            L"System.Devices.InterfaceClassGuid:=\"{6DC23320-AB33-4CE4-80D4-BBB3EBBF2814}\"";
+
+        // PKEY_MIDI_AssociatedUMP, property 52. Restated for the same reason.
+        constexpr wchar_t AssociatedUmpProperty[] = L"{3F114A6A-11FA-4BD0-9D2C-6B7780CD80AD} 52";
+
+        std::wstring NormalizeEndpointId(_In_ std::wstring const& value)
+        {
+            std::wstring result{ value };
+
+            for (auto& character : result)
+            {
+                character = static_cast<wchar_t>(towlower(character));
+            }
+
+            // The service is inconsistent about the trailing separator, and the property is
+            // written from a different string than the one enumeration reports.
+            while (!result.empty() && (result.back() == L'#' || result.back() == L'\\'))
+            {
+                result.pop_back();
+            }
+
+            return result;
+        }
+
+        // MIDI 1.0 ports carry the id of the UMP endpoint they belong to, which is the only way
+        // to tell this test's ports apart from every other endpoint on the machine.
+        uint32_t CountPortsWithSelector(
+            _In_ std::wstring const& selector,
+            _In_ std::wstring const& endpointDeviceId)
+        {
+            uint32_t count{ 0 };
+
+            try
+            {
+                auto properties = winrt::single_threaded_vector<winrt::hstring>();
+                properties.Append(winrt::hstring{ AssociatedUmpProperty });
+
+                auto devices = enumeration::DeviceInformation::FindAllAsync(
+                    winrt::hstring{ selector },
+                    properties,
+                    enumeration::DeviceInformationKind::DeviceInterface).get();
+
+                auto const wanted = NormalizeEndpointId(endpointDeviceId);
+
+                for (auto const& device : devices)
+                {
+                    auto value = device.Properties().TryLookup(winrt::hstring{ AssociatedUmpProperty });
+
+                    if (value == nullptr) continue;
+
+                    auto const associated = NormalizeEndpointId(
+                        std::wstring{ winrt::unbox_value_or<winrt::hstring>(value, L"") });
+
+                    if (!associated.empty() && associated == wanted)
+                    {
+                        count++;
+                    }
+                }
+            }
+            catch (...)
+            {
+                // Treated as zero. The caller is polling, so a transient enumeration failure just
+                // costs one attempt rather than the test.
+            }
+
+            return count;
+        }
+
+        Midi1PortCounts CountMidi1Ports(_In_ std::wstring const& endpointDeviceId)
+        {
+            Midi1PortCounts counts{ };
+
+            counts.Sources = CountPortsWithSelector(Midi1SourceSelector, endpointDeviceId);
+            counts.Destinations = CountPortsWithSelector(Midi1DestinationSelector, endpointDeviceId);
+
+            return counts;
+        }
+
+        // Polls until both directions reach the expected count. Returns whatever it last saw, so
+        // the caller can report the shortfall rather than just "timed out".
+        Midi1PortCounts WaitForMidi1Ports(
+            _In_ std::wstring const& endpointDeviceId,
+            _In_ uint32_t const expectedEachDirection,
+            _In_ std::chrono::milliseconds const timeout)
+        {
+            auto const deadline = std::chrono::steady_clock::now() + timeout;
+
+            Midi1PortCounts counts{ };
+
+            while (std::chrono::steady_clock::now() < deadline)
+            {
+                counts = CountMidi1Ports(endpointDeviceId);
+
+                if (counts.Sources >= expectedEachDirection && counts.Destinations >= expectedEachDirection)
+                {
+                    return counts;
+                }
+
+                std::this_thread::sleep_for(PollInterval);
+            }
+
+            return counts;
+        }
+
+        json::JsonObject ParseResponse(_In_ std::wstring const& responseJson)
+        {
+            json::JsonObject parsed{ nullptr };
+
+            if (!json::JsonObject::TryParse(winrt::hstring{ responseJson }, parsed))
+            {
+                return nullptr;
+            }
+
+            return parsed;
+        }
+
+        // Walks the enumerateClients response for the entry this test created and returns the
+        // endpoint the service built for it. Empty until the endpoint exists.
+        std::wstring FindClientEndpointDeviceId(_In_ std::wstring const& entryIdentifier)
+        {
+            auto result = EnumerateClients();
+
+            if (!result.IsSuccess()) return {};
+
+            auto parsed = ParseResponse(result.ResponseJson);
+
+            if (parsed == nullptr) return {};
+
+            try
+            {
+                auto clients = parsed.GetNamedArray(L"clients", nullptr);
+
+                if (clients == nullptr) return {};
+
+                auto const wantedEntry = NormalizeEndpointId(entryIdentifier);
+
+                for (auto const& entry : clients)
+                {
+                    auto client = entry.GetObject();
+
+                    if (NormalizeEndpointId(std::wstring{ client.GetNamedString(L"entryIdentifier", L"") }) != wantedEntry)
+                    {
+                        continue;
+                    }
+
+                    return std::wstring{ client.GetNamedString(L"endpointDeviceId", L"") };
+                }
+            }
+            catch (...)
+            {
+            }
+
+            return {};
+        }
+
+        // Same for the host side, where the endpoint belongs to a connection rather than the
+        // host entry itself.
+        std::wstring FindHostConnectionEndpointDeviceId(_In_ std::wstring const& entryIdentifier)
+        {
+            auto result = EnumerateHosts();
+
+            if (!result.IsSuccess()) return {};
+
+            auto parsed = ParseResponse(result.ResponseJson);
+
+            if (parsed == nullptr) return {};
+
+            try
+            {
+                auto hosts = parsed.GetNamedArray(L"hosts", nullptr);
+
+                if (hosts == nullptr) return {};
+
+                auto const wantedEntry = NormalizeEndpointId(entryIdentifier);
+
+                for (auto const& entry : hosts)
+                {
+                    auto host = entry.GetObject();
+
+                    if (NormalizeEndpointId(std::wstring{ host.GetNamedString(L"entryIdentifier", L"") }) != wantedEntry)
+                    {
+                        continue;
+                    }
+
+                    auto connections = host.GetNamedArray(L"connections", nullptr);
+
+                    if (connections == nullptr) return {};
+
+                    for (auto const& connectionEntry : connections)
+                    {
+                        auto connection = connectionEntry.GetObject();
+
+                        auto id = std::wstring{ connection.GetNamedString(L"endpointDeviceId", L"") };
+
+                        if (!id.empty()) return id;
+                    }
+                }
+            }
+            catch (...)
+            {
+            }
+
+            return {};
+        }
+
+        // The port a host actually bound, which is only known after it has started.
+        uint16_t FindHostActualPort(_In_ std::wstring const& entryIdentifier)
+        {
+            auto result = EnumerateHosts();
+
+            if (!result.IsSuccess()) return 0;
+
+            auto parsed = ParseResponse(result.ResponseJson);
+
+            if (parsed == nullptr) return 0;
+
+            try
+            {
+                auto hosts = parsed.GetNamedArray(L"hosts", nullptr);
+
+                if (hosts == nullptr) return 0;
+
+                auto const wantedEntry = NormalizeEndpointId(entryIdentifier);
+
+                for (auto const& entry : hosts)
+                {
+                    auto host = entry.GetObject();
+
+                    if (NormalizeEndpointId(std::wstring{ host.GetNamedString(L"entryIdentifier", L"") }) != wantedEntry)
+                    {
+                        continue;
+                    }
+
+                    auto const portText = std::wstring{ host.GetNamedString(L"actualPort", L"") };
+
+                    if (portText.empty()) return 0;
+
+                    auto const port = std::stoul(portText);
+
+                    return (port > 0 && port <= 65535) ? static_cast<uint16_t>(port) : 0;
+                }
+            }
+            catch (...)
+            {
+            }
+
+            return 0;
+        }
+
+        std::wstring WaitForClientEndpointDeviceId(_In_ std::wstring const& entryIdentifier)
+        {
+            auto const deadline = std::chrono::steady_clock::now() + EndpointCreationTimeout;
+
+            while (std::chrono::steady_clock::now() < deadline)
+            {
+                auto id = FindClientEndpointDeviceId(entryIdentifier);
+
+                if (!id.empty()) return id;
+
+                std::this_thread::sleep_for(PollInterval);
+            }
+
+            return {};
+        }
+
+        std::wstring WaitForHostConnectionEndpointDeviceId(_In_ std::wstring const& entryIdentifier)
+        {
+            auto const deadline = std::chrono::steady_clock::now() + EndpointCreationTimeout;
+
+            while (std::chrono::steady_clock::now() < deadline)
+            {
+                auto id = FindHostConnectionEndpointDeviceId(entryIdentifier);
+
+                if (!id.empty()) return id;
+
+                std::this_thread::sleep_for(PollInterval);
+            }
+
+            return {};
+        }
+
+        bool RequireService()
+        {
+            if (!g_serviceAvailable)
+            {
+                Log::Error(L"Windows MIDI Service is not reachable, or the network transport is not enabled.");
+                return false;
+            }
+
+            return true;
+        }
+
+
+        // A remote host under this test's control which the service connects out to.
+        class RemoteHostUnderTest
+        {
+        public:
+            ~RemoteHostUnderTest() { Remove(); }
+
+            FakeNetworkHost& Host() { return m_host; }
+            std::wstring const& EntryIdentifier() const { return m_entryIdentifier; }
+
+            bool Start(_In_ uint8_t const groupCount, _In_ bool const createMidi1Ports)
+            {
+                m_host.SetInvitationBehavior(FakeHostInvitationBehavior::Accept);
+                m_host.SetEndpointName("Port Creation Test Host");
+
+                if (groupCount > 0)
+                {
+                    m_host.DeclareBidirectionalFunctionBlock(groupCount);
+                }
+
+                if (!m_host.Start())
+                {
+                    Log::Error(L"Could not start the fake host.");
+                    return false;
+                }
+
+                m_entryIdentifier = MakeEntryIdentifier();
+
+                auto result = CreateDirectClient(
+                    m_entryIdentifier,
+                    FakeNetworkHost::Address(),
+                    m_host.Port(),
+                    createMidi1Ports);
+
+                if (!result.CallSucceeded)
+                {
+                    Log::Error(String().Format(L"Creating the client failed: %s", result.Message.c_str()));
+                    m_entryIdentifier.clear();
+                    return false;
+                }
+
+                m_created = true;
+
+                return true;
+            }
+
+            void Remove()
+            {
+                if (m_created && !m_entryIdentifier.empty())
+                {
+                    DisconnectClient(m_entryIdentifier);
+                    m_created = false;
+                }
+
+                m_host.Stop();
+            }
+
+        private:
+            FakeNetworkHost m_host{ };
+            std::wstring m_entryIdentifier{ };
+            bool m_created{ false };
+        };
+
+
+        // Answers the Windows host's Endpoint Discovery on a client socket. The fake host does
+        // this from its own receive loop; a client is driven by the test thread, so this is a
+        // blocking pump the test runs until the exchange is done.
+        bool AnswerDiscoveryOnClient(
+            _In_ UdpTestClient& client,
+            _In_ std::vector<FunctionBlockDescription> const& blocks,
+            _In_ std::string const& endpointName,
+            _In_ std::chrono::milliseconds const timeout)
+        {
+            auto const deadline = std::chrono::steady_clock::now() + timeout;
+
+            uint16_t sequenceNumber{ 0 };
+
+            while (std::chrono::steady_clock::now() < deadline)
+            {
+                auto packet = client.ReceivePacket(PollInterval);
+
+                if (!packet.has_value()) continue;
+
+                for (auto const& command : packet->Commands)
+                {
+                    if (command.Code != CommandCode::UmpData) continue;
+
+                    std::vector<uint32_t> words{ };
+
+                    for (size_t word = 0; word < command.PayloadLengthWords; word++)
+                    {
+                        words.push_back(command.GetPayloadUInt32(word));
+                    }
+
+                    if (!ContainsStreamMessageWithStatus(words, StreamStatusEndpointDiscovery))
+                    {
+                        continue;
+                    }
+
+                    auto send = [&client, &sequenceNumber](std::vector<uint32_t> const& reply)
+                    {
+                        if (reply.empty()) return;
+
+                        PacketBuilder builder;
+                        builder.StartPacket().AddUmpData(sequenceNumber++, reply);
+                        client.Send(builder);
+                    };
+
+                    send(BuildEndpointInfoNotification(static_cast<uint8_t>(blocks.size())));
+                    send(BuildEndpointNameNotification(endpointName));
+                    send(BuildProductInstanceIdNotification("PortCreationTestClient"));
+
+                    for (auto const& block : blocks)
+                    {
+                        send(BuildFunctionBlockInfoNotification(block));
+                        send(BuildFunctionBlockNameNotification(block.Number, block.Name));
+                    }
+
+                    return true;
+                }
+            }
+
+            return false;
+        }
+    }
+
+
+    bool PortCreationTests::ClassSetup()
+    {
+        // Nothing here goes through ProtocolTestContext, which is what owns Winsock for the rest
+        // of the DLL, so this class starts it itself. WSAStartup is reference counted.
+        static WinsockScope s_winsock;
+
+        if (!s_winsock.IsInitialized())
+        {
+            Log::Error(L"Winsock could not be initialized.");
+            return false;
+        }
+
+        g_serviceAvailable = IsServiceAvailable();
+
+        if (!g_serviceAvailable)
+        {
+            Log::Warning(L"Windows MIDI Service is not reachable. These tests will fail rather than skip.");
+            return true;
+        }
+
+        // Otherwise a direct client waits up to 20 seconds for the endpoint creator to wake.
+        if (!SetDirectConnectionScanInterval(1000).IsSuccess())
+        {
+            Log::Warning(L"Could not shorten the direct connection scan interval. Tests will be slower.");
+        }
+
+        return true;
+    }
+
+    bool PortCreationTests::TestSetup()
+    {
+        m_deviceNodeTracker.Start();
+
+        return true;
+    }
+
+    bool PortCreationTests::TestCleanup()
+    {
+        m_deviceNodeTracker.RemoveDeviceNodesCreatedSinceStart();
+
+        return true;
+    }
+
+
+    void PortCreationTests::RemoteHostCompletingDiscoveryGetsAPortPerGroup()
+    {
+        if (!RequireService()) return;
+
+        // Two groups rather than one, so a fallback that always produces a single pair cannot
+        // pass this by accident.
+        constexpr uint8_t GroupCount = 2;
+
+        RemoteHostUnderTest remote;
+
+        VERIFY_IS_TRUE(remote.Start(GroupCount, true));
+
+        VERIFY_IS_TRUE(
+            remote.Host().WaitForCommand(CommandCode::Invitation, SessionTimeout).has_value(),
+            L"The service never invited the remote host.");
+
+        auto endpointDeviceId = WaitForClientEndpointDeviceId(remote.EntryIdentifier());
+
+        VERIFY_IS_FALSE(endpointDeviceId.empty(), L"The service never reported an endpoint for this client.");
+
+        if (endpointDeviceId.empty()) return;
+
+        Log::Comment(String().Format(L"Endpoint: %s", endpointDeviceId.c_str()));
+
+        VERIFY_IS_GREATER_THAN(
+            remote.Host().EndpointDiscoveryRequestCount(), static_cast<size_t>(0),
+            L"The service never asked the remote host to describe itself.");
+
+        auto const counts = WaitForMidi1Ports(endpointDeviceId, GroupCount, PortCreationTimeout);
+
+        Log::Comment(String().Format(L"MIDI 1.0 ports: %u sources, %u destinations", counts.Sources, counts.Destinations));
+
+        VERIFY_ARE_EQUAL(static_cast<uint32_t>(GroupCount), counts.Sources,
+            L"One MIDI 1.0 source per group spanned by the function block.");
+        VERIFY_ARE_EQUAL(static_cast<uint32_t>(GroupCount), counts.Destinations,
+            L"One MIDI 1.0 destination per group spanned by the function block.");
+    }
+
+
+    void PortCreationTests::RemoteHostCreatesNoPortsWhenUmpOnly()
+    {
+        if (!RequireService()) return;
+
+        RemoteHostUnderTest remote;
+
+        VERIFY_IS_TRUE(remote.Start(2, false));
+
+        VERIFY_IS_TRUE(
+            remote.Host().WaitForCommand(CommandCode::Invitation, SessionTimeout).has_value(),
+            L"The service never invited the remote host.");
+
+        auto endpointDeviceId = WaitForClientEndpointDeviceId(remote.EntryIdentifier());
+
+        VERIFY_IS_FALSE(endpointDeviceId.empty(), L"The service never reported an endpoint for this client.");
+
+        if (endpointDeviceId.empty()) return;
+
+        // Give the service the same amount of time it would have taken to create them.
+        std::this_thread::sleep_for(std::chrono::milliseconds(5000));
+
+        auto const counts = CountMidi1Ports(endpointDeviceId);
+
+        Log::Comment(String().Format(L"MIDI 1.0 ports: %u sources, %u destinations", counts.Sources, counts.Destinations));
+
+        VERIFY_ARE_EQUAL(static_cast<uint32_t>(0), counts.Total(),
+            L"A UMP-only endpoint gets no MIDI 1.0 ports, however well the remote describes itself.");
+    }
+
+
+    void PortCreationTests::RemoteClientCompletingDiscoveryGetsAPortPerGroup()
+    {
+        if (!RequireService()) return;
+
+        constexpr uint8_t GroupCount = 2;
+
+        auto const entryIdentifier = MakeEntryIdentifier();
+        auto const serviceInstanceName = L"MidiPortCreationTest_" + entryIdentifier.substr(1, 8);
+
+        auto created = CreateHost(
+            entryIdentifier,
+            L"Port Creation Test Host",
+            L"PortCreationTestHost",
+            serviceInstanceName,
+            false,          // accept remote clients without asking
+            L"auto",
+            false,          // do not advertise
+            true,
+            true);          // create MIDI 1.0 ports
+
+        VERIFY_IS_TRUE(created.IsSuccess(), L"Could not create the host.");
+
+        auto removeHost = wil::scope_exit([&entryIdentifier]()
+        {
+            RemoveHost(entryIdentifier);
+        });
+
+        uint16_t hostPort{ 0 };
+
+        auto const portDeadline = std::chrono::steady_clock::now() + EndpointCreationTimeout;
+
+        while (std::chrono::steady_clock::now() < portDeadline && hostPort == 0)
+        {
+            hostPort = FindHostActualPort(entryIdentifier);
+
+            if (hostPort == 0) std::this_thread::sleep_for(PollInterval);
+        }
+
+        VERIFY_IS_GREATER_THAN(hostPort, static_cast<uint16_t>(0), L"The host never reported a port.");
+
+        if (hostPort == 0) return;
+
+        UdpTestClient client;
+
+        VERIFY_IS_TRUE(client.Open(HostEndpointAddress{ L"127.0.0.1", hostPort }), L"Could not open the test client.");
+
+        PacketBuilder invitation;
+        invitation.StartPacket().AddInvitation("Port Creation Test Client", "PortCreationTestClient");
+
+        VERIFY_IS_TRUE(client.Send(invitation), L"Could not send the invitation.");
+
+        VERIFY_IS_TRUE(
+            client.WaitForCommand(CommandCode::InvitationReplyAccepted, SessionTimeout).has_value(),
+            L"The host never accepted the session.");
+
+        FunctionBlockDescription block{ };
+        block.Number = 0;
+        block.Direction = FunctionBlockDirection::Bidirectional;
+        block.FirstGroup = 0;
+        block.GroupCount = GroupCount;
+        block.IsActive = true;
+        block.Name = "Port Creation Test Client";
+
+        VERIFY_IS_TRUE(
+            AnswerDiscoveryOnClient(client, { block }, "Port Creation Test Client", SessionTimeout),
+            L"The host never asked the remote client to describe itself.");
+
+        auto endpointDeviceId = WaitForHostConnectionEndpointDeviceId(entryIdentifier);
+
+        VERIFY_IS_FALSE(endpointDeviceId.empty(), L"The host never reported an endpoint for the connected client.");
+
+        if (endpointDeviceId.empty()) return;
+
+        Log::Comment(String().Format(L"Endpoint: %s", endpointDeviceId.c_str()));
+
+        auto const counts = WaitForMidi1Ports(endpointDeviceId, GroupCount, PortCreationTimeout);
+
+        Log::Comment(String().Format(L"MIDI 1.0 ports: %u sources, %u destinations", counts.Sources, counts.Destinations));
+
+        VERIFY_ARE_EQUAL(static_cast<uint32_t>(GroupCount), counts.Sources,
+            L"One MIDI 1.0 source per group spanned by the function block.");
+        VERIFY_ARE_EQUAL(static_cast<uint32_t>(GroupCount), counts.Destinations,
+            L"One MIDI 1.0 destination per group spanned by the function block.");
+    }
+}

--- a/src/in-box/Test/Midi2.Transport.NetworkMidi2.unittests/NetworkMidiPortCreationTests.cpp
+++ b/src/in-box/Test/Midi2.Transport.NetworkMidi2.unittests/NetworkMidiPortCreationTests.cpp
@@ -49,6 +49,9 @@ namespace NetworkMidiTest
         // PKEY_MIDI_AssociatedUMP, property 52. Restated for the same reason.
         constexpr wchar_t AssociatedUmpProperty[] = L"{3F114A6A-11FA-4BD0-9D2C-6B7780CD80AD} 52";
 
+        // PKEY_MIDI_CustomEndpointName, property 500.
+        constexpr wchar_t CustomEndpointNameProperty[] = L"{3F114A6A-11FA-4BD0-9D2C-6B7780CD80AD} 500";
+
         std::wstring NormalizeEndpointId(_In_ std::wstring const& value)
         {
             std::wstring result{ value };
@@ -120,6 +123,139 @@ namespace NetworkMidiTest
             counts.Destinations = CountPortsWithSelector(Midi1DestinationSelector, endpointDeviceId);
 
             return counts;
+        }
+
+        std::vector<std::wstring> CollectPortNamesWithSelector(
+            _In_ std::wstring const& selector,
+            _In_ std::wstring const& endpointDeviceId)
+        {
+            std::vector<std::wstring> names{ };
+
+            try
+            {
+                auto properties = winrt::single_threaded_vector<winrt::hstring>();
+                properties.Append(winrt::hstring{ AssociatedUmpProperty });
+
+                auto devices = enumeration::DeviceInformation::FindAllAsync(
+                    winrt::hstring{ selector },
+                    properties,
+                    enumeration::DeviceInformationKind::DeviceInterface).get();
+
+                auto const wanted = NormalizeEndpointId(endpointDeviceId);
+
+                for (auto const& device : devices)
+                {
+                    auto value = device.Properties().TryLookup(winrt::hstring{ AssociatedUmpProperty });
+
+                    if (value == nullptr) continue;
+
+                    auto const associated = NormalizeEndpointId(
+                        std::wstring{ winrt::unbox_value_or<winrt::hstring>(value, L"") });
+
+                    if (!associated.empty() && associated == wanted)
+                    {
+                        names.push_back(std::wstring{ device.Name() });
+                    }
+                }
+            }
+            CATCH_LOG();
+
+            return names;
+        }
+
+        bool AllNamesContain(
+            _In_ std::vector<std::wstring> const& names,
+            _In_ std::wstring const& expected)
+        {
+            if (names.empty())
+            {
+                return false;
+            }
+
+            for (auto const& name : names)
+            {
+                if (name.find(expected) == std::wstring::npos)
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+
+        // Separates "the rename never landed" from "it landed but the ports did not follow"
+        std::wstring ReadEndpointName(_In_ std::wstring const& endpointDeviceId)
+        {
+            try
+            {
+                auto device = enumeration::DeviceInformation::CreateFromIdAsync(
+                    winrt::hstring{ endpointDeviceId },
+                    nullptr,
+                    enumeration::DeviceInformationKind::DeviceInterface).get();
+
+                if (device != nullptr)
+                {
+                    return std::wstring{ device.Name() };
+                }
+            }
+            CATCH_LOG();
+
+            return L"";
+        }
+
+        // The display name can lag the customization, so this is what actually says whether the
+        // customization reached the endpoint.
+        std::wstring ReadCustomEndpointName(_In_ std::wstring const& endpointDeviceId)
+        {
+            try
+            {
+                auto properties = winrt::single_threaded_vector<winrt::hstring>();
+                properties.Append(winrt::hstring{ CustomEndpointNameProperty });
+
+                auto device = enumeration::DeviceInformation::CreateFromIdAsync(
+                    winrt::hstring{ endpointDeviceId },
+                    properties,
+                    enumeration::DeviceInformationKind::DeviceInterface).get();
+
+                if (device != nullptr)
+                {
+                    auto value = device.Properties().TryLookup(winrt::hstring{ CustomEndpointNameProperty });
+
+                    if (value != nullptr)
+                    {
+                        return std::wstring{ winrt::unbox_value_or<winrt::hstring>(value, L"") };
+                    }
+                }
+            }
+            CATCH_LOG();
+
+            return L"";
+        }
+
+        // Polls until every port for the endpoint carries the expected text. Returns what it last
+        // saw so a failure can print the names rather than just the fact that it gave up.
+        std::vector<std::wstring> WaitForMidi1PortNames(
+            _In_ std::wstring const& endpointDeviceId,
+            _In_ std::wstring const& expected,
+            _In_ std::chrono::milliseconds const timeout)
+        {
+            auto const deadline = std::chrono::steady_clock::now() + timeout;
+
+            std::vector<std::wstring> names{ };
+
+            while (std::chrono::steady_clock::now() < deadline)
+            {
+                names = CollectPortNamesWithSelector(Midi1SourceSelector, endpointDeviceId);
+
+                if (AllNamesContain(names, expected))
+                {
+                    return names;
+                }
+
+                std::this_thread::sleep_for(PollInterval);
+            }
+
+            return names;
         }
 
         // Polls until both directions reach the expected count. Returns whatever it last saw, so
@@ -346,10 +482,18 @@ namespace NetworkMidiTest
             FakeNetworkHost& Host() { return m_host; }
             std::wstring const& EntryIdentifier() const { return m_entryIdentifier; }
 
-            bool Start(_In_ uint8_t const groupCount, _In_ bool const createMidi1Ports)
+            // What a customization matches on, so a test which renames has to know it
+            std::wstring const& EndpointName() const { return m_endpointName; }
+
+            bool Start(
+                _In_ uint8_t const groupCount,
+                _In_ bool const createMidi1Ports,
+                _In_ std::string const& endpointName = "Port Creation Test Host")
             {
+                m_endpointName = winrt::to_hstring(endpointName);
+
                 m_host.SetInvitationBehavior(FakeHostInvitationBehavior::Accept);
-                m_host.SetEndpointName("Port Creation Test Host");
+                m_host.SetEndpointName(endpointName);
 
                 if (groupCount > 0)
                 {
@@ -396,6 +540,7 @@ namespace NetworkMidiTest
         private:
             FakeNetworkHost m_host{ };
             std::wstring m_entryIdentifier{ };
+            std::wstring m_endpointName{ };
             bool m_created{ false };
         };
 
@@ -573,6 +718,197 @@ namespace NetworkMidiTest
 
         VERIFY_ARE_EQUAL(static_cast<uint32_t>(0), counts.Total(),
             L"A UMP-only endpoint gets no MIDI 1.0 ports, however well the remote describes itself.");
+    }
+
+
+    void PortCreationTests::ChangingTheFallbackPortCountAppliesWithoutReconnecting()
+    {
+        if (!RequireService()) return;
+
+        // No function blocks declared, so the transport's own block decides the port count and a
+        // change to it is observable. A remote which describes itself would override this.
+        RemoteHostUnderTest remote;
+
+        VERIFY_IS_TRUE(remote.Start(0, true));
+
+        VERIFY_IS_TRUE(
+            remote.Host().WaitForCommand(CommandCode::Invitation, SessionTimeout).has_value(),
+            L"The service never invited the remote host.");
+
+        auto endpointDeviceId = WaitForClientEndpointDeviceId(remote.EntryIdentifier());
+
+        VERIFY_IS_FALSE(endpointDeviceId.empty(), L"The service never reported an endpoint for this client.");
+
+        if (endpointDeviceId.empty()) return;
+
+        Log::Comment(String().Format(L"Endpoint: %s", endpointDeviceId.c_str()));
+
+        auto const before = WaitForMidi1Ports(endpointDeviceId, 1, PortCreationTimeout);
+
+        Log::Comment(String().Format(L"Before: %u sources, %u destinations", before.Sources, before.Destinations));
+
+        VERIFY_ARE_EQUAL(static_cast<uint32_t>(1), before.Sources, L"One source to start with.");
+        VERIFY_ARE_EQUAL(static_cast<uint32_t>(1), before.Destinations, L"One destination to start with.");
+
+        constexpr uint8_t NewCount = 3;
+
+        auto const update = UpdateClient(remote.EntryIdentifier(), true, NewCount);
+
+        VERIFY_IS_TRUE(update.IsSuccess(), L"The update was refused.");
+
+        // The transport rewrites the block and the name table, and the service re-syncs the ports
+        // off the property change, so this is not instant.
+        auto const after = WaitForMidi1Ports(endpointDeviceId, NewCount, PortCreationTimeout);
+
+        Log::Comment(String().Format(L"After: %u sources, %u destinations", after.Sources, after.Destinations));
+
+        VERIFY_ARE_EQUAL(static_cast<uint32_t>(NewCount), after.Sources,
+            L"The new port count reached the running endpoint.");
+        VERIFY_ARE_EQUAL(static_cast<uint32_t>(NewCount), after.Destinations,
+            L"The new port count reached the running endpoint.");
+
+        // The session was never taken down to do it.
+        VERIFY_IS_TRUE(
+            remote.Host().CountReceived(CommandCode::Bye) == 0,
+            L"The connection must not be torn down to change the port count.");
+    }
+
+
+    void PortCreationTests::RenamingAnEndpointRenamesItsMidi1Ports()
+    {
+        if (!RequireService()) return;
+
+        // Again no function blocks, so the ports are named from the transport's own block. A
+        // remote which describes itself has its name table rebuilt from the blocks instead, which
+        // is a different path and already worked.
+        //
+        // The name is unique per process because a customization cannot be withdrawn: the remove
+        // section is a stub, so the one this test sends outlives it in the service's cache. With
+        // a fixed name the next run would find its endpoint already renamed and pass without
+        // testing anything.
+        RemoteHostUnderTest remote;
+
+        auto const hostName = ProtocolTestContext::Current().MakeUniqueEndpointName("Rename");
+
+        VERIFY_IS_TRUE(remote.Start(0, true, hostName));
+
+        VERIFY_IS_TRUE(
+            remote.Host().WaitForCommand(CommandCode::Invitation, SessionTimeout).has_value(),
+            L"The service never invited the remote host.");
+
+        auto endpointDeviceId = WaitForClientEndpointDeviceId(remote.EntryIdentifier());
+
+        VERIFY_IS_FALSE(endpointDeviceId.empty(), L"The service never reported an endpoint for this client.");
+
+        if (endpointDeviceId.empty()) return;
+
+        Log::Comment(String().Format(L"Endpoint: %s", endpointDeviceId.c_str()));
+
+        auto const before = WaitForMidi1Ports(endpointDeviceId, 1, PortCreationTimeout);
+
+        VERIFY_ARE_EQUAL(static_cast<uint32_t>(1), before.Sources, L"One source to start with.");
+
+        auto const namesBefore = CollectPortNamesWithSelector(Midi1SourceSelector, endpointDeviceId);
+
+        for (auto const& name : namesBefore)
+        {
+            Log::Comment(String().Format(L"Before: %s", name.c_str()));
+        }
+
+        std::wstring const newName{ L"Renamed Port Creation Test" };
+
+        // Otherwise a leftover customization could rename the endpoint before the test does, and
+        // the assertion below would pass without the rename path running at all.
+        VERIFY_IS_FALSE(
+            AllNamesContain(namesBefore, newName),
+            L"The ports already carried the new name before the rename.");
+
+        auto const renamed = RenameEndpoint(endpointDeviceId, newName);
+
+        VERIFY_IS_TRUE(renamed.IsSuccess(), L"The rename was refused.");
+
+        auto const names = WaitForMidi1PortNames(endpointDeviceId, newName, PortCreationTimeout);
+
+        Log::Comment(String().Format(L"Endpoint name after rename: '%s'", ReadEndpointName(endpointDeviceId).c_str()));
+        Log::Comment(String().Format(L"Custom name property after rename: '%s'", ReadCustomEndpointName(endpointDeviceId).c_str()));
+
+        for (auto const& name : names)
+        {
+            Log::Comment(String().Format(L"After: %s", name.c_str()));
+        }
+
+        VERIFY_IS_FALSE(names.empty(), L"The endpoint lost its MIDI 1.0 ports during the rename.");
+
+        VERIFY_IS_TRUE(
+            AllNamesContain(names, newName),
+            L"The new endpoint name never reached the MIDI 1.0 port names.");
+
+        VERIFY_IS_TRUE(
+            remote.Host().CountReceived(CommandCode::Bye) == 0,
+            L"The connection must not be torn down to rename an endpoint.");
+    }
+
+
+    void PortCreationTests::ChangingThePortCountKeepsACustomName()
+    {
+        if (!RequireService()) return;
+
+        RemoteHostUnderTest remote;
+
+        auto const hostName = ProtocolTestContext::Current().MakeUniqueEndpointName("KeepName");
+
+        VERIFY_IS_TRUE(remote.Start(0, true, hostName));
+
+        VERIFY_IS_TRUE(
+            remote.Host().WaitForCommand(CommandCode::Invitation, SessionTimeout).has_value(),
+            L"The service never invited the remote host.");
+
+        auto endpointDeviceId = WaitForClientEndpointDeviceId(remote.EntryIdentifier());
+
+        VERIFY_IS_FALSE(endpointDeviceId.empty(), L"The service never reported an endpoint for this client.");
+
+        if (endpointDeviceId.empty()) return;
+
+        VERIFY_ARE_EQUAL(
+            static_cast<uint32_t>(1),
+            WaitForMidi1Ports(endpointDeviceId, 1, PortCreationTimeout).Sources,
+            L"One source to start with.");
+
+        std::wstring const customName{ L"Kept Custom Name" };
+
+        VERIFY_IS_TRUE(
+            RenameEndpoint(endpointDeviceId, customName).IsSuccess(),
+            L"The rename was refused.");
+
+        auto const renamedPorts = WaitForMidi1PortNames(endpointDeviceId, customName, PortCreationTimeout);
+
+        VERIFY_IS_TRUE(
+            AllNamesContain(renamedPorts, customName),
+            L"The rename did not reach the ports, so this test cannot say anything about the count change.");
+
+        // The count change resolves the port name for itself rather than being handed one. The
+        // endpoint reports its original name however it was renamed, so this is where a custom
+        // name gets thrown away.
+        constexpr uint8_t NewCount = 3;
+
+        VERIFY_IS_TRUE(
+            UpdateClient(remote.EntryIdentifier(), true, NewCount).IsSuccess(),
+            L"The update was refused.");
+
+        auto const after = WaitForMidi1Ports(endpointDeviceId, NewCount, PortCreationTimeout);
+
+        VERIFY_ARE_EQUAL(static_cast<uint32_t>(NewCount), after.Sources, L"The new port count was applied.");
+
+        auto const namesAfter = WaitForMidi1PortNames(endpointDeviceId, customName, PortCreationTimeout);
+
+        for (auto const& name : namesAfter)
+        {
+            Log::Comment(String().Format(L"After count change: %s", name.c_str()));
+        }
+
+        VERIFY_IS_TRUE(
+            AllNamesContain(namesAfter, customName),
+            L"Changing the port count reverted the ports to the name the remote supplied.");
     }
 
 

--- a/src/in-box/Test/Midi2.Transport.NetworkMidi2.unittests/NetworkMidiPortCreationTests.h
+++ b/src/in-box/Test/Midi2.Transport.NetworkMidi2.unittests/NetworkMidiPortCreationTests.h
@@ -1,0 +1,52 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License
+// ============================================================================
+// This is part of the Windows MIDI Services App API and should be used
+// in your Windows application via an official binary distribution.
+// Further information: https://github.com/microsoft/MIDI/
+// ============================================================================
+
+#pragma once
+
+// MIDI 1.0 port creation for network endpoints, driven end to end against the real service.
+//
+// The remote in each case is a fake which answers Endpoint Discovery with real Function Block
+// Info notifications, so these cover the path an actual device takes: discovery completes, the
+// service reads the function blocks, and the ports follow from them. That is the case
+// https://github.com/microsoft/MIDI/issues/1190 turned out to have several silent ways to fail.
+
+namespace NetworkMidiTest
+{
+    class PortCreationTests
+        : public WEX::TestClass<PortCreationTests>
+    {
+    public:
+
+        BEGIN_TEST_CLASS(PortCreationTests)
+            TEST_CLASS_PROPERTY(L"TestClassification", L"Integration")
+            TEST_CLASS_PROPERTY(L"BinaryUnderTest", L"Midi2.NetworkMidiTransport.dll")
+        END_TEST_CLASS()
+
+        TEST_CLASS_SETUP(ClassSetup);
+        TEST_METHOD_SETUP(TestSetup);
+        TEST_METHOD_CLEANUP(TestCleanup);
+
+        // Windows is the client. A remote host which describes itself with one bidirectional
+        // function block spanning several groups gets one MIDI 1.0 port per group in each
+        // direction.
+        TEST_METHOD(RemoteHostCompletingDiscoveryGetsAPortPerGroup);
+
+        // Windows is the host. Same expectation for a remote client which connects in and
+        // describes itself the same way.
+        TEST_METHOD(RemoteClientCompletingDiscoveryGetsAPortPerGroup);
+
+        // Asking for UMP only means no MIDI 1.0 ports, however well the remote describes itself.
+        // This is the flag whose network default was wrong, so it is worth pinning in both
+        // directions.
+        TEST_METHOD(RemoteHostCreatesNoPortsWhenUmpOnly);
+
+    private:
+
+        MidiTest::DeviceNodeTracker m_deviceNodeTracker{ };
+    };
+}

--- a/src/in-box/Test/Midi2.Transport.NetworkMidi2.unittests/NetworkMidiPortCreationTests.h
+++ b/src/in-box/Test/Midi2.Transport.NetworkMidi2.unittests/NetworkMidiPortCreationTests.h
@@ -58,6 +58,9 @@ namespace NetworkMidiTest
         // custom one.
         TEST_METHOD(ChangingThePortCountKeepsACustomName);
 
+        // Removing a customization puts the endpoint and its ports back to the remote's name.
+        TEST_METHOD(RemovingACustomizationRevertsTheMidi1PortNames);
+
     private:
 
         MidiTest::DeviceNodeTracker m_deviceNodeTracker{ };

--- a/src/in-box/Test/Midi2.Transport.NetworkMidi2.unittests/NetworkMidiPortCreationTests.h
+++ b/src/in-box/Test/Midi2.Transport.NetworkMidi2.unittests/NetworkMidiPortCreationTests.h
@@ -45,6 +45,19 @@ namespace NetworkMidiTest
         // directions.
         TEST_METHOD(RemoteHostCreatesNoPortsWhenUmpOnly);
 
+        // Changing the fallback count reaches an endpoint which is already up, with no
+        // disconnect and no reconnect. https://github.com/microsoft/MIDI/issues/1190
+        TEST_METHOD(ChangingTheFallbackPortCountAppliesWithoutReconnecting);
+
+        // Renaming an endpoint renames its MIDI 1.0 ports too. The endpoint name and the port
+        // name table are separate properties, and only the first was being written.
+        TEST_METHOD(RenamingAnEndpointRenamesItsMidi1Ports);
+
+        // A custom name survives a later port count change. The device interface keeps reporting
+        // the name the remote supplied, so anything which rebuilds the ports from it loses the
+        // custom one.
+        TEST_METHOD(ChangingThePortCountKeepsACustomName);
+
     private:
 
         MidiTest::DeviceNodeTracker m_deviceNodeTracker{ };

--- a/src/in-box/Test/Midi2.Transport.NetworkMidi2.unittests/NetworkMidiTestFakeHost.cpp
+++ b/src/in-box/Test/Midi2.Transport.NetworkMidi2.unittests/NetworkMidiTestFakeHost.cpp
@@ -273,10 +273,100 @@ namespace NetworkMidiTest
                 }
                 break;
 
+            case CommandCode::UmpData:
+                HandleUmpData(command);
+                break;
+
             default:
                 break;
             }
         }
+    }
+
+
+    _Use_decl_annotations_
+    void FakeNetworkHost::HandleUmpData(ReceivedCommand const& command)
+    {
+        std::vector<uint32_t> words{ };
+
+        for (size_t word = 0; word < command.PayloadLengthWords; word++)
+        {
+            words.push_back(command.GetPayloadUInt32(word));
+        }
+
+        if (!ContainsStreamMessageWithStatus(words, StreamStatusEndpointDiscovery))
+        {
+            return;
+        }
+
+        m_endpointDiscoveryRequests++;
+
+        SendDiscoveryResponse();
+    }
+
+
+    void FakeNetworkHost::SendDiscoveryResponse()
+    {
+        std::vector<FunctionBlockDescription> blocks{ };
+
+        {
+            std::lock_guard<std::mutex> guard{ m_functionBlockLock };
+            blocks = m_functionBlocks;
+        }
+
+        // A host with nothing declared says nothing, which is how a device that never completes
+        // discovery behaves. The service times out and moves on.
+        if (blocks.empty())
+        {
+            return;
+        }
+
+        // Each message goes in its own UDP packet with its own sequence number. A real device is
+        // free to batch them, but one per packet keeps the retransmit bookkeeping simple and the
+        // service does not care either way.
+        auto sendWords = [this](std::vector<uint32_t> const& words)
+        {
+            if (words.empty()) return;
+
+            PacketBuilder builder;
+            builder.StartPacket().AddUmpData(m_outboundUmpSequenceNumber++, words);
+            SendToRemote(builder.Bytes());
+        };
+
+        sendWords(BuildEndpointInfoNotification(static_cast<uint8_t>(blocks.size())));
+        sendWords(BuildEndpointNameNotification(m_endpointName));
+        sendWords(BuildProductInstanceIdNotification(m_productInstanceId));
+
+        for (auto const& block : blocks)
+        {
+            sendWords(BuildFunctionBlockInfoNotification(block));
+            sendWords(BuildFunctionBlockNameNotification(block.Number, block.Name));
+        }
+    }
+
+
+    _Use_decl_annotations_
+    void FakeNetworkHost::DeclareFunctionBlocks(std::vector<FunctionBlockDescription> const& blocks)
+    {
+        std::lock_guard<std::mutex> guard{ m_functionBlockLock };
+
+        m_functionBlocks = blocks;
+    }
+
+
+    _Use_decl_annotations_
+    void FakeNetworkHost::DeclareBidirectionalFunctionBlock(uint8_t const groupCount)
+    {
+        FunctionBlockDescription block{ };
+
+        block.Number = 0;
+        block.Direction = FunctionBlockDirection::Bidirectional;
+        block.FirstGroup = 0;
+        block.GroupCount = groupCount;
+        block.IsActive = true;
+        block.Name = m_endpointName;
+
+        DeclareFunctionBlocks({ block });
     }
 
 

--- a/src/in-box/Test/Midi2.Transport.NetworkMidi2.unittests/NetworkMidiTestFakeHost.h
+++ b/src/in-box/Test/Midi2.Transport.NetworkMidi2.unittests/NetworkMidiTestFakeHost.h
@@ -149,6 +149,20 @@ namespace NetworkMidiTest
         // is what makes the reflection and wrong-source-port tests meaningful.
         void SetRelatchOnInvitation(_In_ bool const enabled) { m_relatchOnInvitation = enabled; }
 
+        // Endpoint discovery -----------------------------------------------------------
+
+        // Describes this host the way a real MIDI 2.0 device does. Once blocks are declared the
+        // host answers an Endpoint Discovery request with Endpoint Info, Endpoint Name, Product
+        // Instance Id, and one Function Block Info and Name per block. With no blocks declared
+        // the host stays silent, which is what an endpoint that never completes discovery does.
+        void DeclareFunctionBlocks(_In_ std::vector<FunctionBlockDescription> const& blocks);
+
+        // One bidirectional block spanning the given groups, named after the endpoint. The
+        // common case, and the one that produces groupCount MIDI 1.0 ports in each direction.
+        void DeclareBidirectionalFunctionBlock(_In_ uint8_t const groupCount);
+
+        size_t EndpointDiscoveryRequestCount() const { return m_endpointDiscoveryRequests; }
+
         // Sending ----------------------------------------------------------------------
 
         bool Send(_In_ std::vector<uint8_t> const& bytes);
@@ -164,6 +178,8 @@ namespace NetworkMidiTest
         void ReceiverLoop(_In_ std::stop_token const stopToken);
         void HandlePacket(_In_ ParsedPacket const& packet);
         void HandleInvitation();
+        void HandleUmpData(_In_ ReceivedCommand const& command);
+        void SendDiscoveryResponse();
 
         bool SendToRemote(_In_ std::vector<uint8_t> const& bytes);
 
@@ -191,6 +207,14 @@ namespace NetworkMidiTest
         // restart the timer.
         std::atomic<bool> m_pendingReplySent{ false };
         std::atomic<bool> m_sessionAccepted{ false };
+
+        std::mutex m_functionBlockLock;
+        std::vector<FunctionBlockDescription> m_functionBlocks{ };
+        std::atomic<size_t> m_endpointDiscoveryRequests{ 0 };
+
+        // UMP data commands carry a sequence number the client tracks, so the responses have to
+        // continue it rather than restart at zero.
+        std::atomic<uint16_t> m_outboundUmpSequenceNumber{ 0 };
 
         std::mutex m_historyLock;
         std::condition_variable m_historySignal;

--- a/src/in-box/Test/Midi2.Transport.NetworkMidi2.unittests/NetworkMidiTestProtocol.cpp
+++ b/src/in-box/Test/Midi2.Transport.NetworkMidi2.unittests/NetworkMidiTestProtocol.cpp
@@ -414,4 +414,178 @@ namespace NetworkMidiTest
 
         return ss.str();
     }
+
+
+    namespace
+    {
+        // Word 0 of every Stream message: type 0xF, then the form, then a 10 bit status.
+        uint32_t StreamWord0(_In_ uint8_t const form, _In_ uint16_t const status, _In_ uint16_t const remainder)
+        {
+            return
+                (static_cast<uint32_t>(UmpMessageTypeStream) << 28) |
+                (static_cast<uint32_t>(form & 0x3) << 26) |
+                (static_cast<uint32_t>(status & 0x3FF) << 16) |
+                static_cast<uint32_t>(remainder);
+        }
+
+        uint16_t StreamStatusOf(_In_ uint32_t const word0)
+        {
+            return static_cast<uint16_t>((word0 >> 16) & 0x3FF);
+        }
+
+        bool IsStreamWord0(_In_ uint32_t const word0)
+        {
+            return ((word0 >> 28) & 0xF) == UmpMessageTypeStream;
+        }
+
+        // Text notifications pack their characters after the fixed fields. How many land in
+        // word 0 follows from the per-packet character count, and the rest fill words 1 to 3.
+        std::vector<uint32_t> BuildTextNotification(
+            _In_ uint16_t const status,
+            _In_ uint16_t const word0Remainder,
+            _In_ size_t const maxBytes,
+            _In_ size_t const bytesPerPacket,
+            _In_ std::string const& text)
+        {
+            std::vector<uint32_t> words{ };
+
+            auto const truncated = text.substr(0, maxBytes);
+
+            size_t packetCount = truncated.size() / bytesPerPacket;
+            if (truncated.size() % bytesPerPacket != 0 || packetCount == 0) packetCount++;
+
+            size_t offset = 0;
+
+            for (size_t packet = 0; packet < packetCount; packet++)
+            {
+                uint8_t form;
+
+                if (packetCount == 1)               form = StreamFormComplete;
+                else if (packet == 0)               form = StreamFormStart;
+                else if (packet == packetCount - 1) form = StreamFormEnd;
+                else                                form = StreamFormContinue;
+
+                uint8_t payload[14]{ 0 };
+
+                for (size_t i = 0; i < bytesPerPacket && offset < truncated.size(); i++)
+                {
+                    payload[i] = static_cast<uint8_t>(truncated[offset++]);
+                }
+
+                uint32_t word0 = StreamWord0(form, status, word0Remainder);
+
+                size_t index = 0;
+
+                // 14 characters per packet leaves two in word 0, 13 leaves one
+                if (bytesPerPacket % 4 == 2)
+                {
+                    word0 |= static_cast<uint32_t>(payload[index++]) << 8;
+                }
+
+                if (bytesPerPacket % 4 >= 1)
+                {
+                    word0 |= static_cast<uint32_t>(payload[index++]);
+                }
+
+                words.push_back(word0);
+
+                for (size_t word = 0; word < 3; word++)
+                {
+                    words.push_back(
+                        static_cast<uint32_t>(payload[index]) << 24 |
+                        static_cast<uint32_t>(payload[index + 1]) << 16 |
+                        static_cast<uint32_t>(payload[index + 2]) << 8 |
+                        static_cast<uint32_t>(payload[index + 3]));
+
+                    index += 4;
+                }
+            }
+
+            return words;
+        }
+    }
+
+    _Use_decl_annotations_
+    bool IsStreamMessageWithStatus(std::vector<uint32_t> const& words, uint16_t const status)
+    {
+        return
+            words.size() >= 4 &&
+            IsStreamWord0(words[0]) &&
+            StreamStatusOf(words[0]) == status;
+    }
+
+    _Use_decl_annotations_
+    bool ContainsStreamMessageWithStatus(std::vector<uint32_t> const& words, uint16_t const status)
+    {
+        // A Stream message is always four words, so anything in the run which is not one cannot
+        // be stepped over reliably. Discovery requests arrive on their own, so scanning on a four
+        // word stride is enough and avoids decoding every message type.
+        for (size_t i = 0; i + 3 < words.size(); i += 4)
+        {
+            if (IsStreamWord0(words[i]) && StreamStatusOf(words[i]) == status)
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    _Use_decl_annotations_
+    std::vector<uint32_t> BuildEndpointInfoNotification(uint8_t const functionBlockCount, bool const staticFunctionBlocks)
+    {
+        // UMP version 1.1
+        uint16_t const word0Remainder = (static_cast<uint16_t>(1) << 8) | 1;
+
+        uint32_t word1 = static_cast<uint32_t>(functionBlockCount & 0x7F) << 24;
+
+        if (staticFunctionBlocks) word1 |= 0x80000000;
+
+        word1 |= 0x0100;    // supports MIDI 1.0 protocol
+        word1 |= 0x0200;    // supports MIDI 2.0 protocol
+
+        return { StreamWord0(StreamFormComplete, StreamStatusEndpointInfoNotification, word0Remainder), word1, 0, 0 };
+    }
+
+    _Use_decl_annotations_
+    std::vector<uint32_t> BuildFunctionBlockInfoNotification(FunctionBlockDescription const& block)
+    {
+        uint16_t word0Remainder{ 0 };
+
+        word0Remainder |= static_cast<uint16_t>(block.Number & 0x7F) << 8;
+        word0Remainder |= static_cast<uint16_t>(block.Direction);
+
+        // the active flag is the high bit of the function block number byte
+        if (block.IsActive) word0Remainder |= 0x8000;
+
+        uint32_t const word1 =
+            static_cast<uint32_t>(block.FirstGroup) << 24 |
+            static_cast<uint32_t>(block.GroupCount) << 16;
+
+        return { StreamWord0(StreamFormComplete, StreamStatusFunctionBlockInfoNotification, word0Remainder), word1, 0, 0 };
+    }
+
+    _Use_decl_annotations_
+    std::vector<uint32_t> BuildEndpointNameNotification(std::string const& name)
+    {
+        return BuildTextNotification(StreamStatusEndpointNameNotification, 0, 98, 14, name);
+    }
+
+    _Use_decl_annotations_
+    std::vector<uint32_t> BuildProductInstanceIdNotification(std::string const& productInstanceId)
+    {
+        return BuildTextNotification(StreamStatusProductInstanceIdNotification, 0, 42, 14, productInstanceId);
+    }
+
+    _Use_decl_annotations_
+    std::vector<uint32_t> BuildFunctionBlockNameNotification(uint8_t const functionBlockNumber, std::string const& name)
+    {
+        // the block number sits where the second character would otherwise go
+        return BuildTextNotification(
+            StreamStatusFunctionBlockNameNotification,
+            static_cast<uint16_t>(functionBlockNumber) << 8,
+            91,
+            13,
+            name);
+    }
 }

--- a/src/in-box/Test/Midi2.Transport.NetworkMidi2.unittests/NetworkMidiTestProtocol.h
+++ b/src/in-box/Test/Midi2.Transport.NetworkMidi2.unittests/NetworkMidiTestProtocol.h
@@ -197,4 +197,66 @@ namespace NetworkMidiTest
 
     std::wstring CommandCodeToString(_In_ CommandCode const code);
     std::wstring DescribePacket(_In_ ParsedPacket const& packet);
+
+
+    // UMP Stream messages (message type 0xF), from M2-104-UM v1.1.
+    //
+    // These are what a device says about itself when Windows asks. Written from the
+    // specification for the same reason as everything else in this file: a fake device built
+    // from the service's own reader would agree with the service even when both are wrong.
+
+    constexpr uint8_t UmpMessageTypeStream{ 0xF };
+
+    constexpr uint16_t StreamStatusEndpointDiscovery{ 0x000 };
+    constexpr uint16_t StreamStatusEndpointInfoNotification{ 0x001 };
+    constexpr uint16_t StreamStatusEndpointNameNotification{ 0x003 };
+    constexpr uint16_t StreamStatusProductInstanceIdNotification{ 0x004 };
+    constexpr uint16_t StreamStatusFunctionBlockDiscovery{ 0x010 };
+    constexpr uint16_t StreamStatusFunctionBlockInfoNotification{ 0x011 };
+    constexpr uint16_t StreamStatusFunctionBlockNameNotification{ 0x012 };
+
+    constexpr uint8_t StreamFormComplete{ 0x0 };
+    constexpr uint8_t StreamFormStart{ 0x1 };
+    constexpr uint8_t StreamFormContinue{ 0x2 };
+    constexpr uint8_t StreamFormEnd{ 0x3 };
+
+    // Direction is from the function block's own point of view, so Output is a message source
+    // and a MIDI In port to the user.
+    enum class FunctionBlockDirection : uint8_t
+    {
+        Undefined = 0x0,
+        Input = 0x1,        // message destination. A MIDI Out port to the user.
+        Output = 0x2,       // message source. A MIDI In port to the user.
+        Bidirectional = 0x3,
+    };
+
+    struct FunctionBlockDescription
+    {
+        uint8_t Number{ 0 };
+        FunctionBlockDirection Direction{ FunctionBlockDirection::Bidirectional };
+        uint8_t FirstGroup{ 0 };
+        uint8_t GroupCount{ 1 };
+        bool IsActive{ true };
+        std::string Name{ };
+    };
+
+    // True when this UMP is a Stream message with the given status.
+    bool IsStreamMessageWithStatus(_In_ std::vector<uint32_t> const& words, _In_ uint16_t const status);
+
+    // Every Stream message in a run of UMP words, matched on status. UMP data commands carry
+    // several messages, and a discovery request can arrive alongside others.
+    bool ContainsStreamMessageWithStatus(_In_ std::vector<uint32_t> const& words, _In_ uint16_t const status);
+
+    std::vector<uint32_t> BuildEndpointInfoNotification(
+        _In_ uint8_t const functionBlockCount,
+        _In_ bool const staticFunctionBlocks = true);
+
+    std::vector<uint32_t> BuildFunctionBlockInfoNotification(_In_ FunctionBlockDescription const& block);
+
+    // One or more UMPs, split across packets when the text does not fit in one.
+    std::vector<uint32_t> BuildEndpointNameNotification(_In_ std::string const& name);
+    std::vector<uint32_t> BuildProductInstanceIdNotification(_In_ std::string const& productInstanceId);
+    std::vector<uint32_t> BuildFunctionBlockNameNotification(
+        _In_ uint8_t const functionBlockNumber,
+        _In_ std::string const& name);
 }

--- a/src/in-box/Test/Midi2.Transport.NetworkMidi2.unittests/NetworkMidiTestServiceConfig.cpp
+++ b/src/in-box/Test/Midi2.Transport.NetworkMidi2.unittests/NetworkMidiTestServiceConfig.cpp
@@ -285,6 +285,19 @@ namespace NetworkMidiTest
     }
 
 
+    _Use_decl_annotations_
+    ServiceConfigResult RemoveEndpointCustomization(
+        std::wstring const& endpointDeviceId)
+    {
+        std::wstring json =
+            L"{\"remove\":{\"update\":[{"
+            L"\"match\":{\"endpointDeviceId\":\"" + EscapeJsonString(endpointDeviceId) + L"\"}"
+            L"}]}}";
+
+        return SendNetworkTransportConfig(json);
+    }
+
+
     ServiceConfigResult ConnectDirectClient(
         std::wstring const& entryIdentifier,
         std::wstring const& hostNameOrAddress,

--- a/src/in-box/Test/Midi2.Transport.NetworkMidi2.unittests/NetworkMidiTestServiceConfig.cpp
+++ b/src/in-box/Test/Midi2.Transport.NetworkMidi2.unittests/NetworkMidiTestServiceConfig.cpp
@@ -254,6 +254,37 @@ namespace NetworkMidiTest
     }
 
 
+    _Use_decl_annotations_
+    ServiceConfigResult UpdateClient(
+        std::wstring const& entryIdentifier,
+        bool const createMidi1Ports,
+        uint8_t const fallbackMidi1PortCount)
+    {
+        std::wstring json =
+            L"{\"updateEntries\":{\"clients\":{\"" + EscapeJsonString(entryIdentifier) + L"\":{"
+            L"\"createMidi1Ports\":" + std::wstring(createMidi1Ports ? L"true" : L"false") + L","
+            L"\"fallbackMidi1PortCount\":" + std::to_wstring(fallbackMidi1PortCount) +
+            L"}}}}";
+
+        return SendNetworkTransportConfig(json);
+    }
+
+
+    _Use_decl_annotations_
+    ServiceConfigResult RenameEndpoint(
+        std::wstring const& endpointDeviceId,
+        std::wstring const& newName)
+    {
+        std::wstring json =
+            L"{\"update\":[{"
+            L"\"match\":{\"endpointDeviceId\":\"" + EscapeJsonString(endpointDeviceId) + L"\"},"
+            L"\"customProperties\":{\"name\":\"" + EscapeJsonString(newName) + L"\"}"
+            L"}]}";
+
+        return SendNetworkTransportConfig(json);
+    }
+
+
     ServiceConfigResult ConnectDirectClient(
         std::wstring const& entryIdentifier,
         std::wstring const& hostNameOrAddress,

--- a/src/in-box/Test/Midi2.Transport.NetworkMidi2.unittests/NetworkMidiTestServiceConfig.cpp
+++ b/src/in-box/Test/Midi2.Transport.NetworkMidi2.unittests/NetworkMidiTestServiceConfig.cpp
@@ -353,7 +353,8 @@ namespace NetworkMidiTest
         bool const requireApproval,
         std::wstring const& port,
         bool const advertise,
-        bool const allowPortFallback)
+        bool const allowPortFallback,
+        bool const createMidi1Ports)
     {
         // advertise defaults off so these short-lived test hosts do not appear over mDNS and get
         // picked up by anything else on the network. Only the tests which are specifically about
@@ -371,6 +372,7 @@ namespace NetworkMidiTest
             L"\"enabled\":true,"
             L"\"advertise\":" + std::wstring(advertise ? L"true" : L"false") + L","
             L"\"allowPortFallback\":" + std::wstring(allowPortFallback ? L"true" : L"false") + L","
+            L"\"createMidi1Ports\":" + std::wstring(createMidi1Ports ? L"true" : L"false") + L","
             L"\"remoteClientPolicy\":\"" +
                 std::wstring(requireApproval ? L"requireApproval" : L"allowAny") + L"\""
             L"}}}}";

--- a/src/in-box/Test/Midi2.Transport.NetworkMidi2.unittests/NetworkMidiTestServiceConfig.h
+++ b/src/in-box/Test/Midi2.Transport.NetworkMidi2.unittests/NetworkMidiTestServiceConfig.h
@@ -110,7 +110,8 @@ namespace NetworkMidiTest
         _In_ bool const requireApproval,
         _In_ std::wstring const& port = L"auto",
         _In_ bool const advertise = false,
-        _In_ bool const allowPortFallback = true);
+        _In_ bool const allowPortFallback = true,
+        _In_ bool const createMidi1Ports = false);
 
     // The body of a "create" object, verbatim, so a test can put the wrong type in any field.
     ServiceConfigResult SendRawCreateSection(_In_ std::wstring const& createBodyJson);

--- a/src/in-box/Test/Midi2.Transport.NetworkMidi2.unittests/NetworkMidiTestServiceConfig.h
+++ b/src/in-box/Test/Midi2.Transport.NetworkMidi2.unittests/NetworkMidiTestServiceConfig.h
@@ -74,6 +74,11 @@ namespace NetworkMidiTest
         _In_ std::wstring const& endpointDeviceId,
         _In_ std::wstring const& newName);
 
+    // The "remove" section, which withdraws a customization so the endpoint and its MIDI 1.0
+    // ports go back to what the remote calls itself.
+    ServiceConfigResult RemoveEndpointCustomization(
+        _In_ std::wstring const& endpointDeviceId);
+
     // The connectDirect command. For an entry which already exists this is the app saying the
     // remote is reachable now, and is the only thing which revives a parked direct connection.
     ServiceConfigResult ConnectDirectClient(

--- a/src/in-box/Test/Midi2.Transport.NetworkMidi2.unittests/NetworkMidiTestServiceConfig.h
+++ b/src/in-box/Test/Midi2.Transport.NetworkMidi2.unittests/NetworkMidiTestServiceConfig.h
@@ -61,6 +61,19 @@ namespace NetworkMidiTest
     // no longer present.
     ServiceConfigResult DisconnectClient(_In_ std::wstring const& entryIdentifier);
 
+    // The "updateEntries" section for an existing client entry. The port count reaches an endpoint
+    // which is already up; the create flag is recorded for the next connection.
+    ServiceConfigResult UpdateClient(
+        _In_ std::wstring const& entryIdentifier,
+        _In_ bool const createMidi1Ports,
+        _In_ uint8_t const fallbackMidi1PortCount);
+
+    // The common "update" array, which renames an endpoint by matching it. Matched on the device
+    // id rather than the name, which is the strongest criterion and the one Matches tries first.
+    ServiceConfigResult RenameEndpoint(
+        _In_ std::wstring const& endpointDeviceId,
+        _In_ std::wstring const& newName);
+
     // The connectDirect command. For an entry which already exists this is the app saying the
     // remote is reachable now, and is the only thing which revives a parked direct connection.
     ServiceConfigResult ConnectDirectClient(

--- a/src/in-box/Test/Midi2.Transport.NetworkMidi2.unittests/pch.h
+++ b/src/in-box/Test/Midi2.Transport.NetworkMidi2.unittests/pch.h
@@ -80,5 +80,6 @@
 #include "NetworkMidiErrorTests.h"
 #include "NetworkMidiMalformedTests.h"
 #include "NetworkMidiClientTests.h"
+#include "NetworkMidiPortCreationTests.h"
 
 #endif //PCH_H

--- a/src/in-box/Test/WinRT Client/Transport.Network.integrationtests/MidiNetworkApiTests.cpp
+++ b/src/in-box/Test/WinRT Client/Transport.Network.integrationtests/MidiNetworkApiTests.cpp
@@ -2163,7 +2163,7 @@ void MidiNetworkApiTests::TestDisconnectRemoteClientWithNullConfigFailsCleanly()
     VERIFY_ARE_EQUAL(MidiNetworkRemoteClientDisconnectErrorCode::InvalidArgument, response.ErrorCode());
 }
 
-void MidiNetworkApiTests::TestDefaultHostConfigCreatesUmpEndpointsOnly()
+void MidiNetworkApiTests::TestDefaultHostConfigCreatesMidi1Ports()
 {
     auto config = MidiNetworkHostCreationConfig::CreateDefault();
 
@@ -2171,11 +2171,17 @@ void MidiNetworkApiTests::TestDefaultHostConfigCreatesUmpEndpointsOnly()
 
     if (config == nullptr) return;
 
-    // UMP endpoints only. The comment above this line in the implementation used to claim the
-    // opposite, which is exactly the sort of thing a caller copies.
-    VERIFY_IS_TRUE(
+    // A default host creates MIDI 1.0 ports for the devices which connect to it, matching what a
+    // client entry already does. Pinned here because it is the difference between a connected
+    // device being usable from an older application and not appearing to it at all.
+    VERIFY_IS_FALSE(
         config.CreateOnlyUmpEndpoints(),
-        L"The default host creates UMP endpoints only; a caller wanting MIDI 1.0 ports clears this.");
+        L"The default host also creates MIDI 1.0 ports; a caller wanting UMP only sets this.");
+
+    VERIFY_ARE_EQUAL(
+        (uint8_t)1,
+        config.FallbackMidi1PortCount(),
+        L"One source and destination pair for a device which never describes itself.");
 }
 
 void MidiNetworkApiTests::TestConnectConfigCustomEndpointNameRoundTrip()

--- a/src/in-box/Test/WinRT Client/Transport.Network.integrationtests/MidiNetworkApiTests.h
+++ b/src/in-box/Test/WinRT Client/Transport.Network.integrationtests/MidiNetworkApiTests.h
@@ -174,7 +174,7 @@ public:
 
     // The default host configuration says what it does. The flag and the comment used to
     // disagree, which is the kind of thing that gets copied into a caller's code.
-    TEST_METHOD(TestDefaultHostConfigCreatesUmpEndpointsOnly);
+    TEST_METHOD(TestDefaultHostConfigCreatesMidi1Ports);
 
     // Config surface which had no coverage at all. These are pure client-side round trips, so
     // they run without the service.

--- a/src/in-box/Transport/UdpNetworkMidi2Transport/Midi2.NetworkMidiConfigurationManager.cpp
+++ b/src/in-box/Transport/UdpNetworkMidi2Transport/Midi2.NetworkMidiConfigurationManager.cpp
@@ -1214,6 +1214,16 @@ CMidi2NetworkMidiConfigurationManager::ProcessEndpointCustomizations(
                     existingEndpointDeviceId.c_str(),
                     static_cast<ULONG>(endpointDevProperties.size()),
                     endpointDevProperties.data()));
+
+                // The name above is the endpoint's. The MIDI 1.0 ports take their names from a
+                // separate table, which nothing here has rewritten, so without this a renamed
+                // device keeps its old port names. The name has to be handed over rather than
+                // read back, because the endpoint does not report it yet. Zero keeps the port
+                // count as it is, because a rename is not a reason to change it.
+                LOG_IF_FAILED(endpointManager->RefreshMidi1PortsForEndpoint(
+                    std::wstring{ existingEndpointDeviceId },
+                    0,
+                    std::wstring{ customProperties->Name }));
             }
         }
 
@@ -2268,6 +2278,156 @@ catch (...)
 
 _Use_decl_annotations_
 HRESULT
+CMidi2NetworkMidiConfigurationManager::ProcessEntryUpdates(
+    json::JsonObject const& updateSection,
+    json::JsonObject& responseObject) noexcept
+try
+{
+    UNREFERENCED_PARAMETER(responseObject);
+
+    auto endpointManager = TransportState::Current().GetEndpointManager();
+
+    // Applies one entry's worth of changes. The count is the only thing which can take effect
+    // without rebuilding the endpoint, so it is the only thing pushed to a live one. Whether an
+    // endpoint has MIDI 1.0 ports at all is fixed when the endpoint is created, so the flag is
+    // recorded for the next connection and nothing is torn down to act on it.
+    auto applyToDefinition = [&endpointManager](
+        json::JsonObject const& entry,
+        bool& createMidi1Ports,
+        uint8_t& fallbackMidi1PortCount,
+        std::vector<std::wstring> const& liveEndpointDeviceIds)
+    {
+        createMidi1Ports = SafeGetNamedBoolean(
+            entry,
+            MIDI_CONFIG_JSON_NETWORK_MIDI_CREATE_MIDI1_PORTS_KEY,
+            createMidi1Ports);
+
+        auto const newCount = SafeGetNamedByte(
+            entry,
+            MIDI_CONFIG_JSON_NETWORK_MIDI_FALLBACK_MIDI1_PORT_COUNT_KEY,
+            fallbackMidi1PortCount,
+            MIDI_NETWORK_MIDI_FALLBACK_MIDI1_PORT_COUNT_MINIMUM,
+            MIDI_NETWORK_MIDI_FALLBACK_MIDI1_PORT_COUNT_MAXIMUM);
+
+        if (newCount == fallbackMidi1PortCount)
+        {
+            return;
+        }
+
+        fallbackMidi1PortCount = newCount;
+
+        if (endpointManager == nullptr)
+        {
+            return;
+        }
+
+        for (auto const& endpointDeviceId : liveEndpointDeviceIds)
+        {
+            if (endpointDeviceId.empty()) continue;
+
+            LOG_IF_FAILED(endpointManager->RefreshMidi1PortsForEndpoint(endpointDeviceId, newCount));
+        }
+    };
+
+    auto hostsObject = SafeGetNamedObject(updateSection, MIDI_CONFIG_JSON_NETWORK_MIDI_HOSTS_KEY);
+
+    if (hostsObject != nullptr && hostsObject.Size() > 0)
+    {
+        for (auto const& it = hostsObject.First(); it.HasCurrent(); it.MoveNext())
+        {
+            winrt::guid entryIdentifier{};
+
+            if (!TryParseEntryIdentifier(it.Current().Key(), entryIdentifier)) continue;
+
+            auto entry = SafeGetNamedObject(hostsObject, it.Current().Key());
+
+            if (entry == nullptr) continue;
+
+            // A host's endpoints belong to the remote clients connected to it, so every one of
+            // them follows the host's setting.
+            std::vector<std::wstring> endpointDeviceIds{};
+
+            for (auto const& connection : TransportState::Current().GetHostConnectionsForHost(entryIdentifier))
+            {
+                if (connection != nullptr)
+                {
+                    endpointDeviceIds.push_back(connection->GetEndpointDeviceId());
+                }
+            }
+
+            for (auto const& definition : TransportState::Current().GetPendingHostDefinitions())
+            {
+                if (definition == nullptr || definition->EntryIdentifier != entryIdentifier) continue;
+
+                applyToDefinition(entry, definition->CreateMidi1Ports, definition->FallbackMidi1PortCount, endpointDeviceIds);
+
+                if (auto host = TransportState::Current().GetHost(entryIdentifier); host != nullptr)
+                {
+                    host->SetFallbackMidi1PortCount(definition->FallbackMidi1PortCount);
+                }
+            }
+        }
+    }
+
+    auto clientsObject = SafeGetNamedObject(updateSection, MIDI_CONFIG_JSON_NETWORK_MIDI_CLIENTS_KEY);
+
+    if (clientsObject != nullptr && clientsObject.Size() > 0)
+    {
+        for (auto const& it = clientsObject.First(); it.HasCurrent(); it.MoveNext())
+        {
+            winrt::guid entryIdentifier{};
+
+            if (!TryParseEntryIdentifier(it.Current().Key(), entryIdentifier)) continue;
+
+            auto entry = SafeGetNamedObject(clientsObject, it.Current().Key());
+
+            if (entry == nullptr) continue;
+
+            std::vector<std::wstring> endpointDeviceIds{};
+
+            for (auto const& connection : TransportState::Current().GetAllNetworkConnectionsForClient(entryIdentifier))
+            {
+                if (connection != nullptr)
+                {
+                    endpointDeviceIds.push_back(connection->GetEndpointDeviceId());
+                }
+            }
+
+            // The pending definitions are what the endpoint creator builds from, and what survives
+            // a reconnect, so they are updated whether or not a connection is up right now.
+            for (auto const& definition : TransportState::Current().GetPendingClientDefinitions())
+            {
+                if (definition == nullptr || definition->EntryIdentifier != entryIdentifier) continue;
+
+                applyToDefinition(entry, definition->CreateMidi1Ports, definition->FallbackMidi1PortCount, endpointDeviceIds);
+
+                if (auto client = TransportState::Current().GetClient(entryIdentifier); client != nullptr)
+                {
+                    client->SetFallbackMidi1PortCount(definition->FallbackMidi1PortCount);
+                }
+            }
+        }
+    }
+
+    return S_OK;
+}
+catch (...)
+{
+    TraceLoggingWrite(
+        MidiNetworkMidiTransportTelemetryProvider::Provider(),
+        MIDI_TRACE_EVENT_ERROR,
+        TraceLoggingString(__FUNCTION__, MIDI_TRACE_EVENT_LOCATION_FIELD),
+        TraceLoggingLevel(WINEVENT_LEVEL_ERROR),
+        TraceLoggingPointer(this, "this"),
+        TraceLoggingWideString(L"Exception processing entry updates", MIDI_TRACE_EVENT_MESSAGE_FIELD)
+    );
+
+    return E_FAIL;
+}
+
+
+_Use_decl_annotations_
+HRESULT
 CMidi2NetworkMidiConfigurationManager::UpdateConfiguration(
     LPCWSTR configurationJsonSection,
     LPWSTR* response
@@ -2338,7 +2498,7 @@ try
     auto transportSettingsSection = SafeGetNamedObject(jsonObject, MIDI_CONFIG_JSON_NETWORK_MIDI_TRANSPORT_SETTINGS_KEY);
 
     auto createSection = SafeGetNamedObject(jsonObject, MIDI_CONFIG_JSON_ENDPOINT_COMMON_CREATE_KEY);
-    auto updateSection = SafeGetNamedObject(jsonObject, MIDI_CONFIG_JSON_ENDPOINT_COMMON_UPDATE_KEY);
+    auto updateSection = SafeGetNamedObject(jsonObject, MIDI_CONFIG_JSON_NETWORK_MIDI_UPDATE_ENTRIES_KEY);
     auto removeSection = SafeGetNamedObject(jsonObject, MIDI_CONFIG_JSON_ENDPOINT_COMMON_REMOVE_KEY);
 
     // Endpoint customization, in the array form every other transport uses. Kept separate from
@@ -2798,8 +2958,10 @@ try
     // "update" entries
     if (updateSection != nullptr && updateSection.Size() > 0)
     {
-        // this needs to allow for activating and deactivating existing entries, as well as setting the endpoint names and
-
+        if (SUCCEEDED(ProcessEntryUpdates(updateSection, responseObject)))
+        {
+            internal::SetConfigurationResponseObjectSuccess(responseObject);
+        }
     }
 
     // "remove" entries

--- a/src/in-box/Transport/UdpNetworkMidi2Transport/Midi2.NetworkMidiConfigurationManager.cpp
+++ b/src/in-box/Transport/UdpNetworkMidi2Transport/Midi2.NetworkMidiConfigurationManager.cpp
@@ -121,6 +121,45 @@ namespace
         }
     }
 
+    // A number outside the permitted range is treated as absent. Config files are hand-edited,
+    // and clamping silently would hide the mistake from whoever wrote it.
+    uint8_t SafeGetNamedByte(
+        _In_ json::JsonObject const& parent,
+        _In_ winrt::hstring const& name,
+        _In_ uint8_t const defaultValue,
+        _In_ uint8_t const minimumValue,
+        _In_ uint8_t const maximumValue) noexcept
+    {
+        try
+        {
+            if (parent == nullptr || !parent.HasKey(name))
+            {
+                return defaultValue;
+            }
+
+            auto value = parent.Lookup(name);
+
+            if (value == nullptr || value.ValueType() != json::JsonValueType::Number)
+            {
+                TraceWrongJsonType(name, L"number");
+                return defaultValue;
+            }
+
+            auto const number = value.GetNumber();
+
+            if (number < minimumValue || number > maximumValue)
+            {
+                return defaultValue;
+            }
+
+            return static_cast<uint8_t>(number);
+        }
+        catch (...)
+        {
+            return defaultValue;
+        }
+    }
+
     json::JsonArray SafeGetNamedArray(_In_ json::JsonObject const& parent, _In_ winrt::hstring const& name) noexcept
     {
         try
@@ -661,6 +700,7 @@ CMidi2NetworkMidiConfigurationManager::RunCommandConnectDirect(
     winrt::hstring const& umpEndpointName,
     winrt::hstring const& customEndpointName,
     bool const createMidi1Ports,
+    uint8_t const fallbackMidi1PortCount,
     json::JsonObject& responseObject) noexcept
 try
 {
@@ -710,6 +750,7 @@ try
     auto clientDefinition = std::make_shared<MidiNetworkClientDefinition>();
 
     clientDefinition->CreateMidi1Ports = createMidi1Ports;
+    clientDefinition->FallbackMidi1PortCount = fallbackMidi1PortCount;
     clientDefinition->EntryIdentifier = configEntryId;
     clientDefinition->MatchDirectHostNameOrIPAddress = remoteAddress;
     clientDefinition->MatchDirectPort = remotePort;
@@ -754,6 +795,7 @@ CMidi2NetworkMidiConfigurationManager::RunCommandConnectMdns(
     winrt::hstring const& umpEndpointName,
     winrt::hstring const& customEndpointName,
     bool const createMidi1Ports,
+    uint8_t const fallbackMidi1PortCount,
     json::JsonObject& responseObject) noexcept
 try
 {
@@ -781,6 +823,7 @@ try
     auto clientDefinition = std::make_shared<MidiNetworkClientDefinition>();
 
     clientDefinition->CreateMidi1Ports = createMidi1Ports;
+    clientDefinition->FallbackMidi1PortCount = fallbackMidi1PortCount;
     clientDefinition->EntryIdentifier = configEntryId;
     clientDefinition->MatchId = matchId;
     clientDefinition->LocalEndpointName = umpEndpointName;
@@ -1201,7 +1244,8 @@ CMidi2NetworkMidiConfigurationManager::ProcessEndpointCustomizations(
 //       "remotePort" : "port number",
 //       "localPort" : "port number",
 //       "endpointDeviceId" : "id of associated ump endpoint",
-//       "createMidi1Ports" : true
+//       "createMidi1Ports" : true,
+//       "fallbackMidi1PortCount" : 1
 //      },
 //     ...
 //   ]
@@ -1257,6 +1301,10 @@ try
         clientObject.SetNamedValue(
             MIDI_CONFIG_JSON_NETWORK_MIDI_ENUM_CLIENTS_RESPONSE_CREATE_MIDI1_PORTS_KEY,
             json::JsonValue::CreateBooleanValue(def->CreateMidi1Ports));
+
+        clientObject.SetNamedValue(
+            MIDI_CONFIG_JSON_NETWORK_MIDI_ENUM_CLIENTS_RESPONSE_FALLBACK_MIDI1_PORT_COUNT_KEY,
+            json::JsonValue::CreateNumberValue(def->FallbackMidi1PortCount));
 
         if (client == nullptr)
         {
@@ -1358,6 +1406,7 @@ catch (...)
 //       "name" : "Advertised Endpoint Name",
 //       "productInstanceId" : "instance id",
 //       "createMidi1Ports" : true,
+//       "fallbackMidi1PortCount" : 1,
 //       "serviceInstanceName" : "foobarbaz"
 //      },
 //     ...
@@ -1481,6 +1530,10 @@ try
         hostObject.SetNamedValue(
             MIDI_CONFIG_JSON_NETWORK_MIDI_ENUM_HOSTS_RESPONSE_CREATE_MIDI1_PORTS_KEY,
             json::JsonValue::CreateBooleanValue(def.CreateMidi1Ports));
+
+        hostObject.SetNamedValue(
+            MIDI_CONFIG_JSON_NETWORK_MIDI_ENUM_HOSTS_RESPONSE_FALLBACK_MIDI1_PORT_COUNT_KEY,
+            json::JsonValue::CreateNumberValue(def.FallbackMidi1PortCount));
 
         hostObject.SetNamedValue(
             MIDI_CONFIG_JSON_NETWORK_MIDI_ENUM_HOSTS_RESPONSE_SERVICE_INSTANCE_NAME_KEY,
@@ -1641,6 +1694,39 @@ namespace
         auto const value = internal::ToLowerTrimmedWStringCopy(arg->second);
 
         return value == L"true" || value == L"1";
+    }
+
+    // Same idea for a numeric argument. Anything the caller cannot have meant, including text
+    // which is not a number at all, falls back to the default rather than to zero.
+    uint8_t OptionalCommandArgumentByte(
+        _In_ internal::MidiTransportCommandHelper& commandHelper,
+        _In_ std::wstring const& key,
+        _In_ uint8_t const defaultValue,
+        _In_ uint8_t const minimumValue,
+        _In_ uint8_t const maximumValue)
+    {
+        auto arg = commandHelper.Arguments()->find(key);
+
+        if (arg == commandHelper.Arguments()->end())
+        {
+            return defaultValue;
+        }
+
+        try
+        {
+            auto const value = std::stoi(internal::TrimmedWStringCopy(arg->second));
+
+            if (value < minimumValue || value > maximumValue)
+            {
+                return defaultValue;
+            }
+
+            return static_cast<uint8_t>(value);
+        }
+        catch (...)
+        {
+            return defaultValue;
+        }
     }
 
     // FILETIME to ISO 8601 UTC, with the full 100ns resolution so the value round-trips. An
@@ -1942,6 +2028,7 @@ try
                 name->second.c_str(),
                 OptionalCommandArgument(commandHelper, MIDI_CONFIG_JSON_NETWORK_MIDI_CUSTOM_ENDPOINT_NAME_KEY),
                 OptionalCommandArgumentBool(commandHelper, MIDI_CONFIG_JSON_NETWORK_MIDI_CREATE_MIDI1_PORTS_KEY, MIDI_NETWORK_MIDI_CREATE_MIDI1_PORTS_DEFAULT),
+                OptionalCommandArgumentByte(commandHelper, MIDI_CONFIG_JSON_NETWORK_MIDI_FALLBACK_MIDI1_PORT_COUNT_KEY, MIDI_NETWORK_MIDI_FALLBACK_MIDI1_PORT_COUNT_DEFAULT, MIDI_NETWORK_MIDI_FALLBACK_MIDI1_PORT_COUNT_MINIMUM, MIDI_NETWORK_MIDI_FALLBACK_MIDI1_PORT_COUNT_MAXIMUM),
                 responseObject));
         }
         else
@@ -1973,6 +2060,7 @@ try
                 name->second.c_str(),
                 OptionalCommandArgument(commandHelper, MIDI_CONFIG_JSON_NETWORK_MIDI_CUSTOM_ENDPOINT_NAME_KEY),
                 OptionalCommandArgumentBool(commandHelper, MIDI_CONFIG_JSON_NETWORK_MIDI_CREATE_MIDI1_PORTS_KEY, MIDI_NETWORK_MIDI_CREATE_MIDI1_PORTS_DEFAULT),
+                OptionalCommandArgumentByte(commandHelper, MIDI_CONFIG_JSON_NETWORK_MIDI_FALLBACK_MIDI1_PORT_COUNT_KEY, MIDI_NETWORK_MIDI_FALLBACK_MIDI1_PORT_COUNT_DEFAULT, MIDI_NETWORK_MIDI_FALLBACK_MIDI1_PORT_COUNT_MINIMUM, MIDI_NETWORK_MIDI_FALLBACK_MIDI1_PORT_COUNT_MAXIMUM),
                 responseObject));
         }
         else
@@ -2416,6 +2504,13 @@ try
 
                 definition->CreateMidi1Ports = SafeGetNamedBoolean(hostEntry, MIDI_CONFIG_JSON_NETWORK_MIDI_CREATE_MIDI1_PORTS_KEY, MIDI_NETWORK_MIDI_CREATE_MIDI1_PORTS_DEFAULT);
 
+                definition->FallbackMidi1PortCount = SafeGetNamedByte(
+                    hostEntry,
+                    MIDI_CONFIG_JSON_NETWORK_MIDI_FALLBACK_MIDI1_PORT_COUNT_KEY,
+                    MIDI_NETWORK_MIDI_FALLBACK_MIDI1_PORT_COUNT_DEFAULT,
+                    MIDI_NETWORK_MIDI_FALLBACK_MIDI1_PORT_COUNT_MINIMUM,
+                    MIDI_NETWORK_MIDI_FALLBACK_MIDI1_PORT_COUNT_MAXIMUM);
+
                 definition->UmpEndpointName = internal::TrimmedHStringCopy(SafeGetNamedString(hostEntry, MIDI_CONFIG_JSON_ENDPOINT_COMMON_NAME_PROPERTY, L""));
                 definition->ProductInstanceId = internal::TrimmedHStringCopy(SafeGetNamedString(hostEntry, MIDI_CONFIG_JSON_NETWORK_MIDI_PRODUCT_INSTANCE_ID_PROPERTY, L""));
 
@@ -2613,6 +2708,13 @@ try
                         clientEntry,
                         MIDI_CONFIG_JSON_NETWORK_MIDI_CREATE_MIDI1_PORTS_KEY,
                         MIDI_NETWORK_MIDI_CREATE_MIDI1_PORTS_DEFAULT);
+
+                    definition->FallbackMidi1PortCount = SafeGetNamedByte(
+                        clientEntry,
+                        MIDI_CONFIG_JSON_NETWORK_MIDI_FALLBACK_MIDI1_PORT_COUNT_KEY,
+                        MIDI_NETWORK_MIDI_FALLBACK_MIDI1_PORT_COUNT_DEFAULT,
+                        MIDI_NETWORK_MIDI_FALLBACK_MIDI1_PORT_COUNT_MINIMUM,
+                        MIDI_NETWORK_MIDI_FALLBACK_MIDI1_PORT_COUNT_MAXIMUM);
 
                     winrt::hstring localEndpointName{ };
                     winrt::hstring localProductInstanceId{ };

--- a/src/in-box/Transport/UdpNetworkMidi2Transport/Midi2.NetworkMidiConfigurationManager.cpp
+++ b/src/in-box/Transport/UdpNetworkMidi2Transport/Midi2.NetworkMidiConfigurationManager.cpp
@@ -1241,6 +1241,132 @@ CMidi2NetworkMidiConfigurationManager::ProcessEndpointCustomizations(
 }
 
 
+_Use_decl_annotations_
+HRESULT
+CMidi2NetworkMidiConfigurationManager::ProcessEndpointCustomizationRemovals(
+    json::JsonObject const& removeSection,
+    json::JsonObject& responseObject) noexcept
+{
+    try
+    {
+        // Same array shape as a customization, carrying only the match
+        auto removeArray = SafeGetNamedArray(removeSection, MIDI_CONFIG_JSON_ENDPOINT_COMMON_UPDATE_KEY);
+
+        if (removeArray == nullptr || removeArray.Size() == 0)
+        {
+            return S_OK;
+        }
+
+        bool anyRemovalAccepted{ false };
+
+        // Indexed for the same reason as the customization loop: windows.h renames
+        // IJsonValue::GetObject, and JsonArray::GetObjectAt is unaffected.
+        for (uint32_t i = 0; i < removeArray.Size(); i++)
+        {
+            auto element = removeArray.GetAt(i);
+
+            // one malformed element should cost its own removal, not every one after it
+            if (element == nullptr || element.ValueType() != json::JsonValueType::Object)
+            {
+                continue;
+            }
+
+            auto entryObject = removeArray.GetObjectAt(i);
+
+            if (entryObject == nullptr)
+            {
+                continue;
+            }
+
+            auto matchObject = SafeGetNamedObject(
+                entryObject, WindowsMidiServicesPluginConfigurationLib::MidiEndpointMatchCriteria::PropertyKey);
+
+            if (matchObject == nullptr)
+            {
+                // nothing to tie this removal to
+                continue;
+            }
+
+            auto matchCriteria = WindowsMidiServicesPluginConfigurationLib::MidiEndpointMatchCriteria::FromJson(matchObject);
+
+            if (matchCriteria == nullptr)
+            {
+                continue;
+            }
+
+            // Every member defaults to the uncustomized value, and writing them sends
+            // DEVPROP_TYPE_EMPTY for each string, which deletes it. Add replaces the entry that
+            // matches, so this both withdraws the cached customization and undoes the applied one.
+            auto clearedProperties =
+                std::make_shared<WindowsMidiServicesPluginConfigurationLib::MidiEndpointCustomProperties>();
+
+            if (clearedProperties == nullptr)
+            {
+                continue;
+            }
+
+            LOG_HR_IF(E_FAIL, !m_customPropertiesCache->Add(matchCriteria, clearedProperties));
+
+            anyRemovalAccepted = true;
+
+            TraceLoggingWrite(
+                MidiNetworkMidiTransportTelemetryProvider::Provider(),
+                MIDI_TRACE_EVENT_INFO,
+                TraceLoggingString(__FUNCTION__, MIDI_TRACE_EVENT_LOCATION_FIELD),
+                TraceLoggingLevel(WINEVENT_LEVEL_INFO),
+                TraceLoggingPointer(this, "this"),
+                TraceLoggingWideString(L"Removed endpoint customization", MIDI_TRACE_EVENT_MESSAGE_FIELD),
+                TraceLoggingWideString(matchCriteria->TransportSuppliedEndpointName.c_str(), "transport supplied name"),
+                TraceLoggingWideString(matchCriteria->DeviceProductInstanceId.c_str(), "product instance id")
+            );
+
+            auto endpointManager = TransportState::Current().GetEndpointManager();
+
+            if (endpointManager == nullptr)
+            {
+                continue;
+            }
+
+            auto existingEndpointDeviceId = endpointManager->FindMatchingInstantiatedEndpoint(*matchCriteria);
+
+            if (existingEndpointDeviceId.empty())
+            {
+                // nothing live to revert, but the cache no longer carries it
+                continue;
+            }
+
+            std::vector<DEVPROPERTY> endpointDevProperties{};
+
+            if (clearedProperties->WriteAllProperties(endpointDevProperties) && endpointDevProperties.size() > 0)
+            {
+                LOG_IF_FAILED(m_midiDeviceManager->UpdateEndpointProperties(
+                    existingEndpointDeviceId.c_str(),
+                    static_cast<ULONG>(endpointDevProperties.size()),
+                    endpointDevProperties.data()));
+
+                // An empty name here means the ports go back to the one the remote supplied,
+                // which the endpoint manager still has on record.
+                LOG_IF_FAILED(endpointManager->RefreshMidi1PortsForEndpoint(
+                    std::wstring{ existingEndpointDeviceId },
+                    0,
+                    std::wstring{ }));
+            }
+        }
+
+        if (anyRemovalAccepted)
+        {
+            internal::SetConfigurationResponseObjectSuccess(responseObject);
+        }
+    }
+    catch (...)
+    {
+        RETURN_IF_FAILED(E_FAIL);
+    }
+
+    return S_OK;
+}
+
+
 //
 // Response Object Payload
 // {
@@ -2967,6 +3093,8 @@ try
     // "remove" entries
     if (removeSection != nullptr && removeSection.Size() > 0)
     {
+        LOG_IF_FAILED(ProcessEndpointCustomizationRemovals(removeSection, responseObject));
+
         // remove a host 
 
 

--- a/src/in-box/Transport/UdpNetworkMidi2Transport/Midi2.NetworkMidiConfigurationManager.h
+++ b/src/in-box/Transport/UdpNetworkMidi2Transport/Midi2.NetworkMidiConfigurationManager.h
@@ -69,6 +69,7 @@ private:
         _In_ winrt::hstring const& umpEndpointName,
         _In_ winrt::hstring const& customEndpointName,
         _In_ bool const createMidi1Ports,
+        _In_ uint8_t const fallbackMidi1PortCount,
         _Inout_ json::JsonObject& responseObject) noexcept;
 
     // Connects to an mDNS-discovered host by its Windows device id. The address and port are
@@ -80,6 +81,7 @@ private:
         _In_ winrt::hstring const& umpEndpointName,
         _In_ winrt::hstring const& customEndpointName,
         _In_ bool const createMidi1Ports,
+        _In_ uint8_t const fallbackMidi1PortCount,
         _Inout_ json::JsonObject& responseObject) noexcept;
 
     HRESULT RunCommandDisconnectClient(

--- a/src/in-box/Transport/UdpNetworkMidi2Transport/Midi2.NetworkMidiConfigurationManager.h
+++ b/src/in-box/Transport/UdpNetworkMidi2Transport/Midi2.NetworkMidiConfigurationManager.h
@@ -39,6 +39,13 @@ private:
         _In_ json::JsonObject const& jsonObject,
         _Inout_ json::JsonObject& responseObject) noexcept;
 
+    // Withdraws a customization, so the endpoint goes back to what the remote calls itself. No
+    // other transport does this yet, and the shared cache has no remove, so a customization with
+    // nothing in it is what replaces the cached one.
+    HRESULT ProcessEndpointCustomizationRemovals(
+        _In_ json::JsonObject const& removeSection,
+        _Inout_ json::JsonObject& responseObject) noexcept;
+
     // Changes to this transport's own host and client entries, keyed by entry identifier. Kept
     // separate from the array-shaped endpoint customization every transport shares.
     HRESULT ProcessEntryUpdates(

--- a/src/in-box/Transport/UdpNetworkMidi2Transport/Midi2.NetworkMidiConfigurationManager.h
+++ b/src/in-box/Transport/UdpNetworkMidi2Transport/Midi2.NetworkMidiConfigurationManager.h
@@ -39,6 +39,12 @@ private:
         _In_ json::JsonObject const& jsonObject,
         _Inout_ json::JsonObject& responseObject) noexcept;
 
+    // Changes to this transport's own host and client entries, keyed by entry identifier. Kept
+    // separate from the array-shaped endpoint customization every transport shares.
+    HRESULT ProcessEntryUpdates(
+        _In_ json::JsonObject const& updateSection,
+        _Inout_ json::JsonObject& responseObject) noexcept;
+
     std::shared_ptr<WindowsMidiServicesPluginConfigurationLib::MidiEndpointCustomPropertiesCache> m_customPropertiesCache{ std::make_shared<WindowsMidiServicesPluginConfigurationLib::MidiEndpointCustomPropertiesCache>() };
 
     HRESULT ProcessCommand(

--- a/src/in-box/Transport/UdpNetworkMidi2Transport/Midi2.NetworkMidiEndpointManager.cpp
+++ b/src/in-box/Transport/UdpNetworkMidi2Transport/Midi2.NetworkMidiEndpointManager.cpp
@@ -1778,8 +1778,10 @@ try
     // gives it something. Function blocks take precedence over this the moment they arrive, so a
     // remote which does describe itself is unaffected.
     //
-    // This has to outlive ActivateEndpoint, because the property below points into it.
+    // This has to outlive ActivateEndpoint, because the property below points into it. The name
+    // table holds its own buffer for the same reason.
     std::vector<std::byte> groupTerminalBlockData{};
+    WindowsMidiServicesNamingLib::MidiEndpointNameTable nameTable{};
 
     if (!umpOnly)
     {
@@ -1793,10 +1795,7 @@ try
             (uint8_t)MIDI_NETWORK_MIDI_FALLBACK_MIDI1_PORT_COUNT_MINIMUM,
             (uint8_t)MIDI_NETWORK_MIDI_FALLBACK_MIDI1_PORT_COUNT_MAXIMUM);
         block.Protocol = 0x11;      // 0x11 = MIDI 2.0
-
-        // Left empty on purpose. The service names the ports from the endpoint when a block has
-        // no name of its own, so a later rename is picked up without rewriting this property.
-        block.Name = L"";
+        block.Name = friendlyName;
 
         std::vector<internal::GroupTerminalBlockInternal> blocks{ block };
 
@@ -1804,6 +1803,19 @@ try
         {
             interfaceDevProperties.push_back({ {PKEY_MIDI_GroupTerminalBlocks, DEVPROP_STORE_SYSTEM, nullptr},
                 DEVPROP_TYPE_BINARY, static_cast<ULONG>(groupTerminalBlockData.size()), (PVOID)groupTerminalBlockData.data() });
+
+            // The names the service gives the ports come from this table, not from the block.
+            //
+            // Every group is named, not just the ones the block above spans. When function blocks
+            // arrive the service rebuilds the table from them, but it reads the table back from a
+            // device snapshot taken before that rebuild, so the names it applies on that pass are
+            // the ones written here. A function block may land on any group, and a group with no
+            // entry yields an empty port name.
+            auto namingBlocks = blocks;
+            namingBlocks.front().GroupCount = MIDI_NETWORK_MIDI_GROUP_COUNT;
+
+            LOG_IF_FAILED(nameTable.PopulateAllEntriesForNativeUmpDevice(L"", namingBlocks));
+            LOG_IF_FAILED(nameTable.WriteProperties(interfaceDevProperties));
         }
         else
         {

--- a/src/in-box/Transport/UdpNetworkMidi2Transport/Midi2.NetworkMidiEndpointManager.cpp
+++ b/src/in-box/Transport/UdpNetworkMidi2Transport/Midi2.NetworkMidiEndpointManager.cpp
@@ -1455,6 +1455,7 @@ CMidi2NetworkMidiEndpointManager::CreateNewHostEndpointToRemoteClient(
     _In_ winrt::Windows::Networking::HostName const& hostName,
     _In_ std::wstring const& networkPort,
     _In_ bool umpOnly,
+    _In_ uint8_t const fallbackMidi1PortCount,
     _Out_ std::wstring& createdNewDeviceInstanceId,
     _Out_ std::wstring& createdNewEndpointDeviceInterfaceId
 )
@@ -1470,6 +1471,7 @@ CMidi2NetworkMidiEndpointManager::CreateNewHostEndpointToRemoteClient(
         hostName,
         networkPort,
         umpOnly,
+        fallbackMidi1PortCount,
         createdNewDeviceInstanceId,
         createdNewEndpointDeviceInterfaceId
     );
@@ -1486,6 +1488,7 @@ CMidi2NetworkMidiEndpointManager::CreateNewClientEndpointToRemoteHost(
     _In_ winrt::Windows::Networking::HostName const& hostName,
     _In_ std::wstring const& networkPort,
     _In_ bool umpOnly,
+    _In_ uint8_t const fallbackMidi1PortCount,
     _Out_ std::wstring& createdNewDeviceInstanceId,
     _Out_ std::wstring& createdNewEndpointDeviceInterfaceId
 )
@@ -1501,6 +1504,7 @@ CMidi2NetworkMidiEndpointManager::CreateNewClientEndpointToRemoteHost(
         hostName,
         networkPort,
         umpOnly,
+        fallbackMidi1PortCount,
         createdNewDeviceInstanceId,
         createdNewEndpointDeviceInterfaceId
     );
@@ -1579,6 +1583,7 @@ CMidi2NetworkMidiEndpointManager::CreateNewEndpoint(
     winrt::Windows::Networking::HostName const& hostName,
     std::wstring const& networkPort,
     bool umpOnly,
+    uint8_t const fallbackMidi1PortCount,
     std::wstring& createdNewDeviceInstanceId,
     std::wstring& createdNewEndpointDeviceInterfaceId
 )
@@ -1764,6 +1769,57 @@ try
 
     interfaceDevProperties.push_back({ {PKEY_MIDI_NetworkMidiConnectionRole, DEVPROP_STORE_SYSTEM, nullptr},
         DEVPROP_TYPE_UINT32, static_cast<ULONG>(sizeof(uint32_t)), (PVOID)&connectionRole });
+
+
+    // A Network MIDI 2.0 endpoint declares function blocks, never group terminal blocks, and the
+    // service builds MIDI 1.0 ports from whichever it finds. A remote which never completes
+    // endpoint discovery declares neither, so the service has nothing to work from and the
+    // endpoint ends up with no MIDI 1.0 ports at all. Publishing a group terminal block up front
+    // gives it something. Function blocks take precedence over this the moment they arrive, so a
+    // remote which does describe itself is unaffected.
+    //
+    // This has to outlive ActivateEndpoint, because the property below points into it.
+    std::vector<std::byte> groupTerminalBlockData{};
+
+    if (!umpOnly)
+    {
+        internal::GroupTerminalBlockInternal block{};
+
+        block.Number = 1;
+        block.Direction = MIDI_GROUP_TERMINAL_BLOCK_BIDIRECTIONAL;
+        block.FirstGroupIndex = 0;
+        block.GroupCount = std::clamp(
+            fallbackMidi1PortCount,
+            (uint8_t)MIDI_NETWORK_MIDI_FALLBACK_MIDI1_PORT_COUNT_MINIMUM,
+            (uint8_t)MIDI_NETWORK_MIDI_FALLBACK_MIDI1_PORT_COUNT_MAXIMUM);
+        block.Protocol = 0x11;      // 0x11 = MIDI 2.0
+
+        // Left empty on purpose. The service names the ports from the endpoint when a block has
+        // no name of its own, so a later rename is picked up without rewriting this property.
+        block.Name = L"";
+
+        std::vector<internal::GroupTerminalBlockInternal> blocks{ block };
+
+        if (internal::WriteGroupTerminalBlocksToPropertyDataPointer(blocks, groupTerminalBlockData))
+        {
+            interfaceDevProperties.push_back({ {PKEY_MIDI_GroupTerminalBlocks, DEVPROP_STORE_SYSTEM, nullptr},
+                DEVPROP_TYPE_BINARY, static_cast<ULONG>(groupTerminalBlockData.size()), (PVOID)groupTerminalBlockData.data() });
+        }
+        else
+        {
+            // Not fatal. The endpoint still works for UMP clients, it just has no MIDI 1.0 ports
+            // until the remote declares function blocks.
+            TraceLoggingWrite(
+                MidiNetworkMidiTransportTelemetryProvider::Provider(),
+                MIDI_TRACE_EVENT_ERROR,
+                TraceLoggingString(__FUNCTION__, MIDI_TRACE_EVENT_LOCATION_FIELD),
+                TraceLoggingLevel(WINEVENT_LEVEL_ERROR),
+                TraceLoggingPointer(this, "this"),
+                TraceLoggingWideString(L"Unable to build the fallback group terminal block", MIDI_TRACE_EVENT_MESSAGE_FIELD),
+                TraceLoggingWideString(instanceId.c_str(), "instance id")
+            );
+        }
+    }
 
 
     std::wstring endpointDescription{ L"Network MIDI 2.0 endpoint "};

--- a/src/in-box/Transport/UdpNetworkMidi2Transport/Midi2.NetworkMidiEndpointManager.cpp
+++ b/src/in-box/Transport/UdpNetworkMidi2Transport/Midi2.NetworkMidiEndpointManager.cpp
@@ -17,6 +17,39 @@ using namespace Microsoft::WRL::Wrappers;
 #define MAX_DEVICE_ID_LEN 200 // size in chars
 
 
+namespace
+{
+    uint8_t ClampFallbackMidi1PortCount(_In_ uint8_t const value) noexcept
+    {
+        return std::clamp(
+            value,
+            (uint8_t)MIDI_NETWORK_MIDI_FALLBACK_MIDI1_PORT_COUNT_MINIMUM,
+            (uint8_t)MIDI_NETWORK_MIDI_FALLBACK_MIDI1_PORT_COUNT_MAXIMUM);
+    }
+
+    // A group terminal block descriptor cannot hold a longer string, and the name originates with
+    // the remote. Truncating keeps the ports, where refusing the write would leave the endpoint
+    // with none at all.
+    std::wstring BoundBlockName(_In_ std::wstring const& name) noexcept
+    {
+        if (name.length() <= MAX_DESCRIPTOR_STRING_LENGTH)
+        {
+            return name;
+        }
+
+        auto bounded = name.substr(0, MAX_DESCRIPTOR_STRING_LENGTH);
+
+        // never leave a lead surrogate without its trail
+        if (!bounded.empty() && IS_HIGH_SURROGATE(bounded.back()))
+        {
+            bounded.pop_back();
+        }
+
+        return bounded;
+    }
+}
+
+
 _Use_decl_annotations_
 HRESULT
 CMidi2NetworkMidiEndpointManager::Initialize(
@@ -1895,7 +1928,8 @@ try
             winrt::hstring{ createdNewEndpointDeviceInterfaceId },
             winrt::hstring{ createdNewDeviceInstanceId },
             winrt::hstring{ endpointName },
-            winrt::hstring{ remoteEndpointProductInstanceId } });
+            winrt::hstring{ remoteEndpointProductInstanceId },
+            umpOnly ? (uint8_t)0 : ClampFallbackMidi1PortCount(fallbackMidi1PortCount) });
     }
 
     // Everything the node could not be created with. A network endpoint is never live when its
@@ -1936,6 +1970,7 @@ CMidi2NetworkMidiEndpointManager::BuildFallbackMidi1PortProperties(
     std::vector<std::byte>& groupTerminalBlockData,
     WindowsMidiServicesNamingLib::MidiEndpointNameTable& nameTable,
     std::vector<DEVPROPERTY>& properties)
+try
 {
     // A Network MIDI 2.0 endpoint declares function blocks, never group terminal blocks, and the
     // service builds MIDI 1.0 ports from whichever it finds. A remote which never completes
@@ -1948,12 +1983,12 @@ CMidi2NetworkMidiEndpointManager::BuildFallbackMidi1PortProperties(
     block.Number = 1;
     block.Direction = MIDI_GROUP_TERMINAL_BLOCK_BIDIRECTIONAL;
     block.FirstGroupIndex = 0;
-    block.GroupCount = std::clamp(
-        fallbackMidi1PortCount,
-        (uint8_t)MIDI_NETWORK_MIDI_FALLBACK_MIDI1_PORT_COUNT_MINIMUM,
-        (uint8_t)MIDI_NETWORK_MIDI_FALLBACK_MIDI1_PORT_COUNT_MAXIMUM);
+    block.GroupCount = ClampFallbackMidi1PortCount(fallbackMidi1PortCount);
     block.Protocol = 0x11;      // 0x11 = MIDI 2.0
-    block.Name = portName;
+
+    // The remote chooses this name, and a name too long for a block descriptor would otherwise
+    // make the write fail and leave the endpoint with no MIDI 1.0 ports at all.
+    block.Name = BoundBlockName(portName);
 
     std::vector<internal::GroupTerminalBlockInternal> blocks{ block };
 
@@ -1977,10 +2012,14 @@ CMidi2NetworkMidiEndpointManager::BuildFallbackMidi1PortProperties(
     // legacy WinMM form puts in its parentheses, and leaving it out gives "MIDIIN2 ()" for every
     // group past the first. The naming library strips the block name when it repeats the parent,
     // so the new style name does not end up doubled.
-    RETURN_IF_FAILED(nameTable.PopulateAllEntriesForNativeUmpDevice(portName, namingBlocks));
+    RETURN_IF_FAILED(nameTable.PopulateAllEntriesForNativeUmpDevice(block.Name, namingBlocks));
     RETURN_IF_FAILED(nameTable.WriteProperties(properties));
 
     return S_OK;
+}
+catch (...)
+{
+    RETURN_CAUGHT_EXCEPTION();
 }
 
 
@@ -1990,6 +2029,7 @@ CMidi2NetworkMidiEndpointManager::RefreshMidi1PortsForEndpoint(
     std::wstring const& endpointDeviceInterfaceId,
     uint8_t const fallbackMidi1PortCount,
     std::optional<std::wstring> const& portNameOverride)
+try
 {
     TraceLoggingWrite(
         MidiNetworkMidiTransportTelemetryProvider::Provider(),
@@ -2004,72 +2044,13 @@ CMidi2NetworkMidiEndpointManager::RefreshMidi1PortsForEndpoint(
     RETURN_HR_IF(E_INVALIDARG, endpointDeviceInterfaceId.empty());
     RETURN_HR_IF_NULL(E_UNEXPECTED, m_midiDeviceManager);
 
-    // Without an override the device's own name is the current effective one. With one, the
-    // caller has just written a name the device does not report back yet. The existing block
-    // comes back in the same read: its width is what a rename keeps, and its absence means this
-    // endpoint was built UMP-only and has no MIDI 1.0 ports to rebuild.
-    std::wstring portName{ portNameOverride.value_or(std::wstring{ }) };
-    uint8_t currentGroupCount{ 0 };
+    // What this transport built the endpoint from. Taken from the record rather than read back
+    // out of the group terminal block property, because that means trusting a length-prefixed
+    // blob to walk correctly. A count of zero means the endpoint was built UMP-only and has no
+    // MIDI 1.0 ports to rebuild.
+    std::wstring recordName{ };
+    uint8_t recordCount{ 0 };
 
-    try
-    {
-        auto additionalProperties = winrt::single_threaded_vector<winrt::hstring>();
-        additionalProperties.Append(STRING_PKEY_MIDI_GroupTerminalBlocks);
-        additionalProperties.Append(STRING_PKEY_MIDI_CustomEndpointName);
-
-        auto deviceInfo = winrt::Windows::Devices::Enumeration::DeviceInformation::CreateFromIdAsync(
-            winrt::hstring{ endpointDeviceInterfaceId },
-            additionalProperties,
-            winrt::Windows::Devices::Enumeration::DeviceInformationKind::DeviceInterface).get();
-
-        if (deviceInfo != nullptr)
-        {
-            if (!portNameOverride.has_value())
-            {
-                // A custom name is applied at enumeration and never reaches the device interface
-                // name, which keeps reporting whatever the remote supplied. Reading the name here
-                // instead of the property would quietly undo a rename.
-                auto customName = deviceInfo.Properties().TryLookup(STRING_PKEY_MIDI_CustomEndpointName);
-
-                if (customName != nullptr)
-                {
-                    portName = winrt::unbox_value_or<winrt::hstring>(customName, L"");
-                }
-
-                if (portName.empty())
-                {
-                    portName = deviceInfo.Name();
-                }
-            }
-
-            auto property = deviceInfo.Properties().TryLookup(STRING_PKEY_MIDI_GroupTerminalBlocks);
-
-            if (property != nullptr)
-            {
-                auto referenceArray = winrt::unbox_value_or<winrt::Windows::Foundation::IReferenceArray<uint8_t>>(property, nullptr);
-
-                if (referenceArray != nullptr)
-                {
-                    auto data = referenceArray.Value();
-
-                    auto const blocks = internal::ReadGroupTerminalBlocksFromPropertyData(
-                        data.data(),
-                        static_cast<uint32_t>(data.size()));
-
-                    if (!blocks.empty())
-                    {
-                        currentGroupCount = blocks.front().GroupCount;
-                    }
-                }
-            }
-        }
-    }
-    CATCH_LOG();
-
-    // No block means no MIDI 1.0 ports were ever built for this endpoint
-    RETURN_HR_IF(S_FALSE, currentGroupCount == 0);
-
-    if (portName.empty())
     {
         auto lock = m_createdEndpointsLock.lock();
 
@@ -2084,13 +2065,56 @@ CMidi2NetworkMidiEndpointManager::RefreshMidi1PortsForEndpoint(
 
         RETURN_HR_IF(S_FALSE, record == m_createdEndpoints.end());
 
-        portName = record->TransportSuppliedEndpointName;
+        recordName = record->TransportSuppliedEndpointName;
+        recordCount = record->FallbackMidi1PortCount;
+    }
+
+    RETURN_HR_IF(S_FALSE, recordCount == 0);
+
+    // Without an override the current effective name has to be resolved. With one, the caller has
+    // just written a name the device does not report back yet, and an empty one means the
+    // customization was withdrawn, so the remote's own name applies again.
+    std::wstring portName{ portNameOverride.value_or(std::wstring{ }) };
+
+    if (!portNameOverride.has_value())
+    {
+        try
+        {
+            auto additionalProperties = winrt::single_threaded_vector<winrt::hstring>();
+            additionalProperties.Append(STRING_PKEY_MIDI_CustomEndpointName);
+
+            auto deviceInfo = winrt::Windows::Devices::Enumeration::DeviceInformation::CreateFromIdAsync(
+                winrt::hstring{ endpointDeviceInterfaceId },
+                additionalProperties,
+                winrt::Windows::Devices::Enumeration::DeviceInformationKind::DeviceInterface).get();
+
+            if (deviceInfo != nullptr)
+            {
+                // A custom name is applied at enumeration and never reaches the device interface
+                // name, which keeps reporting whatever the remote supplied. Reading the name here
+                // instead of the property would quietly undo a rename.
+                auto customName = deviceInfo.Properties().TryLookup(STRING_PKEY_MIDI_CustomEndpointName);
+
+                if (customName != nullptr)
+                {
+                    portName = winrt::unbox_value_or<winrt::hstring>(customName, L"");
+                }
+            }
+        }
+        CATCH_LOG();
+    }
+
+    if (portName.empty())
+    {
+        portName = recordName;
     }
 
     RETURN_HR_IF(S_FALSE, portName.empty());
 
     // Zero is a rename asking to keep the width it already has
-    auto const effectiveCount = fallbackMidi1PortCount == 0 ? currentGroupCount : fallbackMidi1PortCount;
+    auto const effectiveCount = fallbackMidi1PortCount == 0
+        ? recordCount
+        : ClampFallbackMidi1PortCount(fallbackMidi1PortCount);
 
     std::vector<std::byte> groupTerminalBlockData{ };
     WindowsMidiServicesNamingLib::MidiEndpointNameTable nameTable{ };
@@ -2120,6 +2144,10 @@ CMidi2NetworkMidiEndpointManager::RefreshMidi1PortsForEndpoint(
     );
 
     return S_OK;
+}
+catch (...)
+{
+    RETURN_CAUGHT_EXCEPTION();
 }
 
 

--- a/src/in-box/Transport/UdpNetworkMidi2Transport/Midi2.NetworkMidiEndpointManager.cpp
+++ b/src/in-box/Transport/UdpNetworkMidi2Transport/Midi2.NetworkMidiEndpointManager.cpp
@@ -1785,52 +1785,12 @@ try
 
     if (!umpOnly)
     {
-        internal::GroupTerminalBlockInternal block{};
-
-        block.Number = 1;
-        block.Direction = MIDI_GROUP_TERMINAL_BLOCK_BIDIRECTIONAL;
-        block.FirstGroupIndex = 0;
-        block.GroupCount = std::clamp(
+        LOG_IF_FAILED(BuildFallbackMidi1PortProperties(
+            friendlyName,
             fallbackMidi1PortCount,
-            (uint8_t)MIDI_NETWORK_MIDI_FALLBACK_MIDI1_PORT_COUNT_MINIMUM,
-            (uint8_t)MIDI_NETWORK_MIDI_FALLBACK_MIDI1_PORT_COUNT_MAXIMUM);
-        block.Protocol = 0x11;      // 0x11 = MIDI 2.0
-        block.Name = friendlyName;
-
-        std::vector<internal::GroupTerminalBlockInternal> blocks{ block };
-
-        if (internal::WriteGroupTerminalBlocksToPropertyDataPointer(blocks, groupTerminalBlockData))
-        {
-            interfaceDevProperties.push_back({ {PKEY_MIDI_GroupTerminalBlocks, DEVPROP_STORE_SYSTEM, nullptr},
-                DEVPROP_TYPE_BINARY, static_cast<ULONG>(groupTerminalBlockData.size()), (PVOID)groupTerminalBlockData.data() });
-
-            // The names the service gives the ports come from this table, not from the block.
-            //
-            // Every group is named, not just the ones the block above spans. When function blocks
-            // arrive the service rebuilds the table from them, but it reads the table back from a
-            // device snapshot taken before that rebuild, so the names it applies on that pass are
-            // the ones written here. A function block may land on any group, and a group with no
-            // entry yields an empty port name.
-            auto namingBlocks = blocks;
-            namingBlocks.front().GroupCount = MIDI_NETWORK_MIDI_GROUP_COUNT;
-
-            LOG_IF_FAILED(nameTable.PopulateAllEntriesForNativeUmpDevice(L"", namingBlocks));
-            LOG_IF_FAILED(nameTable.WriteProperties(interfaceDevProperties));
-        }
-        else
-        {
-            // Not fatal. The endpoint still works for UMP clients, it just has no MIDI 1.0 ports
-            // until the remote declares function blocks.
-            TraceLoggingWrite(
-                MidiNetworkMidiTransportTelemetryProvider::Provider(),
-                MIDI_TRACE_EVENT_ERROR,
-                TraceLoggingString(__FUNCTION__, MIDI_TRACE_EVENT_LOCATION_FIELD),
-                TraceLoggingLevel(WINEVENT_LEVEL_ERROR),
-                TraceLoggingPointer(this, "this"),
-                TraceLoggingWideString(L"Unable to build the fallback group terminal block", MIDI_TRACE_EVENT_MESSAGE_FIELD),
-                TraceLoggingWideString(instanceId.c_str(), "instance id")
-            );
-        }
+            groupTerminalBlockData,
+            nameTable,
+            interfaceDevProperties));
     }
 
 
@@ -1966,6 +1926,201 @@ try
     return S_OK;
 }
 CATCH_RETURN()
+
+
+_Use_decl_annotations_
+HRESULT
+CMidi2NetworkMidiEndpointManager::BuildFallbackMidi1PortProperties(
+    std::wstring const& portName,
+    uint8_t const fallbackMidi1PortCount,
+    std::vector<std::byte>& groupTerminalBlockData,
+    WindowsMidiServicesNamingLib::MidiEndpointNameTable& nameTable,
+    std::vector<DEVPROPERTY>& properties)
+{
+    // A Network MIDI 2.0 endpoint declares function blocks, never group terminal blocks, and the
+    // service builds MIDI 1.0 ports from whichever it finds. A remote which never completes
+    // endpoint discovery declares neither, so the service has nothing to work from and the
+    // endpoint ends up with no MIDI 1.0 ports at all. Publishing a group terminal block gives it
+    // something. Function blocks take precedence the moment they arrive, so a remote which does
+    // describe itself is unaffected.
+    internal::GroupTerminalBlockInternal block{};
+
+    block.Number = 1;
+    block.Direction = MIDI_GROUP_TERMINAL_BLOCK_BIDIRECTIONAL;
+    block.FirstGroupIndex = 0;
+    block.GroupCount = std::clamp(
+        fallbackMidi1PortCount,
+        (uint8_t)MIDI_NETWORK_MIDI_FALLBACK_MIDI1_PORT_COUNT_MINIMUM,
+        (uint8_t)MIDI_NETWORK_MIDI_FALLBACK_MIDI1_PORT_COUNT_MAXIMUM);
+    block.Protocol = 0x11;      // 0x11 = MIDI 2.0
+    block.Name = portName;
+
+    std::vector<internal::GroupTerminalBlockInternal> blocks{ block };
+
+    groupTerminalBlockData.clear();
+
+    RETURN_HR_IF(E_FAIL, !internal::WriteGroupTerminalBlocksToPropertyDataPointer(blocks, groupTerminalBlockData));
+
+    properties.push_back({ {PKEY_MIDI_GroupTerminalBlocks, DEVPROP_STORE_SYSTEM, nullptr},
+        DEVPROP_TYPE_BINARY, static_cast<ULONG>(groupTerminalBlockData.size()), (PVOID)groupTerminalBlockData.data() });
+
+    // The names the service gives the ports come from this table, not from the block.
+    //
+    // Every group is named, not just the ones the block above spans. When function blocks arrive
+    // the service rebuilds the table from them, but it reads the table back from a device snapshot
+    // taken before that rebuild, so the names it applies on that pass are the ones written here. A
+    // function block may land on any group, and a group with no entry yields an empty port name.
+    auto namingBlocks = blocks;
+    namingBlocks.front().GroupCount = MIDI_NETWORK_MIDI_GROUP_COUNT;
+
+    // The endpoint name is passed as the parent as well as being the block name. It is what the
+    // legacy WinMM form puts in its parentheses, and leaving it out gives "MIDIIN2 ()" for every
+    // group past the first. The naming library strips the block name when it repeats the parent,
+    // so the new style name does not end up doubled.
+    RETURN_IF_FAILED(nameTable.PopulateAllEntriesForNativeUmpDevice(portName, namingBlocks));
+    RETURN_IF_FAILED(nameTable.WriteProperties(properties));
+
+    return S_OK;
+}
+
+
+_Use_decl_annotations_
+HRESULT
+CMidi2NetworkMidiEndpointManager::RefreshMidi1PortsForEndpoint(
+    std::wstring const& endpointDeviceInterfaceId,
+    uint8_t const fallbackMidi1PortCount,
+    std::optional<std::wstring> const& portNameOverride)
+{
+    TraceLoggingWrite(
+        MidiNetworkMidiTransportTelemetryProvider::Provider(),
+        MIDI_TRACE_EVENT_INFO,
+        TraceLoggingString(__FUNCTION__, MIDI_TRACE_EVENT_LOCATION_FIELD),
+        TraceLoggingLevel(WINEVENT_LEVEL_INFO),
+        TraceLoggingPointer(this, "this"),
+        TraceLoggingWideString(L"Enter", MIDI_TRACE_EVENT_MESSAGE_FIELD),
+        TraceLoggingWideString(endpointDeviceInterfaceId.c_str(), MIDI_TRACE_EVENT_DEVICE_SWD_ID_FIELD)
+    );
+
+    RETURN_HR_IF(E_INVALIDARG, endpointDeviceInterfaceId.empty());
+    RETURN_HR_IF_NULL(E_UNEXPECTED, m_midiDeviceManager);
+
+    // Without an override the device's own name is the current effective one. With one, the
+    // caller has just written a name the device does not report back yet. The existing block
+    // comes back in the same read: its width is what a rename keeps, and its absence means this
+    // endpoint was built UMP-only and has no MIDI 1.0 ports to rebuild.
+    std::wstring portName{ portNameOverride.value_or(std::wstring{ }) };
+    uint8_t currentGroupCount{ 0 };
+
+    try
+    {
+        auto additionalProperties = winrt::single_threaded_vector<winrt::hstring>();
+        additionalProperties.Append(STRING_PKEY_MIDI_GroupTerminalBlocks);
+        additionalProperties.Append(STRING_PKEY_MIDI_CustomEndpointName);
+
+        auto deviceInfo = winrt::Windows::Devices::Enumeration::DeviceInformation::CreateFromIdAsync(
+            winrt::hstring{ endpointDeviceInterfaceId },
+            additionalProperties,
+            winrt::Windows::Devices::Enumeration::DeviceInformationKind::DeviceInterface).get();
+
+        if (deviceInfo != nullptr)
+        {
+            if (!portNameOverride.has_value())
+            {
+                // A custom name is applied at enumeration and never reaches the device interface
+                // name, which keeps reporting whatever the remote supplied. Reading the name here
+                // instead of the property would quietly undo a rename.
+                auto customName = deviceInfo.Properties().TryLookup(STRING_PKEY_MIDI_CustomEndpointName);
+
+                if (customName != nullptr)
+                {
+                    portName = winrt::unbox_value_or<winrt::hstring>(customName, L"");
+                }
+
+                if (portName.empty())
+                {
+                    portName = deviceInfo.Name();
+                }
+            }
+
+            auto property = deviceInfo.Properties().TryLookup(STRING_PKEY_MIDI_GroupTerminalBlocks);
+
+            if (property != nullptr)
+            {
+                auto referenceArray = winrt::unbox_value_or<winrt::Windows::Foundation::IReferenceArray<uint8_t>>(property, nullptr);
+
+                if (referenceArray != nullptr)
+                {
+                    auto data = referenceArray.Value();
+
+                    auto const blocks = internal::ReadGroupTerminalBlocksFromPropertyData(
+                        data.data(),
+                        static_cast<uint32_t>(data.size()));
+
+                    if (!blocks.empty())
+                    {
+                        currentGroupCount = blocks.front().GroupCount;
+                    }
+                }
+            }
+        }
+    }
+    CATCH_LOG();
+
+    // No block means no MIDI 1.0 ports were ever built for this endpoint
+    RETURN_HR_IF(S_FALSE, currentGroupCount == 0);
+
+    if (portName.empty())
+    {
+        auto lock = m_createdEndpointsLock.lock();
+
+        auto const record = std::find_if(
+            m_createdEndpoints.begin(),
+            m_createdEndpoints.end(),
+            [&endpointDeviceInterfaceId](CreatedEndpointRecord const& entry)
+            {
+                return internal::NormalizeEndpointInterfaceIdWStringCopy(std::wstring{ entry.EndpointDeviceId }) ==
+                    internal::NormalizeEndpointInterfaceIdWStringCopy(endpointDeviceInterfaceId);
+            });
+
+        RETURN_HR_IF(S_FALSE, record == m_createdEndpoints.end());
+
+        portName = record->TransportSuppliedEndpointName;
+    }
+
+    RETURN_HR_IF(S_FALSE, portName.empty());
+
+    // Zero is a rename asking to keep the width it already has
+    auto const effectiveCount = fallbackMidi1PortCount == 0 ? currentGroupCount : fallbackMidi1PortCount;
+
+    std::vector<std::byte> groupTerminalBlockData{ };
+    WindowsMidiServicesNamingLib::MidiEndpointNameTable nameTable{ };
+    std::vector<DEVPROPERTY> properties{ };
+
+    RETURN_IF_FAILED(BuildFallbackMidi1PortProperties(
+        portName,
+        effectiveCount,
+        groupTerminalBlockData,
+        nameTable,
+        properties));
+
+    RETURN_IF_FAILED(m_midiDeviceManager->UpdateEndpointProperties(
+        endpointDeviceInterfaceId.c_str(),
+        static_cast<ULONG>(properties.size()),
+        properties.data()));
+
+    TraceLoggingWrite(
+        MidiNetworkMidiTransportTelemetryProvider::Provider(),
+        MIDI_TRACE_EVENT_INFO,
+        TraceLoggingString(__FUNCTION__, MIDI_TRACE_EVENT_LOCATION_FIELD),
+        TraceLoggingLevel(WINEVENT_LEVEL_INFO),
+        TraceLoggingPointer(this, "this"),
+        TraceLoggingWideString(L"Rebuilt the fallback MIDI 1.0 port properties", MIDI_TRACE_EVENT_MESSAGE_FIELD),
+        TraceLoggingWideString(endpointDeviceInterfaceId.c_str(), MIDI_TRACE_EVENT_DEVICE_SWD_ID_FIELD),
+        TraceLoggingUInt8(effectiveCount, "fallback port count")
+    );
+
+    return S_OK;
+}
 
 
 _Use_decl_annotations_

--- a/src/in-box/Transport/UdpNetworkMidi2Transport/Midi2.NetworkMidiEndpointManager.h
+++ b/src/in-box/Transport/UdpNetworkMidi2Transport/Midi2.NetworkMidiEndpointManager.h
@@ -43,6 +43,7 @@ public:
         _In_ winrt::Windows::Networking::HostName const& hostName,
         _In_ std::wstring const& networkPort,
         _In_ bool umpOnly,
+        _In_ uint8_t const fallbackMidi1PortCount,
         _Out_ std::wstring& createdNewDeviceInstanceId,
         _Out_ std::wstring& createdNewEndpointDeviceInterfaceId
     ));
@@ -55,6 +56,7 @@ public:
         _In_ winrt::Windows::Networking::HostName const& hostName,
         _In_ std::wstring const& networkPort,
         _In_ bool umpOnly,
+        _In_ uint8_t const fallbackMidi1PortCount,
         _Out_ std::wstring& createdNewDeviceInstanceId,
         _Out_ std::wstring& createdNewEndpointDeviceInterfaceId
     ));
@@ -112,6 +114,7 @@ private:
         _In_ winrt::Windows::Networking::HostName const& hostName,
         _In_ std::wstring const& networkPort,
         _In_ bool umpOnly,
+        _In_ uint8_t const fallbackMidi1PortCount,
         _Out_ std::wstring& createdNewDeviceInstanceId,
         _Out_ std::wstring& createdNewEndpointDeviceInterfaceId
     ));

--- a/src/in-box/Transport/UdpNetworkMidi2Transport/Midi2.NetworkMidiEndpointManager.h
+++ b/src/in-box/Transport/UdpNetworkMidi2Transport/Midi2.NetworkMidiEndpointManager.h
@@ -165,6 +165,11 @@ private:
         winrt::hstring DeviceInstanceId;
         winrt::hstring TransportSuppliedEndpointName;
         winrt::hstring ProductInstanceId;
+
+        // Groups the fallback block spans, so a refresh can keep the width without reading the
+        // block back out of the device store. Zero means the endpoint was built UMP-only and has
+        // no MIDI 1.0 ports to rebuild.
+        uint8_t FallbackMidi1PortCount{ 0 };
     };
 
     wil::critical_section m_createdEndpointsLock;

--- a/src/in-box/Transport/UdpNetworkMidi2Transport/Midi2.NetworkMidiEndpointManager.h
+++ b/src/in-box/Transport/UdpNetworkMidi2Transport/Midi2.NetworkMidiEndpointManager.h
@@ -69,6 +69,23 @@ public:
     winrt::hstring FindMatchingInstantiatedEndpoint(
         _In_ WindowsMidiServicesPluginConfigurationLib::MidiEndpointMatchCriteria& criteria);
 
+    // Rewrites the fallback group terminal block and the MIDI 1.0 port name table for an endpoint
+    // which is already up. Both properties are ones the service watches, so writing them is what
+    // makes it re-sync the MIDI 1.0 ports: a changed port count takes effect, and a renamed
+    // endpoint carries its new name down to its ports, without the connection being torn down.
+    //
+    // Pass zero for the count to keep whatever the endpoint already spans, which is what a rename
+    // wants. Does nothing for an endpoint with no block, which is how a UMP-only one is told
+    // apart without having to find the entry it came from.
+    //
+    // A caller which is applying a customization has to pass the name, because the endpoint's own
+    // name does not reflect a custom name that was only just written. An empty string means the
+    // custom name was cleared, so the device's own name is used again.
+    HRESULT RefreshMidi1PortsForEndpoint(
+        _In_ std::wstring const& endpointDeviceInterfaceId,
+        _In_ uint8_t const fallbackMidi1PortCount,
+        _In_ std::optional<std::wstring> const& portNameOverride = std::nullopt);
+
     STDMETHOD(StartRemoteHostWatcher)();
     STDMETHOD(StartBackgroundEndpointCreator)();
     STDMETHOD(StartBackgroundConnectionShutdown)();
@@ -118,6 +135,16 @@ private:
         _Out_ std::wstring& createdNewDeviceInstanceId,
         _Out_ std::wstring& createdNewEndpointDeviceInterfaceId
     ));
+
+    // Shared by endpoint creation and the live refresh, so both produce the same blocks. The two
+    // buffers are owned by the caller because the property entries point into them and must stay
+    // valid until the device manager call returns.
+    HRESULT BuildFallbackMidi1PortProperties(
+        _In_ std::wstring const& portName,
+        _In_ uint8_t const fallbackMidi1PortCount,
+        _Inout_ std::vector<std::byte>& groupTerminalBlockData,
+        _Inout_ WindowsMidiServicesNamingLib::MidiEndpointNameTable& nameTable,
+        _Inout_ std::vector<DEVPROPERTY>& properties);
 
     ::WindowsMidiServicesInternal::MidiDnssdBrowser m_browser;
 

--- a/src/in-box/Transport/UdpNetworkMidi2Transport/Midi2.NetworkMidiTransport.rc
+++ b/src/in-box/Transport/UdpNetworkMidi2Transport/Midi2.NetworkMidiTransport.rc
@@ -53,8 +53,8 @@ END
 //
 
 VS_VERSION_INFO VERSIONINFO
- FILEVERSION 1,0,0,3
- PRODUCTVERSION 1,0,0,3
+ FILEVERSION 1,0,0,4
+ PRODUCTVERSION 1,0,0,4
  FILEFLAGSMASK VS_FFI_FILEFLAGSMASK
 #ifdef _DEBUG
  FILEFLAGS VS_FF_DEBUG
@@ -75,8 +75,8 @@ BEGIN
             VALUE "InternalName", "Midi2.NetworkMidiTransport.dll"
             VALUE "OriginalFilename", "Midi2.NetworkMidiTransport.dll"
             VALUE "ProductName", "Windows MIDI Services"
-            VALUE "FileVersion", "1.0.0.3"
-            VALUE "ProductVersion", "1.0.0.3"
+            VALUE "FileVersion", "1.0.0.4"
+            VALUE "ProductVersion", "1.0.0.4"
             VALUE "OLESelfRegister", ""
         END
     END
@@ -95,7 +95,7 @@ STRINGTABLE
 BEGIN
     IDS_PROJNAME                    "Midi2.NetworkMidiTransport"
 
-    IDS_PLUGIN_METADATA_VERSION         "1.0.0.3"
+    IDS_PLUGIN_METADATA_VERSION         "1.0.0.4"
     IDS_PLUGIN_METADATA_NAME            "Network MIDI 2.0 (UDP)"
     IDS_PLUGIN_METADATA_DESCRIPTION     "Provides host and client Network MIDI 2.0 (UDP) capabilities"
     IDS_PLUGIN_METADATA_AUTHOR          "Microsoft"

--- a/src/in-box/Transport/UdpNetworkMidi2Transport/MidiNetworkClient.cpp
+++ b/src/in-box/Transport/UdpNetworkMidi2Transport/MidiNetworkClient.cpp
@@ -30,6 +30,7 @@ MidiNetworkClient::Initialize(
 
 
     m_createUmpEndpointsOnly = !clientDefinition.CreateMidi1Ports;
+    m_fallbackMidi1PortCount = clientDefinition.FallbackMidi1PortCount;
 
     m_thisEndpointName = clientDefinition.LocalEndpointName;
     m_thisProductInstanceId = clientDefinition.LocalProductInstanceId;
@@ -244,7 +245,8 @@ MidiNetworkClient::Start(
         m_thisProductInstanceId,
         TransportState::Current().TransportSettings.RetransmitBufferMaxCommandPacketCount,
         TransportState::Current().TransportSettings.ForwardErrorCorrectionMaxCommandPacketCount,
-        m_createUmpEndpointsOnly
+        m_createUmpEndpointsOnly,
+        m_fallbackMidi1PortCount
     ));
 
     TransportState::Current().AddNetworkConnection(remoteHostName, remotePort, conn);

--- a/src/in-box/Transport/UdpNetworkMidi2Transport/MidiNetworkClient.h
+++ b/src/in-box/Transport/UdpNetworkMidi2Transport/MidiNetworkClient.h
@@ -83,6 +83,10 @@ public:
 
     MidiNetworkClientDefinition GetDefinition() { return m_clientDefinition; }
 
+    // Used the next time this client builds a connection. An endpoint already up is updated in
+    // place by the configuration manager.
+    void SetFallbackMidi1PortCount(_In_ uint8_t const value) noexcept { m_fallbackMidi1PortCount = value; }
+
     winrt::hstring RemoteAddress() { auto socket = GetSocket(); return socket != nullptr ? socket.Information().RemoteAddress().DisplayName() : L""; }
     winrt::hstring RemotePort() { auto socket = GetSocket(); return socket != nullptr ? socket.Information().RemotePort() : L""; }
 

--- a/src/in-box/Transport/UdpNetworkMidi2Transport/MidiNetworkClient.h
+++ b/src/in-box/Transport/UdpNetworkMidi2Transport/MidiNetworkClient.h
@@ -28,6 +28,9 @@ struct MidiNetworkClientDefinition
 
     bool CreateMidi1Ports{ MIDI_NETWORK_MIDI_CREATE_MIDI1_PORTS_DEFAULT };
 
+    // Only used when the remote declares no function blocks. See the constant for why.
+    uint8_t FallbackMidi1PortCount{ MIDI_NETWORK_MIDI_FALLBACK_MIDI1_PORT_COUNT_DEFAULT };
+
 
     // protocol
 //    MidiNetworkHostProtocol NetworkProtocol{ MidiNetworkHostProtocol::ProtocolDefault };
@@ -115,6 +118,7 @@ private:
     winrt::guid m_configIdentifier{};
 
     bool m_createUmpEndpointsOnly{ true };
+    uint8_t m_fallbackMidi1PortCount{ MIDI_NETWORK_MIDI_FALLBACK_MIDI1_PORT_COUNT_DEFAULT };
 
     wil::critical_section m_connectionLock;
     std::shared_ptr<MidiNetworkClientConnection> m_networkConnection{ nullptr };

--- a/src/in-box/Transport/UdpNetworkMidi2Transport/MidiNetworkClientConnection.cpp
+++ b/src/in-box/Transport/UdpNetworkMidi2Transport/MidiNetworkClientConnection.cpp
@@ -20,7 +20,8 @@ MidiNetworkClientConnection::Initialize(
     std::wstring const& thisProductInstanceId,
     uint16_t const retransmitBufferMaxCommandPacketCount,
     uint8_t const maxForwardErrorCorrectionCommandPacketCount,
-    bool createUmpEndpointsOnly
+    bool createUmpEndpointsOnly,
+    uint8_t const fallbackMidi1PortCount
 )
 {
     return MidiNetworkConnection::Initialize(
@@ -34,7 +35,8 @@ MidiNetworkClientConnection::Initialize(
         thisProductInstanceId,
         retransmitBufferMaxCommandPacketCount,
         maxForwardErrorCorrectionCommandPacketCount,
-        createUmpEndpointsOnly
+        createUmpEndpointsOnly,
+        fallbackMidi1PortCount
     );
 }
 
@@ -286,6 +288,7 @@ MidiNetworkClientConnection::HandleIncomingInvitationReplyAccepted(
             m_remoteHostName,
             m_remotePort,
             m_createUmpEndpointsOnly,
+            m_fallbackMidi1PortCount,
             newDeviceInstanceId,
             newEndpointDeviceInterfaceId
         );

--- a/src/in-box/Transport/UdpNetworkMidi2Transport/MidiNetworkClientConnection.h
+++ b/src/in-box/Transport/UdpNetworkMidi2Transport/MidiNetworkClientConnection.h
@@ -23,7 +23,8 @@ public:
         _In_ std::wstring const& thisProductInstanceId,
         _In_ uint16_t const retransmitBufferMaxCommandPacketCount,
         _In_ uint8_t const maxForwardErrorCorrectionCommandPacketCount,
-        _In_ bool createUmpEndpointsOnly
+        _In_ bool createUmpEndpointsOnly,
+        _In_ uint8_t const fallbackMidi1PortCount
     );
 
     HRESULT SendInvitation();

--- a/src/in-box/Transport/UdpNetworkMidi2Transport/MidiNetworkConnection.cpp
+++ b/src/in-box/Transport/UdpNetworkMidi2Transport/MidiNetworkConnection.cpp
@@ -24,7 +24,8 @@ MidiNetworkConnection::Initialize(
     std::wstring const& thisProductInstanceId,
     uint16_t const retransmitBufferMaxCommandPacketCount,
     uint8_t const maxForwardErrorCorrectionCommandPacketCount,
-    bool createUmpEndpointsOnly
+    bool createUmpEndpointsOnly,
+    uint8_t const fallbackMidi1PortCount
 )
 {
     TraceLoggingWrite(
@@ -47,6 +48,7 @@ MidiNetworkConnection::Initialize(
     m_remotePort = port;
 
     m_createUmpEndpointsOnly = createUmpEndpointsOnly;
+    m_fallbackMidi1PortCount = fallbackMidi1PortCount;
 
     m_thisEndpointName = thisEndpointName;
     m_thisProductInstanceId = thisProductInstanceId;

--- a/src/in-box/Transport/UdpNetworkMidi2Transport/MidiNetworkConnection.h
+++ b/src/in-box/Transport/UdpNetworkMidi2Transport/MidiNetworkConnection.h
@@ -171,7 +171,8 @@ protected:
         _In_ std::wstring const& thisProductInstanceId,
         _In_ uint16_t const retransmitBufferMaxCommandPacketCount,
         _In_ uint8_t const maxForwardErrorCorrectionCommandPacketCount,
-        _In_ bool createUmpEndpointsOnly
+        _In_ bool createUmpEndpointsOnly,
+        _In_ uint8_t const fallbackMidi1PortCount
     );
 
     // Role hooks. The defaults are what happens when a command arrives for the role this
@@ -303,6 +304,7 @@ protected:
     HRESULT OutboundProcessingThreadWorker(_In_ std::stop_token stopToken);
 
     bool m_createUmpEndpointsOnly{ true };
+    uint8_t m_fallbackMidi1PortCount{ MIDI_NETWORK_MIDI_FALLBACK_MIDI1_PORT_COUNT_DEFAULT };
 
     MidiNetworkConnectionRole m_role{};
 

--- a/src/in-box/Transport/UdpNetworkMidi2Transport/MidiNetworkHost.cpp
+++ b/src/in-box/Transport/UdpNetworkMidi2Transport/MidiNetworkHost.cpp
@@ -54,6 +54,7 @@ MidiNetworkHost::Initialize(
     m_started = false;
 
     m_createUmpEndpointsOnly = !hostDefinition.CreateMidi1Ports;
+    m_fallbackMidi1PortCount = hostDefinition.FallbackMidi1PortCount;
 
     m_hostEndpointName = hostDefinition.UmpEndpointName;
     m_hostProductInstanceId = hostDefinition.ProductInstanceId;
@@ -283,6 +284,7 @@ MidiNetworkHost::CreateNetworkConnection(
             TransportState::Current().TransportSettings.RetransmitBufferMaxCommandPacketCount,
             TransportState::Current().TransportSettings.ForwardErrorCorrectionMaxCommandPacketCount,
             m_createUmpEndpointsOnly,
+            m_fallbackMidi1PortCount,
             AuthenticationKindFromHostAuthentication(m_hostDefinition.Authentication),
             MidiNetworkCredentialIdentifier{ std::wstring{ m_hostDefinition.AuthenticationCredentialIdentifier } }
         ));

--- a/src/in-box/Transport/UdpNetworkMidi2Transport/MidiNetworkHost.h
+++ b/src/in-box/Transport/UdpNetworkMidi2Transport/MidiNetworkHost.h
@@ -111,6 +111,10 @@ public:
 
     MidiNetworkHostDefinition GetDefinition() { return m_hostDefinition; }
 
+    // Used for the next remote client which connects to this host. The ones already connected are
+    // updated in place by the configuration manager.
+    void SetFallbackMidi1PortCount(_In_ uint8_t const value) noexcept { m_fallbackMidi1PortCount = value; }
+
     winrt::hstring ActualPort() { auto socket = GetSocket(); return socket != nullptr ? socket.Information().LocalPort() : L""; }
     winrt::hstring ActualAddress() { auto socket = GetSocket(); return socket != nullptr ? socket.Information().LocalAddress().DisplayName() : L""; }
 

--- a/src/in-box/Transport/UdpNetworkMidi2Transport/MidiNetworkHost.h
+++ b/src/in-box/Transport/UdpNetworkMidi2Transport/MidiNetworkHost.h
@@ -52,6 +52,9 @@ struct MidiNetworkHostDefinition
 
     bool CreateMidi1Ports{ MIDI_NETWORK_MIDI_CREATE_MIDI1_PORTS_DEFAULT };
 
+    // Only used when the remote client declares no function blocks. See the constant for why.
+    uint8_t FallbackMidi1PortCount{ MIDI_NETWORK_MIDI_FALLBACK_MIDI1_PORT_COUNT_DEFAULT };
+
     // connection rules
     MidiNetworkRemoteClientPolicy RemoteClientPolicy{ MidiNetworkRemoteClientPolicy::PolicyAllowAny };
 
@@ -128,6 +131,7 @@ private:
     bool m_portFallbackUsed{ false };
     std::atomic<bool> m_started{ false };
     bool m_createUmpEndpointsOnly{ true };
+    uint8_t m_fallbackMidi1PortCount{ MIDI_NETWORK_MIDI_FALLBACK_MIDI1_PORT_COUNT_DEFAULT };
 
     std::wstring m_hostEndpointName{ };
     std::wstring m_hostProductInstanceId{ };

--- a/src/in-box/Transport/UdpNetworkMidi2Transport/MidiNetworkHostConnection.cpp
+++ b/src/in-box/Transport/UdpNetworkMidi2Transport/MidiNetworkHostConnection.cpp
@@ -22,6 +22,7 @@ MidiNetworkHostConnection::Initialize(
     uint16_t const retransmitBufferMaxCommandPacketCount,
     uint8_t const maxForwardErrorCorrectionCommandPacketCount,
     bool createUmpEndpointsOnly,
+    uint8_t const fallbackMidi1PortCount,
     MidiNetworkAuthenticationKind const authenticationKind,
     MidiNetworkCredentialIdentifier const& credentialIdentifier
 )
@@ -40,7 +41,8 @@ MidiNetworkHostConnection::Initialize(
         thisProductInstanceId,
         retransmitBufferMaxCommandPacketCount,
         maxForwardErrorCorrectionCommandPacketCount,
-        createUmpEndpointsOnly
+        createUmpEndpointsOnly,
+        fallbackMidi1PortCount
     );
 }
 
@@ -65,6 +67,7 @@ MidiNetworkHostConnection::CreateHostEndpointForPendingInvitation(
         m_remoteHostName,
         m_remotePort,
         m_createUmpEndpointsOnly,
+        m_fallbackMidi1PortCount,
         newDeviceInstanceId,
         newEndpointDeviceInterfaceId));
 

--- a/src/in-box/Transport/UdpNetworkMidi2Transport/MidiNetworkHostConnection.h
+++ b/src/in-box/Transport/UdpNetworkMidi2Transport/MidiNetworkHostConnection.h
@@ -25,6 +25,7 @@ public:
         _In_ uint16_t const retransmitBufferMaxCommandPacketCount,
         _In_ uint8_t const maxForwardErrorCorrectionCommandPacketCount,
         _In_ bool createUmpEndpointsOnly,
+        _In_ uint8_t const fallbackMidi1PortCount,
         _In_ MidiNetworkAuthenticationKind const authenticationKind,
         _In_ MidiNetworkCredentialIdentifier const& credentialIdentifier
     );

--- a/src/in-box/Transport/UdpNetworkMidi2Transport/net2udp_transport_defs.h
+++ b/src/in-box/Transport/UdpNetworkMidi2Transport/net2udp_transport_defs.h
@@ -189,7 +189,7 @@ enum class MidiNetworkEntryState
 // by one object and two threads on every reconnect.
 #define MIDI_NETWORK_CONNECTION_IDLE_RECLAIM_MILLISECONDS               30000
 
-#define MIDI_NETWORK_MIDI_CREATE_MIDI1_PORTS_DEFAULT                    false
+#define MIDI_NETWORK_MIDI_CREATE_MIDI1_PORTS_DEFAULT                    true
 
 // header sized plus a command packet header
 #define MINIMUM_VALID_UDP_PACKET_SIZE (sizeof(uint32_t) * 2)

--- a/src/in-box/Transport/UdpNetworkMidi2Transport/net2udp_transport_defs.h
+++ b/src/in-box/Transport/UdpNetworkMidi2Transport/net2udp_transport_defs.h
@@ -191,6 +191,9 @@ enum class MidiNetworkEntryState
 
 #define MIDI_NETWORK_MIDI_CREATE_MIDI1_PORTS_DEFAULT                    true
 
+// A UMP endpoint addresses sixteen groups.
+#define MIDI_NETWORK_MIDI_GROUP_COUNT                                   16
+
 // header sized plus a command packet header
 #define MINIMUM_VALID_UDP_PACKET_SIZE (sizeof(uint32_t) * 2)
 

--- a/src/in-box/Transport/UdpNetworkMidi2Transport/network_json_defs.h
+++ b/src/in-box/Transport/UdpNetworkMidi2Transport/network_json_defs.h
@@ -16,6 +16,10 @@
 #define MIDI_CONFIG_JSON_NETWORK_MIDI_CLIENTS_KEY                               L"clients"
 #define MIDI_CONFIG_JSON_NETWORK_MIDI_TRANSPORT_SETTINGS_KEY                    L"transportSettings"
 
+// Changes to existing host and client entries. Deliberately not the common "update" key, which
+// holds an array of endpoint customizations in this same object and would collide in a saved file.
+#define MIDI_CONFIG_JSON_NETWORK_MIDI_UPDATE_ENTRIES_KEY                        L"updateEntries"
+
 
 #define MIDI_CONFIG_JSON_NETWORK_MIDI_MAX_FEC_PACKETS_KEY                       L"maxForwardErrorCorrectionCommandPackets"
 #define MIDI_CONFIG_JSON_NETWORK_MIDI_RETRANSMIT_BUFFER_SIZE_KEY                L"maxRetransmitBufferCommandPackets"

--- a/src/in-box/Transport/UdpNetworkMidi2Transport/network_json_defs.h
+++ b/src/in-box/Transport/UdpNetworkMidi2Transport/network_json_defs.h
@@ -33,6 +33,16 @@
 #define MIDI_CONFIG_JSON_NETWORK_MIDI_ENABLED_KEY                               L"enabled"                  // boolean
 
 #define MIDI_CONFIG_JSON_NETWORK_MIDI_CREATE_MIDI1_PORTS_KEY                    L"createMidi1Ports"         // boolean - set to true to enable creating WinMM/WinRT 1.0 ports
+#define MIDI_CONFIG_JSON_NETWORK_MIDI_FALLBACK_MIDI1_PORT_COUNT_KEY            L"fallbackMidi1PortCount"   // number 1-16 - source/destination pairs to create when the device declares no function blocks
+
+// A remote which never completes MIDI 2.0 discovery declares no function blocks, and the service
+// has nothing to build MIDI 1.0 ports from. The transport supplies a group terminal block for
+// that case, spanning this many groups bidirectionally, so the count is also the number of
+// source and destination ports. One pair, because a device which does not describe itself is
+// usually a bridge with a single cable, and sixteen pairs is thirty two ports of clutter.
+#define MIDI_NETWORK_MIDI_FALLBACK_MIDI1_PORT_COUNT_DEFAULT                     1
+#define MIDI_NETWORK_MIDI_FALLBACK_MIDI1_PORT_COUNT_MINIMUM                     1
+#define MIDI_NETWORK_MIDI_FALLBACK_MIDI1_PORT_COUNT_MAXIMUM                     16
 
 
 #define MIDI_CONFIG_JSON_NETWORK_MIDI_SERVICE_INSTANCE_NAME_KEY                 L"serviceInstanceName"      // just the first part (before the . ) of the host instance name. Defaults to machine name
@@ -148,6 +158,7 @@
 #define MIDI_CONFIG_JSON_NETWORK_MIDI_ENUM_CLIENTS_RESPONSE_LOCAL_PORT_KEY          L"localPort"
 #define MIDI_CONFIG_JSON_NETWORK_MIDI_ENUM_CLIENTS_RESPONSE_UMP_ENDPOINT_ID_KEY     L"endpointDeviceId"
 #define MIDI_CONFIG_JSON_NETWORK_MIDI_ENUM_CLIENTS_RESPONSE_CREATE_MIDI1_PORTS_KEY  MIDI_CONFIG_JSON_NETWORK_MIDI_CREATE_MIDI1_PORTS_KEY
+#define MIDI_CONFIG_JSON_NETWORK_MIDI_ENUM_CLIENTS_RESPONSE_FALLBACK_MIDI1_PORT_COUNT_KEY MIDI_CONFIG_JSON_NETWORK_MIDI_FALLBACK_MIDI1_PORT_COUNT_KEY
 
 // A configured client is reported whether or not it is connected, so the app can show an entry
 // which is not currently reachable.
@@ -195,6 +206,7 @@
 #define MIDI_CONFIG_JSON_NETWORK_MIDI_ENUM_HOSTS_RESPONSE_NAME_KEY                  MIDI_CONFIG_JSON_ENDPOINT_COMMON_NAME_PROPERTY
 #define MIDI_CONFIG_JSON_NETWORK_MIDI_ENUM_HOSTS_RESPONSE_PRODUCT_INSTANCE_ID_KEY   MIDI_CONFIG_JSON_NETWORK_MIDI_PRODUCT_INSTANCE_ID_PROPERTY
 #define MIDI_CONFIG_JSON_NETWORK_MIDI_ENUM_HOSTS_RESPONSE_CREATE_MIDI1_PORTS_KEY    MIDI_CONFIG_JSON_NETWORK_MIDI_CREATE_MIDI1_PORTS_KEY
+#define MIDI_CONFIG_JSON_NETWORK_MIDI_ENUM_HOSTS_RESPONSE_FALLBACK_MIDI1_PORT_COUNT_KEY MIDI_CONFIG_JSON_NETWORK_MIDI_FALLBACK_MIDI1_PORT_COUNT_KEY
 #define MIDI_CONFIG_JSON_NETWORK_MIDI_ENUM_HOSTS_RESPONSE_SERVICE_INSTANCE_NAME_KEY MIDI_CONFIG_JSON_NETWORK_MIDI_SERVICE_INSTANCE_NAME_KEY
 
 // Per-host list of remote clients, so a polling app can show what is connected and what is

--- a/src/in-box/Transport/UdpNetworkMidi2Transport/pch.h
+++ b/src/in-box/Transport/UdpNetworkMidi2Transport/pch.h
@@ -80,6 +80,7 @@ namespace foundation = ::winrt::Windows::Foundation;
 #include "midi_ump_message_defs.h"
 #include "midi_timestamp.h"
 #include "midi_group_terminal_blocks.h"
+#include "MidiEndpointNameTable.h"
 
 #undef GetObject
 #include <winrt/Windows.Data.Json.h>

--- a/src/in-box/Transport/UdpNetworkMidi2Transport/pch.h
+++ b/src/in-box/Transport/UdpNetworkMidi2Transport/pch.h
@@ -79,6 +79,7 @@ namespace foundation = ::winrt::Windows::Foundation;
 #include "ump_helpers.h"
 #include "midi_ump_message_defs.h"
 #include "midi_timestamp.h"
+#include "midi_group_terminal_blocks.h"
 
 #undef GetObject
 #include <winrt/Windows.Data.Json.h>

--- a/src/in-box/user-tools/bluetooth-midi-setup/Resources.rc
+++ b/src/in-box/user-tools/bluetooth-midi-setup/Resources.rc
@@ -19,9 +19,9 @@
 #define VER_LEGALCOPYRIGHT_STR      "Copyright (c) Microsoft Corporation"
 #undef VER_PRODUCTNAME_STR
 #define VER_PRODUCTNAME_STR         "Windows MIDI Services"
-#define VER_FILEVERSION_STR         "1.0.0.1"
+#define VER_FILEVERSION_STR         "1.0.0.2"
 #undef VER_PRODUCTVERSION_STR
-#define VER_PRODUCTVERSION_STR      "1.0.0.1"
+#define VER_PRODUCTVERSION_STR      "1.0.0.2"
 
 // this builds the version resource based on the above
 #include "common.ver"

--- a/src/in-box/user-tools/loopback-setup/Resources.rc
+++ b/src/in-box/user-tools/loopback-setup/Resources.rc
@@ -19,9 +19,9 @@
 #define VER_LEGALCOPYRIGHT_STR      "Copyright (c) Microsoft Corporation"
 #undef VER_PRODUCTNAME_STR
 #define VER_PRODUCTNAME_STR         "Windows MIDI Services"
-#define VER_FILEVERSION_STR         "1.0.0.1"
+#define VER_FILEVERSION_STR         "1.0.0.2"
 #undef VER_PRODUCTVERSION_STR
-#define VER_PRODUCTVERSION_STR      "1.0.0.1"
+#define VER_PRODUCTVERSION_STR      "1.0.0.2"
 
 // this builds the version resource based on the above
 #include "common.ver"

--- a/src/in-box/user-tools/midi-settings/MainWindowDetails.cpp
+++ b/src/in-box/user-tools/midi-settings/MainWindowDetails.cpp
@@ -528,7 +528,7 @@ namespace winrt::midisettings::implementation
             }
 
             CustomizePortNamingPanel().Visibility(
-                (transportCode == L"KS" || transportCode == L"KSA") && endpoint.IsMidi1PortCreationEnabled() ?
+                (transportCode == L"KS" || transportCode == L"KSA") ?
                     xaml::Visibility::Visible : xaml::Visibility::Collapsed);
 
             m_portNamesRequested = false;

--- a/src/in-box/user-tools/mididiag/mididiag_field_defs.h
+++ b/src/in-box/user-tools/mididiag/mididiag_field_defs.h
@@ -98,6 +98,13 @@
 #define MIDIDIAG_FIELD_LABEL_GTB_GROUP_COUNT                             L"gtb_group_count"
 #define MIDIDIAG_FIELD_LABEL_GTB_DIRECTION                               L"gtb_direction"
 
+#define MIDIDIAG_FIELD_LABEL_FUNCTION_BLOCK_NUMBER                       L"fb_number"
+#define MIDIDIAG_FIELD_LABEL_FUNCTION_BLOCK_NAME                         L"fb_name"
+#define MIDIDIAG_FIELD_LABEL_FUNCTION_BLOCK_FIRST_GROUP                  L"fb_first_group_number"
+#define MIDIDIAG_FIELD_LABEL_FUNCTION_BLOCK_GROUP_COUNT                  L"fb_group_count"
+#define MIDIDIAG_FIELD_LABEL_FUNCTION_BLOCK_DIRECTION                    L"fb_direction"
+#define MIDIDIAG_FIELD_LABEL_FUNCTION_BLOCK_ACTIVE                       L"fb_active"
+
 #define MIDIDIAG_FIELD_LABEL_REG_DEFAULT_MIDI1_NAME_TABLE_SELECTION      L"reg_default_midi1_winmm_naming"
 #define MIDIDIAG_FIELD_LABEL_REG_DEFAULT_MIDI2_UMP_NAME_TABLE_SELECTION  L"reg_default_midi2_ump_winmm_naming"
 #define MIDIDIAG_FIELD_LABEL_REG_DEFAULT_MIDI1_UMP_NAME_TABLE_SELECTION  L"reg_default_midi1_ump_winmm_naming"
@@ -108,10 +115,7 @@
 #define MIDIDIAG_FIELD_LABEL_NAME_TABLE_DATA_FLOW                        L"name_table_data_flow"
 #define MIDIDIAG_FIELD_LABEL_NAME_TABLE_CUSTOM_NAME                      L"name_table_custom_name"
 #define MIDIDIAG_FIELD_LABEL_NAME_TABLE_LEGACY_WINMM_NAME                L"name_table_legacy_winmm_name"
-#define MIDIDIAG_FIELD_LABEL_NAME_TABLE_GTB_NAME                         L"name_table_gtb_name"
-#define MIDIDIAG_FIELD_LABEL_NAME_TABLE_FILTER_PLUS_GTB_NAME             L"name_table_filter_plus_gtb_name"
-#define MIDIDIAG_FIELD_LABEL_NAME_TABLE_PIN_NAME                         L"name_table_pin_name"
-#define MIDIDIAG_FIELD_LABEL_NAME_TABLE_FILTER_PLUS_PIN_NAME             L"name_table_filter_plus_pin_name"
+#define MIDIDIAG_FIELD_LABEL_NAME_TABLE_NEW_STYLE_NAME                   L"name_table_new_style_name"
 
 #define MIDIDIAG_FIELD_LABEL_MIDI1_PORT_IN                               L"midi_in_port"
 #define MIDIDIAG_FIELD_LABEL_MIDI1_PORT_OUT                              L"midi_out_port"

--- a/src/in-box/user-tools/mididiag/mididiag_main.cpp
+++ b/src/in-box/user-tools/mididiag/mididiag_main.cpp
@@ -786,6 +786,42 @@ bool DoSectionMidi2ApiEndpoints(_In_ bool const verbose)
             }
 
 
+            // Show function blocks. Necessary especially for MIDI 2.0 devices which have no GTBs. Also helps decide if a port should be created
+
+            for (auto const& fb : device.GetDeclaredFunctionBlocks())
+            {
+                WriteBlankLine();
+
+                OutputPortNumberField(MIDIDIAG_FIELD_LABEL_FUNCTION_BLOCK_NUMBER, fb.Number());
+                OutputEntityNameField(MIDIDIAG_FIELD_LABEL_FUNCTION_BLOCK_NAME, fb.Name());
+                OutputNumericField(MIDIDIAG_FIELD_LABEL_FUNCTION_BLOCK_FIRST_GROUP, fb.FirstGroup().DisplayValue());
+                OutputNumericField(MIDIDIAG_FIELD_LABEL_FUNCTION_BLOCK_GROUP_COUNT, fb.GroupCount());
+                OutputBooleanField(MIDIDIAG_FIELD_LABEL_FUNCTION_BLOCK_ACTIVE, fb.IsActive());
+
+                std::wstring gtbDirection{};
+
+                if (fb.Direction() == midi2enum::MidiFunctionBlockDirection::Bidirectional)
+                {
+                    gtbDirection = L"Bidirectional";
+                }
+                else if (fb.Direction() == midi2enum::MidiFunctionBlockDirection::BlockInput)
+                {
+                    gtbDirection = L"Message Destination";
+                }
+                else if (fb.Direction() == midi2enum::MidiFunctionBlockDirection::BlockOutput)
+                {
+                    gtbDirection = L"Message Source";
+                }
+
+                OutputStringField(MIDIDIAG_FIELD_LABEL_FUNCTION_BLOCK_DIRECTION, gtbDirection);
+            }
+
+            if (device.GetDeclaredFunctionBlocks().Size() > 0)
+            {
+                WriteBlankLine();
+            }
+
+
             // Show associated MIDI 1.0 endpoints
 
 
@@ -803,54 +839,37 @@ bool DoSectionMidi2ApiEndpoints(_In_ bool const verbose)
             }
 
 
-
-
-
-
-
             // TODO: Get the reg keys that set the global defaults (move this up to the registry section)
 
 
-            // get the base device so we can use some of the service-based helpers, which
-            // don't know anything about the SDK types. These properties aren't normally
-            // used at the SDK-level
-            auto additionalProps = winrt::single_threaded_vector<winrt::hstring>();
 
-            additionalProps.Append(STRING_PKEY_MIDI_Midi1PortNamingSelection);
-            additionalProps.Append(STRING_PKEY_MIDI_Midi1PortNameTable);
-            auto basicDevice = winrt::Windows::Devices::Enumeration::DeviceInformation::CreateFromIdAsync(
-                device.EndpointDeviceId(),
-                additionalProps,
-                winrt::Windows::Devices::Enumeration::DeviceInformationKind::DeviceInterface
-                ).get();
+            std::wstring namingApproach {};
+            
+            switch (device.Midi1PortNamingApproach())
+            {
+            case midi2enum::Midi1PortNamingApproach::Default:
+                namingApproach = L"Use global default from registry";
+                break;
+            case midi2enum::Midi1PortNamingApproach::UseClassicCompatible:
+                namingApproach = L"Use WinMM Compatible";
+                break;
+            case midi2enum::Midi1PortNamingApproach::UseNewStyle:
+                namingApproach = L"Use New Style";
+                break;
+            default:
+                namingApproach = L"UNKNOWN";
+            }
 
-
-
-
-
-
-
-#if false
-
-
-
-            // show which name property this endpoint has selected for MIDI 1 ports
-            auto namingSelection = (midi2::Midi1PortNameSelectionProperty)internal::SafeGetSwdPropertyFromDeviceInformation<uint32_t>(STRING_PKEY_MIDI_Midi1PortNamingSelection, basicDevice, Midi1PortNameSelectionProperty::PortName_UseGlobalDefault);
-
-            OutputStringField(MIDIDIAG_FIELD_LABEL_NAME_TABLE_SELECTION, GetDisplayValueFromNamingSelection(namingSelection));
-            OutputBlankLine();
+            OutputStringField(MIDIDIAG_FIELD_LABEL_NAME_TABLE_SELECTION, namingApproach);
+            WriteBlankLine();
 
             // Show the full MIDI 1 port name table
 
-            auto nameTableRefArray = internal::SafeGetSwdPropertyFromDeviceInformation<winrt::Windows::Foundation::IReferenceArray<uint8_t>>(STRING_PKEY_MIDI_Midi1PortNameTable, basicDevice, nullptr);
+            auto nameEntries = device.GetNameTable();
 
-            if (nameTableRefArray != nullptr)
+            if (nameEntries != nullptr)
             {
-                auto refData = nameTableRefArray.Value();
-
-                auto nameEntries = internal::Midi1PortNaming::ReadMidi1PortNameTableFromPropertyData(refData.data(), refData.size());
-
-                if (nameEntries.size() == 0)
+                if (nameEntries.Size() == 0)
                 {
                     OutputError(internal::ResourceGetWString(IDS_ERROR_NO_NAMING_TABLE));
                 }
@@ -858,44 +877,34 @@ bool DoSectionMidi2ApiEndpoints(_In_ bool const verbose)
                 {
                     for (auto const& nameEntry : nameEntries)
                     {
-                        OutputNumericField(MIDIDIAG_FIELD_LABEL_NAME_TABLE_GROUP_NUMBER, nameEntry.GroupIndex + 1);
+                        OutputNumericField(MIDIDIAG_FIELD_LABEL_NAME_TABLE_GROUP_NUMBER, nameEntry.Group().DisplayValue());
 
-                        switch (nameEntry.DataFlowFromUserPerspective)
+                        switch (nameEntry.Flow())
                         {
-                        case MidiFlow::MidiFlowIn:
+                        case midi2::Enumeration::Midi1PortFlow::MidiMessageSource:
                             OutputStringField(MIDIDIAG_FIELD_LABEL_NAME_TABLE_DATA_FLOW, std::wstring(L"MIDI In Port (Message Source)"));
                             break;
-                        case MidiFlow::MidiFlowOut:
+                        case midi2::Enumeration::Midi1PortFlow::MidiMessageDestination:
                             OutputStringField(MIDIDIAG_FIELD_LABEL_NAME_TABLE_DATA_FLOW, std::wstring(L"MIDI Out Port (Message Destination)"));
-                            break;
-                        case MidiFlow::MidiFlowBidirectional:
-                            OutputStringField(MIDIDIAG_FIELD_LABEL_NAME_TABLE_DATA_FLOW, std::wstring(L"Bidirectional (This is unexpected)"));
                             break;
                         default:
                             OutputStringField(MIDIDIAG_FIELD_LABEL_NAME_TABLE_DATA_FLOW, std::wstring(L"INVALID VALUE"));
                             break;
                         }
 
-                        auto customName = std::wstring{ nameEntry.CustomName };
-                        auto legacyWinMMName = std::wstring{ nameEntry.LegacyWinMMName };
-                        auto groupTerminalBlockName = std::wstring{ nameEntry.BlockName };
-                        auto filterPlusGroupTerminalBlockName = std::wstring{ nameEntry.FilterPlusBlockName };
-                        auto pinName = std::wstring{ nameEntry.PinName };
-                        auto filterPlusPinName = std::wstring{ nameEntry.FilterPlusPinName };
+                        auto customName = std::wstring{ nameEntry.CustomName() };
+                        auto legacyWinMMName = std::wstring{ nameEntry.LegacyCompatibleName() };
+                        auto newStyleName = std::wstring{ nameEntry.NewStyleName() };
 
                         OutputStringField(MIDIDIAG_FIELD_LABEL_NAME_TABLE_CUSTOM_NAME, customName);
                         OutputStringField(MIDIDIAG_FIELD_LABEL_NAME_TABLE_LEGACY_WINMM_NAME, legacyWinMMName);
-                        OutputStringField(MIDIDIAG_FIELD_LABEL_NAME_TABLE_GTB_NAME, groupTerminalBlockName);
-                        OutputStringField(MIDIDIAG_FIELD_LABEL_NAME_TABLE_FILTER_PLUS_GTB_NAME, filterPlusGroupTerminalBlockName);
-                        OutputStringField(MIDIDIAG_FIELD_LABEL_NAME_TABLE_PIN_NAME, pinName);
-                        OutputStringField(MIDIDIAG_FIELD_LABEL_NAME_TABLE_FILTER_PLUS_PIN_NAME, filterPlusPinName);
-                        OutputBlankLine();
+                        OutputStringField(MIDIDIAG_FIELD_LABEL_NAME_TABLE_NEW_STYLE_NAME, newStyleName);
+                        WriteBlankLine();
                     }
                 }
-
             }
 
-#endif
+
             // Parent device
 
             auto parent = device.GetParentDeviceInformation();

--- a/src/in-box/user-tools/network-midi-setup/ConfigFile.cpp
+++ b/src/in-box/user-tools/network-midi-setup/ConfigFile.cpp
@@ -832,48 +832,6 @@ namespace midinetworksetup
     }
 
     _Use_decl_annotations_
-    bool NetworkConfigFile::SetClientMidi1PortSettings(
-        winrt::hstring const& clientIdKey,
-        bool const createMidi1Ports,
-        uint8_t const fallbackMidi1PortCount) noexcept
-    {
-        json::JsonObject config{ nullptr };
-
-        if (!Load(config))
-        {
-            return false;
-        }
-
-        auto clients = GetEntriesObject(config, MIDI_CONFIG_JSON_NETWORK_MIDI_CLIENTS_KEY, false);
-
-        auto client = FindObject(clients, ResolveKey(clients, clientIdKey));
-
-        if (client == nullptr)
-        {
-            m_lastError = resources::GetString(L"ConfigFileClientEntryMissingError");
-            return false;
-        }
-
-        try
-        {
-            json::JsonObject clientChange{};
-            clientChange.SetNamedValue(
-                MIDI_CONFIG_JSON_NETWORK_MIDI_CREATE_MIDI1_PORTS_KEY,
-                json::JsonValue::CreateBooleanValue(createMidi1Ports));
-            clientChange.SetNamedValue(
-                MIDI_CONFIG_JSON_NETWORK_MIDI_FALLBACK_MIDI1_PORT_COUNT_KEY,
-                json::JsonValue::CreateNumberValue(fallbackMidi1PortCount));
-
-            return SaveSection(BuildClientSection(ResolveKey(clients, clientIdKey), clientChange));
-        }
-        catch (...)
-        {
-            m_lastError = resources::FormatString(L"ConfigFileWriteError", m_path);
-            return false;
-        }
-    }
-
-    _Use_decl_annotations_
     bool NetworkConfigFile::SetRemoteClientDecision(
         winrt::hstring const& hostIdKey,
         winrt::hstring const& umpEndpointName,

--- a/src/in-box/user-tools/network-midi-setup/ConfigFile.cpp
+++ b/src/in-box/user-tools/network-midi-setup/ConfigFile.cpp
@@ -832,6 +832,35 @@ namespace midinetworksetup
     }
 
     _Use_decl_annotations_
+    bool NetworkConfigFile::GetClientCreateMidi1Ports(winrt::hstring const& clientIdKey) noexcept
+    {
+        json::JsonObject config{ nullptr };
+
+        if (!LoadCached(config))
+        {
+            return true;
+        }
+
+        auto clients = GetEntriesObject(config, MIDI_CONFIG_JSON_NETWORK_MIDI_CLIENTS_KEY, false);
+
+        auto client = FindObject(clients, ResolveKey(clients, clientIdKey));
+
+        if (client == nullptr)
+        {
+            return true;
+        }
+
+        try
+        {
+            return client.GetNamedBoolean(MIDI_CONFIG_JSON_NETWORK_MIDI_CREATE_MIDI1_PORTS_KEY, true);
+        }
+        catch (...)
+        {
+            return true;
+        }
+    }
+
+    _Use_decl_annotations_
     bool NetworkConfigFile::SetRemoteClientDecision(
         winrt::hstring const& hostIdKey,
         winrt::hstring const& umpEndpointName,

--- a/src/in-box/user-tools/network-midi-setup/ConfigFile.cpp
+++ b/src/in-box/user-tools/network-midi-setup/ConfigFile.cpp
@@ -793,9 +793,49 @@ namespace midinetworksetup
     }
 
     _Use_decl_annotations_
-    bool NetworkConfigFile::SetClientCreateMidi1Ports(
+    uint8_t NetworkConfigFile::GetClientFallbackMidi1PortCount(winrt::hstring const& clientIdKey) noexcept
+    {
+        json::JsonObject config{ nullptr };
+
+        if (!LoadCached(config))
+        {
+            return MIDI_NETWORK_MIDI_FALLBACK_MIDI1_PORT_COUNT_DEFAULT;
+        }
+
+        auto clients = GetEntriesObject(config, MIDI_CONFIG_JSON_NETWORK_MIDI_CLIENTS_KEY, false);
+
+        auto client = FindObject(clients, ResolveKey(clients, clientIdKey));
+
+        if (client == nullptr)
+        {
+            return MIDI_NETWORK_MIDI_FALLBACK_MIDI1_PORT_COUNT_DEFAULT;
+        }
+
+        try
+        {
+            auto const value = client.GetNamedNumber(
+                MIDI_CONFIG_JSON_NETWORK_MIDI_FALLBACK_MIDI1_PORT_COUNT_KEY,
+                MIDI_NETWORK_MIDI_FALLBACK_MIDI1_PORT_COUNT_DEFAULT);
+
+            if (value < MIDI_NETWORK_MIDI_FALLBACK_MIDI1_PORT_COUNT_MINIMUM ||
+                value > MIDI_NETWORK_MIDI_FALLBACK_MIDI1_PORT_COUNT_MAXIMUM)
+            {
+                return MIDI_NETWORK_MIDI_FALLBACK_MIDI1_PORT_COUNT_DEFAULT;
+            }
+
+            return static_cast<uint8_t>(value);
+        }
+        catch (...)
+        {
+            return MIDI_NETWORK_MIDI_FALLBACK_MIDI1_PORT_COUNT_DEFAULT;
+        }
+    }
+
+    _Use_decl_annotations_
+    bool NetworkConfigFile::SetClientMidi1PortSettings(
         winrt::hstring const& clientIdKey,
-        bool const createMidi1Ports) noexcept
+        bool const createMidi1Ports,
+        uint8_t const fallbackMidi1PortCount) noexcept
     {
         json::JsonObject config{ nullptr };
 
@@ -820,6 +860,9 @@ namespace midinetworksetup
             clientChange.SetNamedValue(
                 MIDI_CONFIG_JSON_NETWORK_MIDI_CREATE_MIDI1_PORTS_KEY,
                 json::JsonValue::CreateBooleanValue(createMidi1Ports));
+            clientChange.SetNamedValue(
+                MIDI_CONFIG_JSON_NETWORK_MIDI_FALLBACK_MIDI1_PORT_COUNT_KEY,
+                json::JsonValue::CreateNumberValue(fallbackMidi1PortCount));
 
             return SaveSection(BuildClientSection(ResolveKey(clients, clientIdKey), clientChange));
         }

--- a/src/in-box/user-tools/network-midi-setup/ConfigFile.h
+++ b/src/in-box/user-tools/network-midi-setup/ConfigFile.h
@@ -83,11 +83,17 @@ namespace midinetworksetup
         // endpoint following the device's own name instead of pinning what it happened to be.
         winrt::hstring GetClientCustomEndpointName(_In_ winrt::hstring const& clientIdKey) noexcept;
 
+        // The fallback port count saved for this entry, or the default when the entry does not
+        // say. There is no endpoint property for this one, because it only matters for a device
+        // which never described itself, so the file is the only place it is recorded.
+        uint8_t GetClientFallbackMidi1PortCount(_In_ winrt::hstring const& clientIdKey) noexcept;
+
         // MIDI 1.0 ports are decided when the endpoint is built, so this only changes what the
         // next connection creates. Nothing about the running endpoint changes.
-        bool SetClientCreateMidi1Ports(
+        bool SetClientMidi1PortSettings(
             _In_ winrt::hstring const& clientIdKey,
-            _In_ bool const createMidi1Ports) noexcept;
+            _In_ bool const createMidi1Ports,
+            _In_ uint8_t const fallbackMidi1PortCount) noexcept;
 
     private:
         NetworkConfigFile() noexcept;

--- a/src/in-box/user-tools/network-midi-setup/ConfigFile.h
+++ b/src/in-box/user-tools/network-midi-setup/ConfigFile.h
@@ -88,6 +88,10 @@ namespace midinetworksetup
         // which never described itself, so the file is the only place it is recorded.
         uint8_t GetClientFallbackMidi1PortCount(_In_ winrt::hstring const& clientIdKey) noexcept;
 
+        // Companion to the above. Nothing writes this to the endpoint's properties, so the file
+        // is the only record of what was asked for.
+        bool GetClientCreateMidi1Ports(_In_ winrt::hstring const& clientIdKey) noexcept;
+
 
     private:
         NetworkConfigFile() noexcept;

--- a/src/in-box/user-tools/network-midi-setup/ConfigFile.h
+++ b/src/in-box/user-tools/network-midi-setup/ConfigFile.h
@@ -88,12 +88,6 @@ namespace midinetworksetup
         // which never described itself, so the file is the only place it is recorded.
         uint8_t GetClientFallbackMidi1PortCount(_In_ winrt::hstring const& clientIdKey) noexcept;
 
-        // MIDI 1.0 ports are decided when the endpoint is built, so this only changes what the
-        // next connection creates. Nothing about the running endpoint changes.
-        bool SetClientMidi1PortSettings(
-            _In_ winrt::hstring const& clientIdKey,
-            _In_ bool const createMidi1Ports,
-            _In_ uint8_t const fallbackMidi1PortCount) noexcept;
 
     private:
         NetworkConfigFile() noexcept;

--- a/src/in-box/user-tools/network-midi-setup/MainWindow.xaml
+++ b/src/in-box/user-tools/network-midi-setup/MainWindow.xaml
@@ -1363,7 +1363,7 @@
                           Content="Create MIDI 1.0 ports for this device" />
 
                 <TextBlock x:Uid="CustomizeCreateMidi1PortsHint"
-                           Text="MIDI 1.0 ports are built with the endpoint, so changing this takes effect the next time this device connects."
+                           Text="Turning this on or off takes effect the next time this device connects. The number of ports below applies right away."
                            TextWrapping="Wrap"
                            Style="{ThemeResource CaptionTextBlockStyle}"
                            Foreground="{ThemeResource TextFillColorTertiaryBrush}" />

--- a/src/in-box/user-tools/network-midi-setup/MainWindow.xaml
+++ b/src/in-box/user-tools/network-midi-setup/MainWindow.xaml
@@ -1165,6 +1165,22 @@
                               Content="Also create MIDI 1.0 ports for connected devices"
                               IsChecked="True" />
 
+                    <StackPanel Spacing="4" Margin="28,0,0,0">
+                        <NumberBox x:Name="HostFallbackMidi1PortCountBox"
+                                   x:Uid="HostFallbackMidi1PortCountBox"
+                                   Header="MIDI 1.0 ports to create for a device that does not describe itself"
+                                   Minimum="1"
+                                   Maximum="16"
+                                   MinWidth="160"
+                                   HorizontalAlignment="Left"
+                                   SpinButtonPlacementMode="Compact" />
+                        <TextBlock x:Uid="HostFallbackMidi1PortCountHint"
+                                   Text="Most devices say how many ports they have, and this is not used for them. It is only for a device that never tells us."
+                                   TextWrapping="Wrap"
+                                   Style="{ThemeResource CaptionTextBlockStyle}"
+                                   Foreground="{ThemeResource TextFillColorTertiaryBrush}" />
+                    </StackPanel>
+
                     <Expander x:Uid="HostAdvancedExpander"
                               Header="Advanced"
                               HorizontalAlignment="Stretch"
@@ -1351,6 +1367,22 @@
                            TextWrapping="Wrap"
                            Style="{ThemeResource CaptionTextBlockStyle}"
                            Foreground="{ThemeResource TextFillColorTertiaryBrush}" />
+
+                <StackPanel Spacing="4" Margin="28,0,0,0">
+                    <NumberBox x:Name="CustomizeFallbackMidi1PortCountBox"
+                               x:Uid="CustomizeFallbackMidi1PortCountBox"
+                               Header="MIDI 1.0 ports to create if this device does not describe itself"
+                               Minimum="1"
+                               Maximum="16"
+                               MinWidth="160"
+                               HorizontalAlignment="Left"
+                               SpinButtonPlacementMode="Compact" />
+                    <TextBlock x:Uid="CustomizeFallbackMidi1PortCountHint"
+                               Text="Most devices say how many ports they have, and this is not used for them. It is only for a device that never tells us."
+                               TextWrapping="Wrap"
+                               Style="{ThemeResource CaptionTextBlockStyle}"
+                               Foreground="{ThemeResource TextFillColorTertiaryBrush}" />
+                </StackPanel>
             </StackPanel>
         </ContentDialog>
     </Grid>

--- a/src/in-box/user-tools/network-midi-setup/MainWindowActions.cpp
+++ b/src/in-box/user-tools/network-midi-setup/MainWindowActions.cpp
@@ -699,10 +699,12 @@ namespace winrt::midinetworksetup::implementation
         winrt::hstring currentName{};
         winrt::hstring currentDescription{};
         winrt::hstring currentImage{};
-        bool currentCreateMidi1Ports{ true };
 
-        // Only the configuration file records this, so it is read before the endpoint lookup
-        // rather than from the endpoint's properties.
+        // Only the configuration file records these two, so they are read before the endpoint
+        // lookup rather than from the endpoint's properties.
+        bool const currentCreateMidi1Ports =
+            native::NetworkConfigFile::Current().GetClientCreateMidi1Ports(item.ClientId());
+
         auto const currentFallbackMidi1PortCount =
             native::NetworkConfigFile::Current().GetClientFallbackMidi1PortCount(item.ClientId());
 
@@ -717,7 +719,6 @@ namespace winrt::midinetworksetup::implementation
             }
 
             deviceInstanceId = info.DeviceInstanceId();
-            currentCreateMidi1Ports = info.IsMidi1PortCreationEnabled();
 
             auto const transportInfo = info.GetTransportSuppliedInfo();
             transportSuppliedName = transportInfo.Name();

--- a/src/in-box/user-tools/network-midi-setup/MainWindowActions.cpp
+++ b/src/in-box/user-tools/network-midi-setup/MainWindowActions.cpp
@@ -14,6 +14,8 @@
 
 #include "StringResources.h"
 
+#include "..\..\Transport\UdpNetworkMidi2Transport\network_json_defs.h"
+
 namespace native = ::midinetworksetup;
 namespace res = ::midinetworksetup::resources;
 
@@ -159,6 +161,44 @@ namespace winrt::midinetworksetup::implementation
             catch (...)
             {
                 return 0;
+            }
+        }
+
+        // Same focus problem as PortFrom, so Text is preferred here too. Anything unreadable or
+        // out of range becomes the default rather than zero, which would mean no ports at all.
+        uint8_t FallbackMidi1PortCountFrom(_In_ controls::NumberBox const& box) noexcept
+        {
+            try
+            {
+                std::wstring const text{ box.Text() };
+
+                if (!text.empty() &&
+                    std::all_of(text.begin(), text.end(), [](wchar_t const c) { return c >= L'0' && c <= L'9'; }))
+                {
+                    auto const parsed = std::stoul(text);
+
+                    if (parsed >= MIDI_NETWORK_MIDI_FALLBACK_MIDI1_PORT_COUNT_MINIMUM &&
+                        parsed <= MIDI_NETWORK_MIDI_FALLBACK_MIDI1_PORT_COUNT_MAXIMUM)
+                    {
+                        return static_cast<uint8_t>(parsed);
+                    }
+                }
+
+                auto const value = box.Value();
+
+                // NaN when the box is empty
+                if (value == value &&
+                    value >= MIDI_NETWORK_MIDI_FALLBACK_MIDI1_PORT_COUNT_MINIMUM &&
+                    value <= MIDI_NETWORK_MIDI_FALLBACK_MIDI1_PORT_COUNT_MAXIMUM)
+                {
+                    return static_cast<uint8_t>(value);
+                }
+
+                return MIDI_NETWORK_MIDI_FALLBACK_MIDI1_PORT_COUNT_DEFAULT;
+            }
+            catch (...)
+            {
+                return MIDI_NETWORK_MIDI_FALLBACK_MIDI1_PORT_COUNT_DEFAULT;
             }
         }
 
@@ -661,6 +701,11 @@ namespace winrt::midinetworksetup::implementation
         winrt::hstring currentImage{};
         bool currentCreateMidi1Ports{ true };
 
+        // Only the configuration file records this, so it is read before the endpoint lookup
+        // rather than from the endpoint's properties.
+        auto const currentFallbackMidi1PortCount =
+            native::NetworkConfigFile::Current().GetClientFallbackMidi1PortCount(item.ClientId());
+
         try
         {
             auto const info = midi2enum::MidiEndpointDeviceInformation::CreateFromEndpointDeviceId(
@@ -708,6 +753,7 @@ namespace winrt::midinetworksetup::implementation
             CustomizeDescriptionBox().Text(currentDescription);
             CustomizeImageBox().Text(currentImage);
             CustomizeCreateMidi1PortsCheckBox().IsChecked(currentCreateMidi1Ports);
+            CustomizeFallbackMidi1PortCountBox().Value(static_cast<double>(currentFallbackMidi1PortCount));
 
             CustomizeDialog().XamlRoot(Content().XamlRoot());
 
@@ -750,6 +796,10 @@ namespace winrt::midinetworksetup::implementation
         auto const createMidi1Ports = reset ?
             currentCreateMidi1Ports :
             (checkBoxState != nullptr && checkBoxState.Value());
+
+        auto const fallbackMidi1PortCount = reset ?
+            currentFallbackMidi1PortCount :
+            FallbackMidi1PortCountFrom(CustomizeFallbackMidi1PortCountBox());
 
         auto const clientKey = item.ClientId();
 
@@ -815,9 +865,11 @@ namespace winrt::midinetworksetup::implementation
 
             // Kept out of the customization above on purpose: this one is read when the endpoint
             // is built, so it belongs to the entry which creates it and cannot be pushed live.
-            if (succeeded && !clientKey.empty() && createMidi1Ports != currentCreateMidi1Ports)
+            if (succeeded && !clientKey.empty() &&
+                (createMidi1Ports != currentCreateMidi1Ports ||
+                 fallbackMidi1PortCount != currentFallbackMidi1PortCount))
             {
-                if (!native::NetworkConfigFile::Current().SetClientCreateMidi1Ports(clientKey, createMidi1Ports))
+                if (!native::NetworkConfigFile::Current().SetClientMidi1PortSettings(clientKey, createMidi1Ports, fallbackMidi1PortCount))
                 {
                     failure = native::NetworkConfigFile::Current().LastErrorMessage();
                     succeeded = false;
@@ -1743,6 +1795,7 @@ namespace winrt::midinetworksetup::implementation
         HostProductInstanceIdTextBox().Text(config.ProductInstanceId());
         HostAdvertiseCheckBox().IsChecked(config.Advertise());
         HostCreateMidi1PortsCheckBox().IsChecked(!config.CreateOnlyUmpEndpoints());
+        HostFallbackMidi1PortCountBox().Value(static_cast<double>(config.FallbackMidi1PortCount()));
         HostAutomaticPortCheckBox().IsChecked(config.UseAutomaticPortAllocation());
         HostPortNumberBox().IsEnabled(!config.UseAutomaticPortAllocation());
         HostAllowPortFallbackCheckBox().IsChecked(config.AllowPortFallback());
@@ -1784,6 +1837,7 @@ namespace winrt::midinetworksetup::implementation
             config.ProductInstanceId(TextOf(HostProductInstanceIdTextBox()));
             config.Advertise(IsCheckBoxChecked(HostAdvertiseCheckBox()));
             config.CreateOnlyUmpEndpoints(!IsCheckBoxChecked(HostCreateMidi1PortsCheckBox()));
+            config.FallbackMidi1PortCount(FallbackMidi1PortCountFrom(HostFallbackMidi1PortCountBox()));
 
             auto const automaticPort = IsCheckBoxChecked(HostAutomaticPortCheckBox());
 

--- a/src/in-box/user-tools/network-midi-setup/MainWindowActions.cpp
+++ b/src/in-box/user-tools/network-midi-setup/MainWindowActions.cpp
@@ -863,16 +863,46 @@ namespace winrt::midinetworksetup::implementation
                 failure = sendResponse.ServiceErrorMessage();
             }
 
-            // Kept out of the customization above on purpose: this one is read when the endpoint
-            // is built, so it belongs to the entry which creates it and cannot be pushed live.
+            // The port count reaches the running endpoint; the create flag is recorded for the
+            // next connection, because whether an endpoint has MIDI 1.0 ports at all is settled
+            // when the endpoint is built.
             if (succeeded && !clientKey.empty() &&
                 (createMidi1Ports != currentCreateMidi1Ports ||
                  fallbackMidi1PortCount != currentFallbackMidi1PortCount))
             {
-                if (!native::NetworkConfigFile::Current().SetClientMidi1PortSettings(clientKey, createMidi1Ports, fallbackMidi1PortCount))
+                winrt::guid clientEntryId{};
+
+                if (TryParseKey(clientKey, clientEntryId))
                 {
-                    failure = native::NetworkConfigFile::Current().LastErrorMessage();
-                    succeeded = false;
+                    midi2net::MidiNetworkClientUpdateConfig update{};
+
+                    update.ClientId(clientEntryId);
+                    update.CreateMidi1Ports(createMidi1Ports);
+                    update.FallbackMidi1PortCount(fallbackMidi1PortCount);
+
+                    auto const updateResponse = midi2svc::MidiServiceTransportPluginConfigManager::SendUpdate(update);
+
+                    if (updateResponse != nullptr &&
+                        updateResponse.Status() == midi2svc::MidiServiceConfigResponseStatus::Success)
+                    {
+                        auto const saveResponse = midi2svc::MidiServiceTransportPluginConfigManager::SaveUpdate(update);
+
+                        succeeded = saveResponse != nullptr && saveResponse.Success();
+
+                        if (!succeeded && saveResponse != nullptr)
+                        {
+                            failure = saveResponse.ErrorMessage();
+                        }
+                    }
+                    else
+                    {
+                        succeeded = false;
+
+                        if (updateResponse != nullptr)
+                        {
+                            failure = updateResponse.ServiceErrorMessage();
+                        }
+                    }
                 }
             }
         }

--- a/src/in-box/user-tools/network-midi-setup/Strings/en-US/Resources.resw
+++ b/src/in-box/user-tools/network-midi-setup/Strings/en-US/Resources.resw
@@ -261,8 +261,8 @@
     <comment>MIDI 1.0 ports are what older applications use. They are built along with the endpoint.</comment>
   </data>
   <data name="CustomizeCreateMidi1PortsHint.Text" xml:space="preserve">
-    <value>MIDI 1.0 ports are built with the endpoint, so changing this takes effect the next time this device connects.</value>
-    <comment>Explains why this one setting, unlike the others in the same dialog, does not apply immediately.</comment>
+    <value>Turning this on or off takes effect the next time this device connects. The number of ports below applies right away.</value>
+    <comment>Explains which of the two MIDI 1.0 settings is immediate and which needs a reconnect.</comment>
   </data>
   <data name="CustomizeFallbackMidi1PortCountBox.Header" xml:space="preserve">
     <value>MIDI 1.0 ports to create if this device does not describe itself</value>

--- a/src/in-box/user-tools/network-midi-setup/Strings/en-US/Resources.resw
+++ b/src/in-box/user-tools/network-midi-setup/Strings/en-US/Resources.resw
@@ -264,6 +264,14 @@
     <value>MIDI 1.0 ports are built with the endpoint, so changing this takes effect the next time this device connects.</value>
     <comment>Explains why this one setting, unlike the others in the same dialog, does not apply immediately.</comment>
   </data>
+  <data name="CustomizeFallbackMidi1PortCountBox.Header" xml:space="preserve">
+    <value>MIDI 1.0 ports to create if this device does not describe itself</value>
+    <comment>Label for a spin box holding a number from 1 to 16.</comment>
+  </data>
+  <data name="CustomizeFallbackMidi1PortCountHint.Text" xml:space="preserve">
+    <value>Most devices say how many ports they have, and this is not used for them. It is only for a device that never tells us.</value>
+    <comment>Explains that the number above is a fallback, so the customer does not expect it to change a device that works.</comment>
+  </data>
   <data name="CustomizeTransportNameFormat" xml:space="preserve">
     <value>This device reports itself as {0}.</value>
     <comment>{0} is the name the device supplies. Shown so the customer can tell what they are replacing.</comment>
@@ -577,6 +585,14 @@
   </data>
   <data name="HostCreateMidi1PortsCheckBox.Content" xml:space="preserve">
     <value>Also create MIDI 1.0 ports for connected devices</value>
+  </data>
+  <data name="HostFallbackMidi1PortCountBox.Header" xml:space="preserve">
+    <value>MIDI 1.0 ports to create for a device that does not describe itself</value>
+    <comment>Label for a spin box holding a number from 1 to 16.</comment>
+  </data>
+  <data name="HostFallbackMidi1PortCountHint.Text" xml:space="preserve">
+    <value>Most devices say how many ports they have, and this is not used for them. It is only for a device that never tells us.</value>
+    <comment>Explains that the number above is a fallback, so the customer does not expect it to change a device that works.</comment>
   </data>
   <data name="HostAdvancedExpander.Header" xml:space="preserve">
     <value>Advanced</value>


### PR DESCRIPTION
This pull request introduces several important updates, primarily focused on improving documentation for MIDI 1.0 port handling in Network MIDI 2.0, correcting and clarifying string conversion safety in the codebase, and updating version numbers for the SDK, plugins, and sample projects. These changes enhance user guidance, prevent subtle bugs, and keep the project aligned with the latest release.

**Documentation improvements for MIDI 1.0 port handling:**

* Updated `docs/kb/network-midi2-transport.md` to clarify that MIDI 1.0 ports are now created by default for connected devices, added the new `fallbackMidi1PortCount` setting, and provided detailed explanations on how and when these settings take effect. Also, updated configuration examples and tables to reflect these changes. [[1]](diffhunk://#diff-ebe7bc306c8d338640184c47b2dde9f57c49e0c075bfd4da08cf59cfce70440aL85-R89) [[2]](diffhunk://#diff-ebe7bc306c8d338640184c47b2dde9f57c49e0c075bfd4da08cf59cfce70440aL170-R173) [[3]](diffhunk://#diff-ebe7bc306c8d338640184c47b2dde9f57c49e0c075bfd4da08cf59cfce70440aR183-R184) [[4]](diffhunk://#diff-ebe7bc306c8d338640184c47b2dde9f57c49e0c075bfd4da08cf59cfce70440aL231-R237) [[5]](diffhunk://#diff-ebe7bc306c8d338640184c47b2dde9f57c49e0c075bfd4da08cf59cfce70440aR249-R250) [[6]](diffhunk://#diff-ebe7bc306c8d338640184c47b2dde9f57c49e0c075bfd4da08cf59cfce70440aR273-R300)
* Enhanced `docs/tools/midinetworksetup/index.md` with instructions for customizing device names, descriptions, images, and MIDI 1.0 port settings, including explanations of when changes take effect and how fallback port counts are used. [[1]](diffhunk://#diff-5dd9cec81d8b8f915c9b400fd77cbcc9a287466274c34e4cc35380aff665df71R106-R132) [[2]](diffhunk://#diff-5dd9cec81d8b8f915c9b400fd77cbcc9a287466274c34e4cc35380aff665df71R189-R195)

**String conversion safety guidance:**

* Added warnings and best practices to `.github/skills/midi-contributing/SKILL.md` and `.github/skills/midi-contributing/references/code-safety-review.md` regarding improper narrow/wide string conversions, highlighting potential data loss and referencing correct helper functions to use. [[1]](diffhunk://#diff-1afbde3e5a3e3b4bbe1d7ccc389dc69bb0bf4df0829803ba19d65ce4639b67bcR170-R177) [[2]](diffhunk://#diff-76b38f5068da2e58dcf3b1858464e98da0d80ae168ab10bfeafa292e64abf777R163-R177)

**Version updates:**

* Bumped SDK, tools, and plugin versions to `1.0.24-preview.5` and `0.99.68-devpreview.7` in `build/version-plugins.json`, `build/staging/version/BundleInfo.wxi`, `build/version.json`, and `build/staging/version/WindowsMidiServicesVersion.h`. [[1]](diffhunk://#diff-1717e579fb851c7498c781298dc25b5c3faa9e59f71765c62d22d0615897b21bL27-R27) [[2]](diffhunk://#diff-638656d88dc0df626463bba40b278d8630531c22c97c958b064e1260a3c31a66L24-R24) [[3]](diffhunk://#diff-4297e57c769231b4a8133f660ddee47dea5b7bce6eb060957c36752dd9d8add9L5-R7) [[4]](diffhunk://#diff-577645421a971f887e59f259ad677e0b6d65a6b3d272edb9859b43e67c735bcaL10-R18)
* Updated sample project references in `samples/cpp-winrt/basics/client-basics-cpp.vcxproj`, `samples/cpp-winrt/basics/packages.config`, and `samples/cpp-winrt/com-extensions/com-extensions-cpp.vcxproj` to use the new NuGet package version. [[1]](diffhunk://#diff-ea936148a73eeedddd010c56252cbe02ba0f87a86f12f7b6525301240e9fee4eL3-R3) [[2]](diffhunk://#diff-ea936148a73eeedddd010c56252cbe02ba0f87a86f12f7b6525301240e9fee4eL167-R176) [[3]](diffhunk://#diff-73f48df28dfa0fde830f9e557e6534e892e1848b49d8eb0bfbbea672d1b77637L4-R4) [[4]](diffhunk://#diff-8cdba4a35b19bc7a0e2124935786ad3b0d6d5a08614044bd221ae39ac96b9be3L3-R3)